### PR TITLE
Vectorized implementation of update_distinguisher functions

### DIFF
--- a/claasp/cipher_modules/neural_network_tests.py
+++ b/claasp/cipher_modules/neural_network_tests.py
@@ -119,9 +119,10 @@ def update_blackbox_distinguisher_tests_ds(base_inputs, base_output, cipher, ds,
                         dtype=np.float32))
                     
 
-def update_blackbox_distinguisher_vectorized_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_samples):
+def update_blackbox_distinguisher_vectorized_tests_ds(base_inputs, base_output, cipher, ds, index, labels, nb_samples):
     input_lengths = cipher.inputs_bit_size
     random_labels_size = nb_samples - np.count_nonzero(np.array(labels))
+    #cipher_output = base_output
 
     base_inputs_np = [np.broadcast_to(
         np.array([b for b in x.to_bytes(input_lengths[i] // 8, byteorder='big')], dtype=np.uint8),

--- a/claasp/cipher_modules/neural_network_tests.py
+++ b/claasp/cipher_modules/neural_network_tests.py
@@ -51,7 +51,7 @@ def neural_network_blackbox_distinguisher_tests(cipher, nb_samples=10000,
 
         partial_result, ds, component_output_ids = create_structure(base_output, cipher, index)
         update_component_output_ids(cipher, component_output_ids)
-        update_blackbox_distinguisher_tests_ds(base_inputs, base_output, cipher, ds, index, labels, nb_samples)
+        update_blackbox_distinguisher_vectorized_tests_ds(base_inputs, base_output, cipher, ds, index, labels, nb_samples)
         update_partial_result(cipher, component_output_ids, ds, index, hidden_layers,
                               labels, number_of_epochs, partial_result)
 
@@ -117,6 +117,30 @@ def update_blackbox_distinguisher_tests_ds(base_inputs, base_output, cipher, ds,
                         list(map(int, list(bin(base_inputs[index])[2:].rjust(input_lengths[index], '0')))) +
                         list(map(int, list(bin(secrets.randbits(ds[k][0]))[2:].rjust(ds[k][0], '0')))),
                         dtype=np.float32))
+                    
+
+def update_blackbox_distinguisher_vectorized_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_samples):
+    input_lengths = cipher.inputs_bit_size
+    random_labels_size = nb_samples - np.count_nonzero(np.array(labels))
+
+    base_inputs_np = [np.broadcast_to(
+        np.array([b for b in x.to_bytes(input_lengths[i] // 8, byteorder='big')], dtype=np.uint8),
+        (nb_samples, input_lengths[i] // 8)
+    ).transpose().copy() for i,x in enumerate(base_inputs)]
+    random_inputs_for_index = np.frombuffer(os.urandom(nb_samples * input_lengths[index] // 8), dtype=np.uint8).reshape(nb_samples, input_lengths[index] // 8).transpose()
+    base_inputs_np[index] = random_inputs_for_index
+    base_input_index_unpacked = np.unpackbits(base_inputs_np[index].transpose(), axis=1)
+
+    cipher_output = evaluator.evaluate_vectorized(cipher, base_inputs_np, intermediate_outputs=True)
+
+    for k in cipher_output:
+        for j in range(len(cipher_output[k])):
+            output_size = len(cipher_output[k][j][0])
+            cipher_output[k][j][labels==0] = np.frombuffer(os.urandom(random_labels_size * output_size), dtype=np.uint8).reshape(random_labels_size, output_size)
+            cipher_output_unpacked = np.unpackbits(cipher_output[k][j], axis=1)
+
+            full_output = np.append(base_input_index_unpacked, cipher_output_unpacked, axis=1)
+            ds[k][1][j].extend(list(full_output))
 
 
 def update_component_output_ids(cipher, component_output_ids):
@@ -176,7 +200,7 @@ def neural_network_differential_distinguisher_tests(cipher, nb_samples=10000, hi
         for d in diff:
             partial_result, ds, component_output_ids = create_structure(base_output, cipher, index)
             update_component_output_ids(cipher, component_output_ids)
-            update_distinguisher_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_samples)
+            update_distinguisher_vectorized_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_samples)
             update_partial_result(cipher, component_output_ids, ds, index, hidden_layers, labels,
                                   number_of_epochs, partial_result, False)
 
@@ -206,6 +230,35 @@ def update_distinguisher_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_
                         .append(np.array(list(map(int, list(bin(cipher_output[k][j])[2:].rjust(ds[k][0], '0')))) +
                                          list(map(int, list(bin(secrets.randbits(ds[k][0]))[2:].rjust(ds[k][0], '0')))),
                                          dtype=np.float32))
+                    
+
+def update_distinguisher_vectorized_tests_ds(base_inputs, cipher, d, ds, index, labels, nb_samples):
+    input_lengths = cipher.inputs_bit_size
+    random_labels_size = nb_samples - np.count_nonzero(np.array(labels))
+
+    base_inputs_np = [np.broadcast_to(
+        np.array([b for b in x.to_bytes(input_lengths[i] // 8, byteorder='big')], dtype=np.uint8),
+        (nb_samples, input_lengths[i] // 8)
+    ).transpose().copy() for i,x in enumerate(base_inputs)]
+    random_inputs_for_index = np.frombuffer(os.urandom(nb_samples * input_lengths[index] // 8), dtype=np.uint8).reshape(nb_samples, input_lengths[index] // 8).transpose()
+    base_inputs_np[index] = random_inputs_for_index
+
+    other_inputs_np = list(base_inputs_np)
+    d_array = np.array([b for b in d.to_bytes(input_lengths[index] // 8, byteorder='big')])
+    other_inputs_np[index] = other_inputs_np[index] ^ np.broadcast_to(d_array, (nb_samples, input_lengths[index] // 8)).transpose()
+
+    cipher_output = evaluator.evaluate_vectorized(cipher, base_inputs_np, intermediate_outputs=True)
+    other_output = evaluator.evaluate_vectorized(cipher, other_inputs_np, intermediate_outputs=True)
+
+    for k in cipher_output:
+        for j in range(len(cipher_output[k])):
+            output_size = len(cipher_output[k][j][0])
+            other_output[k][j][labels==0] = np.frombuffer(os.urandom(random_labels_size * output_size), dtype=np.uint8).reshape(random_labels_size, output_size)
+            cipher_output_unpacked = np.unpackbits(cipher_output[k][j], axis=1)
+            other_output_unpacked = np.unpackbits(other_output[k][j], axis=1)
+
+            full_output = np.append(cipher_output_unpacked, other_output_unpacked, axis=1)
+            ds[k][1][j].extend(list(full_output))
 
 
 def integer_to_np(val, number_of_bits):


### PR DESCRIPTION
New vectorized functions `update_blackbox_distinguisher_vectorized_tests_ds(...)` and `update_distinguisher_vectorized_tests_ds(...)` can be used as drop-in replacements of the existing non-vectorized ones.
Function calls have been replaced at line 54 and 203 for testing purpouses