### PR TITLE
Refactor: Latin Dances Ciphers

### DIFF
--- a/claasp/ciphers/permutations/chacha_permutation.py
+++ b/claasp/ciphers/permutations/chacha_permutation.py
@@ -41,6 +41,7 @@ class ChachaPermutation(Cipher):
     Construct an instance of the ChachaPermutation class.
 
     This class is used to store compact representations of a permutation, used to generate the corresponding cipher.
+    Additionally, one can use this class to implement ChaCha toy ciphers, such as the one described in [DEY2023]_.
 
     INPUT:
 
@@ -51,6 +52,9 @@ class ChachaPermutation(Cipher):
     - ``cipher_type`` -- **string** (default: `permutation`)
     - ``inputs`` -- **list of integer** (default: `None`)
     - ``cipher_inputs_bit_size`` -- **integer** (default: `None`)
+    - ``rotations`` -- *list of integer* (default: `[8, 7, 16, 12]`)
+    - ``word_size`` --  **integer** (default: `32`)
+    - ``start_round`` --  **string** (default: `odd`)
 
     EXAMPLES::
 
@@ -62,16 +66,19 @@ class ChachaPermutation(Cipher):
 
     def __init__(self, number_of_rounds=0, state_of_components=None,
                  cipher_family="chacha_permutation", cipher_type="permutation",
-                 inputs=None, cipher_inputs_bit_size=None, start_round="odd"):
+                 inputs=None, cipher_inputs_bit_size=None,
+                 rotations=[8, 7, 16, 12],
+                 word_size=32, start_round="odd"):
         init_latin_dances_cipher(
             self, super(), INPUT_PLAINTEXT, state_of_components, number_of_rounds,
-            start_round, cipher_family, cipher_type, inputs, cipher_inputs_bit_size, COLUMNS, DIAGONALS
+            start_round, cipher_family, cipher_type, inputs, cipher_inputs_bit_size, [COLUMNS, DIAGONALS],
+            word_size, rotations
         )
 
-    def bottom_half_quarter_round(self, a, b, c, d, state):
-        sub_quarter_round_latin_dances(self, state, a, b, d, -8, 'chacha')
-        sub_quarter_round_latin_dances(self, state, c, d, b, -7, 'chacha')
-
     def top_half_quarter_round(self, a, b, c, d, state):
-        sub_quarter_round_latin_dances(self, state, a, b, d, -16, 'chacha')
-        sub_quarter_round_latin_dances(self, state, c, d, b, -12, 'chacha')
+        sub_quarter_round_latin_dances(self, state, a, b, d, -self.rotation_3, 'chacha')
+        sub_quarter_round_latin_dances(self, state, c, d, b, -self.rotation_4, 'chacha')
+
+    def bottom_half_quarter_round(self, a, b, c, d, state):
+        sub_quarter_round_latin_dances(self, state, a, b, d, -self.rotation_1, 'chacha')
+        sub_quarter_round_latin_dances(self, state, c, d, b, -self.rotation_2, 'chacha')

--- a/claasp/ciphers/permutations/salsa_permutation.py
+++ b/claasp/ciphers/permutations/salsa_permutation.py
@@ -51,6 +51,9 @@ class SalsaPermutation(Cipher):
     - ``cipher_type`` -- **string** (default: `permutation`)
     - ``inputs`` -- **list of integer** (default: `None`)
     - ``cipher_inputs_bit_size`` -- **integer** (default: `None`)
+    - ``rotations`` -- *list of integer* (default: `[8, 7, 16, 12]`)
+    - ``word_size`` --  **integer** (default: `32`)
+    - ``start_round`` --  **string** (default: `odd`)
 
     EXAMPLES::
 
@@ -62,16 +65,19 @@ class SalsaPermutation(Cipher):
 
     def __init__(self, number_of_rounds=0, state_of_components=None,
                  cipher_family="salsa_permutation", cipher_type="permutation",
-                 inputs=None, cipher_inputs_bit_size=None, start_round="odd"):
+                 inputs=None, cipher_inputs_bit_size=None,
+                 rotations=[13, 18, 7, 9],
+                 word_size=32, start_round="odd"):
         init_latin_dances_cipher(
             self, super(), INPUT_PLAINTEXT, state_of_components, number_of_rounds,
-            start_round, cipher_family, cipher_type, inputs, cipher_inputs_bit_size, COLUMNS, DIAGONALS
+            start_round, cipher_family, cipher_type, inputs, cipher_inputs_bit_size, [COLUMNS, DIAGONALS],
+            word_size, rotations
         )
 
-    def bottom_half_quarter_round(self, a, b, c, d, state):
-        sub_quarter_round_latin_dances(self, state, b, c, d, -13, 'salsa')
-        sub_quarter_round_latin_dances(self, state, c, d, a, -18, 'salsa')
-
     def top_half_quarter_round(self, a, b, c, d, state):
-        sub_quarter_round_latin_dances(self, state, a, d, b, -7, 'salsa')
-        sub_quarter_round_latin_dances(self, state, a, b, c, -9, 'salsa')
+        sub_quarter_round_latin_dances(self, state, a, d, b, -self.rotation_3, 'salsa')
+        sub_quarter_round_latin_dances(self, state, a, b, c, -self.rotation_4, 'salsa')
+
+    def bottom_half_quarter_round(self, a, b, c, d, state):
+        sub_quarter_round_latin_dances(self, state, b, c, d, -self.rotation_1, 'salsa')
+        sub_quarter_round_latin_dances(self, state, c, d, a, -self.rotation_2, 'salsa')

--- a/docs/build/html/_sources/references.rst.txt
+++ b/docs/build/html/_sources/references.rst.txt
@@ -182,6 +182,11 @@
         \D'Anvers, J.-P., Karmakar, A., Roy S.S., Vercauteren F.: Saber: Module-LWR Based Key Exchange, CPA-Secure
         Encryption and CCA-Secure KEM. AFRICACRYPT 2018: 282-305.
 
+.. [DEY2023]
+        Sabyasachi D, Hirendra K,  Subhamoy M.: *Cryptanalysis of Reduced Round ChaCha - New Attack and Deeper
+        Analysis.* IACR Trans. Symmetric Cryptol, pages 89-110,
+        2023.
+
 .. [Din2021Cry]
         Dinur I. : *Cryptanalytic Applications of the Polynomial Method for
         Solving Multivariate Equation Systems over GF(2).* Springer-Verlag,

--- a/tests/ciphers/permutations/chacha_permutation_test.py
+++ b/tests/ciphers/permutations/chacha_permutation_test.py
@@ -20,3 +20,27 @@ def test_chacha_permutation():
     output = int('0x837778abe238d763a67ae21e5950bb2fc4f2d0c7fc62bb2f8fa018fc3f5ec7b7335271c2f29489f3eabda8fc82e46ebdd'
                  '19c12b4b04e16de9e83d0cb4e3c50a2', 16)
     assert chacha.evaluate([plaintext], verbosity=False) == output
+
+
+def test_toy_chacha_permutation():
+    """
+    The test vectors below were taken from the source code available in the URL specified in [DEY2023]_.
+    """
+
+    chacha = ChachaPermutation(number_of_rounds=2, rotations=[2, 1, 4, 3], word_size=8)
+    state = ["01", "00", "00", "00",
+             "00", "00", "00", "00",
+             "00", "00", "00", "00",
+             "00", "00", "00", "00"]
+    plaintext = int("0x" + "".join(state), 16)
+    output = int('0x81000000ad0000005600000046000000', 16)
+    assert chacha.evaluate([plaintext], verbosity=False) == output
+
+    chacha = ChachaPermutation(number_of_rounds=8, rotations=[2, 1, 4, 3], word_size=8)
+    state = ["01", "00", "00", "00",
+             "00", "00", "00", "00",
+             "00", "00", "00", "00",
+             "00", "00", "00", "00"]
+    plaintext = int("0x" + "".join(state), 16)
+    output = int('0xe023858e713feb86a730656ac909f76a', 16)
+    assert chacha.evaluate([plaintext], verbosity=False) == output


### PR DESCRIPTION
This refactoring allows to use ChaCha/Salsa toy ciphers as for example the ChaCha toy cipher proposed in https://eprint.iacr.org/2023/134.pdf