### PR TITLE
Feat/change milp file paths to absolute

### DIFF
--- a/claasp/cipher_modules/models/milp/utils/generate_inequalities_for_large_sboxes.py
+++ b/claasp/cipher_modules/models/milp/utils/generate_inequalities_for_large_sboxes.py
@@ -22,15 +22,17 @@ The target of this module is to generate MILP inequalities for small and large s
 
 The logic minimizer espresso is required for this module. It is already installed in the docker.
 """
-import pickle
+import pickle, os, pathlib
 import subprocess
 
 from sage.rings.integer_ring import ZZ
 
-large_sboxes_inequalities_file_path = \
-    "./claasp/cipher_modules/models/milp/dictionary_that_contains_inequalities_for_large_sboxes.obj"
-large_sboxes_xor_linear_inequalities_file_path = \
-    "./claasp/cipher_modules/models/milp/dictionary_that_contains_inequalities_for_large_sboxes_xor_linear.obj"
+large_sbox_file_name = "dictionary_that_contains_inequalities_for_large_sboxes.obj"
+large_sbox_xor_linear_file_name = "dictionary_that_contains_inequalities_for_large_sboxes_xor_linear.obj"
+
+large_sboxes_inequalities_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), large_sbox_file_name)
+large_sboxes_xor_linear_inequalities_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(),
+                                                             large_sbox_xor_linear_file_name)
 
 
 def generate_espresso_input(input_size, output_size, value, valid_transformations_matrix):

--- a/claasp/cipher_modules/models/milp/utils/generate_inequalities_for_xor_with_n_input_bits.py
+++ b/claasp/cipher_modules/models/milp/utils/generate_inequalities_for_xor_with_n_input_bits.py
@@ -20,11 +20,12 @@
 """
 The target of this module is to generate MILP inequalities for a XOR operation between n input bits.
 """
-import pickle
+import pickle, os, pathlib
 import subprocess
 
-xor_inequalities_between_n_input_bits_file_path = \
-    "./claasp/cipher_modules/models/milp/dictionary_containing_xor_inequalities_between_n_input_bits.obj"
+file_name = "dictionary_containing_xor_inequalities_between_n_input_bits.obj"
+
+xor_inequalities_between_n_input_bits_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), file_name)
 
 
 def generate_all_possible_points_with_n_bits(number_of_bits):

--- a/claasp/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search.py
+++ b/claasp/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search.py
@@ -26,16 +26,18 @@ Generate inequalities for 8-bit sboxes is infeasible with this module.
 The module generate_inequalities_for_large_sboxes.py take care of both cases, small and large sboxes.
 Hence, this module can be removed, but we decide to keep it for comparison purpose.
 """
-import pickle
+import pickle, os, pathlib
 
 from sage.rings.integer_ring import ZZ
 
 from claasp.cipher_modules.models.milp.utils.config import SOLVER_DEFAULT
 
-inequalities_for_small_sboxes_path = \
-    "claasp/cipher_modules/models/milp/dictionary_that_contains_inequalities_for_small_sboxes.obj"
-inequalities_for_small_sboxes_xor_linear_path = \
-    "claasp/cipher_modules/models/milp/dictionary_that_contains_inequalities_for_small_sboxes_xor_linear.obj"
+small_sbox_file_name = "dictionary_that_contains_inequalities_for_small_sboxes.obj"
+small_sbox_xor_linear_file_name = "dictionary_that_contains_inequalities_for_small_sboxes_xor_linear.obj"
+
+inequalities_for_small_sboxes_path = os.path.join(pathlib.Path(__file__).parent.resolve(), small_sbox_file_name)
+inequalities_for_small_sboxes_xor_linear_path = os.path.join(pathlib.Path(__file__).parent.resolve(),
+                                                             small_sbox_xor_linear_file_name)
 
 
 def sbox_inequalities(sbox, analysis="differential", algorithm="milp", big_endian=False):

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -84,7 +84,7 @@ def test_find_lowest_weight_xor_linear_trail():
     # milp = MilpXorLinearModel(present.remove_key_schedule())
     # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
     #                                 bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
-    # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext, ciphertext])
+    # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
     # assert trail["total_weight"] == 4.0
 
 

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -84,9 +84,6 @@ def test_find_lowest_weight_xor_linear_trail():
     # milp = MilpXorLinearModel(present.remove_key_schedule())
     # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
     #                                 bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
-    # ciphertext = set_fixed_variables(component_id='cipher_output_2_25', constraint_type='equal',
-    #                                  bit_positions=range(64), bit_values = integer_to_bit_list(0x0200020002000200, 64, 'big'))
-    #
     # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext, ciphertext])
     # assert trail["total_weight"] == 4.0
 

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -80,14 +80,14 @@ def test_find_lowest_weight_xor_linear_trail():
     trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
     assert trail["total_weight"] == 1.0
     #
-    present = PresentBlockCipher(number_of_rounds=3)
-    milp = MilpXorLinearModel(present.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
-                                    bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
-    ciphertext = set_fixed_variables(component_id='cipher_output_2_25', constraint_type='equal',
-                                     bit_positions=range(64), bit_values = integer_to_bit_list(0x0200020002000200, 64, 'big'))
-
-    trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext, ciphertext])
+    # present = PresentBlockCipher(number_of_rounds=3)
+    # milp = MilpXorLinearModel(present.remove_key_schedule())
+    # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
+    #                                 bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
+    # ciphertext = set_fixed_variables(component_id='cipher_output_2_25', constraint_type='equal',
+    #                                  bit_positions=range(64), bit_values = integer_to_bit_list(0x0200020002000200, 64, 'big'))
+    #
+    # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext, ciphertext])
     # assert trail["total_weight"] == 4.0
 
 

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -80,11 +80,14 @@ def test_find_lowest_weight_xor_linear_trail():
     trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
     assert trail["total_weight"] == 1.0
     #
-    # present = PresentBlockCipher(number_of_rounds=3)
-    # milp = MilpXorLinearModel(present.remove_key_schedule())
-    # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
-    #                                 bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
-    # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+    present = PresentBlockCipher(number_of_rounds=3)
+    milp = MilpXorLinearModel(present.remove_key_schedule())
+    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
+                                    bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
+    ciphertext = set_fixed_variables(component_id='cipher_output_2_25', constraint_type='equal',
+                                     bit_positions=range(64), bit_values = integer_to_bit_list(0x0200020002000200, 64, 'big'))
+
+    trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext, ciphertext])
     # assert trail["total_weight"] == 4.0
 
 


### PR DESCRIPTION
Paths were relative to the main claasp directory, which can cause some `FileError` issues when the library is called from another folder. Absolute paths are now used to solve this.