### PR TITLE
fix:inversion for primitives using subkeys as inputs

### DIFF
--- a/claasp/cipher.py
+++ b/claasp/cipher.py
@@ -1068,7 +1068,7 @@ class Cipher:
                                                                                      end_round, keep_key_schedule)
 
         if start_round > 0:
-            for input_type in set(self.inputs) - {INPUT_KEY}:
+            for input_type in set([input for input in self.inputs if INPUT_KEY not in input]):
                 removed_components_ids.append(input_type)
                 input_index = partial_cipher.inputs.index(input_type)
                 partial_cipher.inputs.pop(input_index)
@@ -1145,8 +1145,8 @@ class Cipher:
         partial_cipher_inverse = partial_cipher.cipher_inverse()
 
         key_schedule_component_ids = get_key_schedule_component_ids(partial_cipher_inverse)
-        key_schedule_components = [partial_cipher_inverse.get_component_from_id(id) for id in
-                                   key_schedule_component_ids[1:]]
+        key_schedule_components = [partial_cipher_inverse.get_component_from_id(id) for id in key_schedule_component_ids if
+                                   INPUT_KEY not in id]
 
         if not keep_key_schedule:
             for current_round in partial_cipher_inverse.rounds_as_list:

--- a/claasp/cipher_modules/inverse_cipher.py
+++ b/claasp/cipher_modules/inverse_cipher.py
@@ -17,7 +17,11 @@ def get_cipher_components(self):
         setattr(c, 'round', int(c.id.split("_")[-2]))
     # build input components
     for index, input_id in enumerate(self.inputs):
-        input_component = Component(input_id, "cipher_input", Input(0, [[]], [[]]), self.inputs_bit_size[index], [input_id])
+        if INPUT_KEY in input_id:
+            input_component = Component(input_id, "cipher_input", Input(0, [[]], [[]]), self.inputs_bit_size[index],
+                                        [INPUT_KEY])
+        else:
+            input_component = Component(input_id, "cipher_input", Input(0, [[]], [[]]), self.inputs_bit_size[index], [input_id])
         setattr(input_component, 'round', -1)
         component_list.append(input_component)
     return component_list
@@ -673,7 +677,7 @@ def update_output_bits(inverse_component, self, all_equivalent_bits, available_b
     flag_is_intersection_of_input_id_links_null, input_bit_positions = is_intersection_of_input_id_links_null(
         inverse_component, component)
 
-    if (component.id == INPUT_KEY) or (component.type == CONSTANT):
+    if (component.description == [INPUT_KEY]) or (component.type == CONSTANT):
         for i in range(component.output_bit_size):
             output_bit_name_updated = id + "_" + str(i) + "_output_updated"
             bit = {
@@ -821,7 +825,7 @@ def component_inverse(component, available_bits, all_equivalent_bits, key_schedu
                                       component.output_bit_size, [component.id])
         inverse_component.__class__ = cipher_output_component.CipherOutput
         setattr(inverse_component, "round", component.round)
-    elif component.type == CIPHER_INPUT and (component.id == INPUT_KEY or component.id == INPUT_TWEAK):
+    elif component.type == CIPHER_INPUT and (component.description == [INPUT_KEY] or component.id == INPUT_TWEAK):
         inverse_component = Component(component.id, CIPHER_INPUT,
                                       Input(0, [[]], [[]]),
                                       component.output_bit_size, [component.id])
@@ -941,7 +945,7 @@ def get_component_from_id(component_id, self):
 
 
 def get_key_schedule_component_ids(self):
-    key_schedule_component_ids = [INPUT_KEY]
+    key_schedule_component_ids = [input for input in self.inputs if INPUT_KEY in input]
     component_list = self.get_all_components()
     for c in component_list:
         flag_belong_to_key_schedule = True
@@ -1248,7 +1252,7 @@ def sort_cipher_graph(cipher):
 def remove_components_from_rounds(cipher, start_round, end_round, keep_key_schedule):
     list_of_rounds = cipher.rounds_as_list[:start_round] + cipher.rounds_as_list[end_round + 1:]
     key_schedule_component_ids = get_key_schedule_component_ids(cipher)
-    key_schedule_components = [cipher.get_component_from_id(id) for id in key_schedule_component_ids[1:]]
+    key_schedule_components = [cipher.get_component_from_id(id) for id in key_schedule_component_ids if INPUT_KEY not in id]
 
     if not keep_key_schedule:
         for current_round in cipher.rounds_as_list:

--- a/claasp/cipher_modules/models/milp/milp_models/milp_wordwise_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_wordwise_deterministic_truncated_xor_differential_model.py
@@ -40,7 +40,7 @@ class MilpWordwiseDeterministicTruncatedXorDifferentialModel(MilpModel):
     def __init__(self, cipher, n_window_heuristic=None):
         super().__init__(cipher, n_window_heuristic)
         self._trunc_wordvar = None
-        self._word_size = 1
+        self._word_size = 4
         if self._cipher.is_spn():
             for component in self._cipher.get_all_components():
                 if SBOX in component.type:
@@ -158,7 +158,7 @@ class MilpWordwiseDeterministicTruncatedXorDifferentialModel(MilpModel):
             operation = component.description[0]
             operation_types = ['AND', 'MODADD', 'MODSUB', 'NOT', 'OR', 'ROTATE', 'SHIFT', 'XOR']
 
-            if component.type in component_types and (component.type != WORD_OPERATION or operation in operation_types):
+            if component.type in component_types or operation in operation_types:
                 variables, constraints = component.milp_wordwise_deterministic_truncated_xor_differential_constraints(self)
             else:
                 print(f'{component.id} not yet implemented')

--- a/claasp/component.py
+++ b/claasp/component.py
@@ -322,10 +322,8 @@ class Component:
         input_class_ids = []
 
         for index, link in enumerate(self.input_id_links):
-            for pos in range(len(self.input_bit_positions[index]) // model.word_size):
-                input_class_ids.append(link + '_word_' + str(
-                        (pos * model.word_size + self.input_bit_positions[index][
-                            0]) // model.word_size) + '_class')
+            for pos in self.input_bit_positions[index][::model.word_size]:
+                input_class_ids.append(link + '_word_' + str(pos // model.word_size) + '_class')
 
         return input_class_ids, output_class_ids
 


### PR DESCRIPTION
- Ciphers can now be inverted after using the `remove_key_schedule` method
- Minor fix for the MILP worldwide truncated / impossible module regarding variables naming