### PR TITLE
Fix/change milp external files writing to current dir

### DIFF
--- a/claasp/cipher_modules/models/milp/milp_model.py
+++ b/claasp/cipher_modules/models/milp/milp_model.py
@@ -43,7 +43,8 @@ import tracemalloc
 
 from sage.numerical.mip import MixedIntegerLinearProgram, MIPSolverException
 
-from claasp.cipher_modules.models.milp.utils.config import SOLVER_DEFAULT, EXTERNAL_MILP_SOLVERS
+from claasp.cipher_modules.models.milp.utils.config import SOLVER_DEFAULT, EXTERNAL_MILP_SOLVERS, \
+    SOLUTION_FILE_DEFAULT_NAME
 from claasp.cipher_modules.models.milp.utils.utils import _get_data, _parse_external_solver_output, _write_model_to_lp_file
 from claasp.cipher_modules.models.utils import convert_solver_solution_to_dictionary
 
@@ -337,6 +338,7 @@ class MilpModel:
             status, objective_value, components_values, milp_time, milp_memory = self._solve_with_external_solver(
                 model_type, model_path, external_solver_name)
             os.remove(model_path)
+            os.remove(f"{SOLUTION_FILE_DEFAULT_NAME}")
         else:
             solver_name_in_solution = solver_name
             status, milp_time, milp_memory = self._solve_with_internal_solver()

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -216,7 +216,7 @@ class MilpXorDifferentialModel(MilpModel):
 
         self._number_of_trails_found = 0
 
-        return list_trails
+        return [trail for trail in list_trails if trail['status'] == 'SATISFIABLE']
 
     def exclude_variables_value_constraints(self, fixed_variables=[]):
         """
@@ -397,7 +397,7 @@ class MilpXorDifferentialModel(MilpModel):
             mip.remove_constraints(range(number_constraints - number_new_constraints, number_constraints))
         self._number_of_trails_found = 0
 
-        return list_trails
+        return [trail for trail in list_trails if trail['status'] == 'SATISFIABLE']
 
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name=SOLVER_DEFAULT,
                                                   external_solver_name=False):

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
@@ -343,7 +343,7 @@ class MilpXorLinearModel(MilpModel):
 
         self._number_of_trails_found = 0
 
-        return list_trails
+        return [trail for trail in list_trails if trail['status'] == 'SATISFIABLE']
 
     def find_all_xor_linear_trails_with_weight_at_most(self, min_weight, max_weight, fixed_values=[],
                                                        solver_name=SOLVER_DEFAULT, external_solver_name=None):
@@ -420,7 +420,7 @@ class MilpXorLinearModel(MilpModel):
             mip.remove_constraints(range(number_constraints - number_new_constraints, number_constraints))
         self._number_of_trails_found = 0
 
-        return list_trails
+        return [trail for trail in list_trails if trail['status'] == 'SATISFIABLE']
 
     def find_lowest_weight_xor_linear_trail(self, fixed_values=[], solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """

--- a/claasp/cipher_modules/models/milp/utils/config.py
+++ b/claasp/cipher_modules/models/milp/utils/config.py
@@ -18,12 +18,11 @@
 
 
 SOLVER_DEFAULT = "GLPK"
-MODEL_DEFAULT_PATH = "./claasp/cipher_modules/models/milp/tmp"
 SOLUTION_FILE_DEFAULT_NAME = "milp_model.sol"
 
 EXTERNAL_MILP_SOLVERS = {
     'Gurobi': {
-        'command': f'gurobi_cl ResultFile={MODEL_DEFAULT_PATH}/{SOLUTION_FILE_DEFAULT_NAME} ',
+        'command': f'gurobi_cl ResultFile={SOLUTION_FILE_DEFAULT_NAME} ',
         'options': "",
         'time': r"Explored \d+ nodes \(\d+ simplex iterations\) in ([0-9]*[.]?[0-9]+) seconds",
         'unsat_condition': "Model is infeasible"
@@ -31,20 +30,20 @@ EXTERNAL_MILP_SOLVERS = {
     'scip': {
         'file_path': [],
         'command': 'scip -c \"read ',
-        'options': f' opt write solution {MODEL_DEFAULT_PATH}/{SOLUTION_FILE_DEFAULT_NAME} quit\"',
+        'options': f' opt write solution {SOLUTION_FILE_DEFAULT_NAME} quit\"',
         'time': r"Solving Time \(sec\)[\s]+:[\s]+([0-9]*[.]?[0-9]+)",
         'unsat_condition': "problem is solved [infeasible]"
     },
     'glpk': {
         'command': 'glpsol --lp ',
-        'options': f' --output {MODEL_DEFAULT_PATH}/{SOLUTION_FILE_DEFAULT_NAME}',
+        'options': f' --output {SOLUTION_FILE_DEFAULT_NAME}',
         'time': r"Time used:[\s]+([0-9]*[.]?[0-9]+) secs",
         'memory': r"Memory used:[\s]+([0-9]*[.]?[0-9]+) Mb",
         'unsat_condition': 'PROBLEM HAS NO PRIMAL FEASIBLE SOLUTION'
     },
     'cplex': {
         'command': 'cplex -c \"read ',
-        'options': f'\" \"optimize\" \"display solution variables *\" | tee {MODEL_DEFAULT_PATH}/{SOLUTION_FILE_DEFAULT_NAME}',
+        'options': f'\" \"optimize\" \"display solution variables *\" | tee {SOLUTION_FILE_DEFAULT_NAME}',
         'time': r"Solution time =[\s]+([0-9]*[.]?[0-9]+) sec.",
         'unsat_condition': "MIP - Integer infeasible."
     }

--- a/claasp/cipher_modules/models/milp/utils/utils.py
+++ b/claasp/cipher_modules/models/milp/utils/utils.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 import pickle
-import re, os
+import re
 from subprocess import run
 
 from bitstring import BitArray
@@ -24,7 +24,7 @@ from claasp.cipher_modules.models.milp.utils.generate_inequalities_for_xor_with_
     output_dictionary_that_contains_xor_inequalities,
     update_dictionary_that_contains_xor_inequalities_between_n_input_bits)
 
-from claasp.cipher_modules.models.milp.utils.config import EXTERNAL_MILP_SOLVERS, MODEL_DEFAULT_PATH, \
+from claasp.cipher_modules.models.milp.utils.config import EXTERNAL_MILP_SOLVERS, \
     SOLUTION_FILE_DEFAULT_NAME
 from sage.numerical.mip import MIPSolverException
 
@@ -39,7 +39,7 @@ from claasp.cipher_modules.models.milp.utils.milp_name_mappings import MILP_BITW
 
 def _write_model_to_lp_file(model, model_type):
     mip = model._model
-    model_file_path = os.path.join(MODEL_DEFAULT_PATH, f"{model.cipher_id}_{model_type}.lp")
+    model_file_path = f"{model.cipher_id}_{model_type}.lp"
     mip.write_lp(model_file_path)
 
     return model_file_path
@@ -74,7 +74,7 @@ def _parse_external_solver_output(model, model_type, solver_name, solver_process
     if solver_specs['unsat_condition'] not in str(solver_process):
         status = 'SATISFIABLE'
 
-        solution_file_path = os.path.join(MODEL_DEFAULT_PATH, SOLUTION_FILE_DEFAULT_NAME)
+        solution_file_path = SOLUTION_FILE_DEFAULT_NAME
 
         with open(solution_file_path, 'r') as lp_file:
             read_file = lp_file.read()


### PR DESCRIPTION
Moving the temporary files needed for MILP solving when using external solvers to the current working directory to avoid writing access requirement to clasp source code.