### PR TITLE
Fix/change default trail search behavior

### DIFF
--- a/claasp/cipher_modules/models/cp/cp_models/cp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/cp_models/cp_xor_differential_model.py
@@ -37,7 +37,7 @@ def and_xor_differential_probability_ddt(numadd):
 
     EXAMPLES::
 
-        sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
+        sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (
         ....:     and_xor_differential_probability_ddt)
         sage: from claasp.ciphers.block_ciphers.simon_block_cipher import SimonBlockCipher
         sage: simon = SimonBlockCipher()
@@ -111,16 +111,10 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: fixed_variables = [set_fixed_variables('key', 'equal', range(64),
-            ....: integer_to_bit_list(0, 64, 'little'))]
-            sage: fixed_variables.append(set_fixed_variables('plaintext', 'equal', range(32),
-            ....: integer_to_bit_list(0, 32, 'little')))
+            sage: cp = CpXorDifferentialModel(speck)
             sage: cp.build_xor_differential_trail_model(-1, fixed_variables)
         """
         self.initialise_model()
@@ -172,17 +166,11 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: fixed_variables = [set_fixed_variables('key', 'equal', range(64),
-            ....: integer_to_bit_list(0, 64, 'little'))]
-            sage: fixed_variables.append(set_fixed_variables('plaintext', 'equal', range(32),
-            ....: integer_to_bit_list(0, 32, 'little')))
-            sage: cp.build_xor_differential_trail_model(-1, fixed_variables)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: cp.build_xor_differential_trail_model(-1)
             sage: cp.final_xor_differential_constraints(-1)[:-1]
             ['solve:: int_search(p, smallest, indomain_min, complete) minimize weight;']
         """
@@ -213,7 +201,7 @@ class CpXorDifferentialModel(CpModel):
     def find_all_xor_differential_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='Chuffed'):
         """
         Return a list of solutions containing all the differential trails having the ``fixed_weight`` weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -227,21 +215,25 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            # single-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
-            sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: fixed_values = []
-            sage: fixed_values.append(set_fixed_variables('key', 'equal', list(range(16)),
-            ....: integer_to_bit_list(0, 16, 'big')))
-            sage: fixed_values.append(set_fixed_variables('plaintext', 'not_equal', list(range(8)),
-            ....: integer_to_bit_list(0, 8, 'big')))
-            sage: trails = cp.find_all_xor_differential_trails_with_fixed_weight(1, fixed_values, 'Chuffed') # long
-            ...
-            sage: len(trails) # long
-            6
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: trails = cp.find_all_xor_differential_trails_with_fixed_weight(9, solver_name='Chuffed')
+            sage: len(trails)
+            2
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher( number_of_rounds=5)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trails = cp.find_all_xor_differential_trails_with_fixed_weight(2, fixed_values=[key], solver_name='Chuffed')
+            sage: len(trails)
+            2
         """
         start = tm.time()
         self.build_xor_differential_trail_model(fixed_weight, fixed_values)
@@ -257,7 +249,7 @@ class CpXorDifferentialModel(CpModel):
                                                              solver_name='Chuffed'):
         """
         Return a list of solutions containing all the differential trails.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         The differential trails having the weight of correlation lying in the interval ``[min_weight, max_weight]``.
 
         INPUT:
@@ -273,21 +265,26 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            # single-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
-            sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: fixed_values = []
-            sage: fixed_values.append(set_fixed_variables('key', 'equal', list(range(16)),
-            ....: integer_to_bit_list(0, 16, 'big')))
-            sage: fixed_values.append(set_fixed_variables('plaintext', 'not_equal', list(range(8)),
-            ....: integer_to_bit_list(0, 8, 'big')))
-            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(0,1, fixed_values, 'Chuffed')
-            ...
-            sage: len(trails) # long
-            7
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(9,10, solver_name='Chuffed')
+            sage: len(trails)
+            28
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(2,3, fixed_values=[key], solver_name='Chuffed') # long
+            sage: len(trails)
+            9
+
         """
         start = tm.time()
         self.build_xor_differential_trail_model(0, fixed_values)
@@ -316,7 +313,7 @@ class CpXorDifferentialModel(CpModel):
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a differential trail with the lowest probability weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         
         .. NOTE::
 
@@ -334,24 +331,29 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            # single-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: fixed_values = []
-            sage: fixed_values.append(set_fixed_variables('key', 'equal', list(range(64)),
-            ....: integer_to_bit_list(0, 64, 'big')))
-            sage: fixed_values.append(set_fixed_variables('plaintext', 'not_equal', list(range(32)),
-            ....: integer_to_bit_list(0, 32, 'big')))
-            sage: cp.find_lowest_weight_xor_differential_trail(fixed_values,'Chuffed') # random
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: cp.find_lowest_weight_xor_differential_trail(solver_name='Chuffed') # random
             {'building_time': 0.007165431976318359,
              'cipher_id': 'speck_p32_k64_o32_r4',
              'components_values': {'cipher_output_4_12': {'value': '850a9520',
              'weight': 0},
               ...
              'total_weight': '9.0'}
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(32)), [0] * 32)
+            sage: trail = cp.find_lowest_weight_xor_differential_trail(fixed_values=[key], solver_name='Chuffed')
+            sage: trail['total_weight']
+            '1.0'
         """
         start = tm.time()
         self.build_xor_differential_trail_model(-1, fixed_values)
@@ -366,7 +368,7 @@ class CpXorDifferentialModel(CpModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a differential trail with any weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -379,23 +381,27 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            # single-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=2)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=[0]*32)
-            sage: cp.find_one_xor_differential_trail([plaintext], 'Chuffed') # random
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: cp.find_one_xor_differential_trail(solver_name=Chuffed') # random
             {'cipher_id': 'speck_p32_k64_o32_r2',
              'model_type': 'xor_differential_one_solution',
               ...
              'cipher_output_1_12': {'value': 'ffff0000', 'weight': 0}},
              'total_weight': '18.0'}
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=2)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(32)), [0] * 32)
+            sage: trail = cp.find_one_xor_differential_trail(fixed_values=[key], solver_name='Chuffed') # random
+
         """
         start = tm.time()
         self.build_xor_differential_trail_model(0, fixed_values)
@@ -410,7 +416,7 @@ class CpXorDifferentialModel(CpModel):
                                                           solver_name='Chuffed'):
         """
         Return the solution representing a differential trail with the weight of probability equal to ``fixed_weight``.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -424,23 +430,25 @@ class CpXorDifferentialModel(CpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            # single-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: speck = SpeckBlockCipher(number_of_rounds=5)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=[0]*32)
-            sage: cp.find_one_xor_differential_trail_with_fixed_weight(9, [plaintext], 'Chuffed') # random
-            {'cipher_id': 'speck_p32_k64_o32_r5',
-             'model_type': 'xor_differential_one_solution',
-             ...
-             'total_weight': '9.0',
-             'building_time_seconds': 0.0013153553009033203}
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: trail = cp.find_one_xor_differential_trail_with_fixed_weight(3, solver_name='Chuffed') # random
+            sage: trail['total_weight']
+            '3.0'
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: cp = CpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trail = cp.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[key], solver_name='Chuffed')
+            sage: trail['total_weight']
+            '3.0'
         """
         start = tm.time()
         self.build_xor_differential_trail_model(fixed_weight, fixed_values)
@@ -475,10 +483,9 @@ class CpXorDifferentialModel(CpModel):
         EXAMPLES::
 
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_trail_search_model import (
-            ....:     CpXorDifferentialTrailSearchModel)
+            sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (CpXorDifferentialModel)
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: cp = CpXorDifferentialTrailSearchModel(speck)
+            sage: cp = CpXorDifferentialModel(speck)
             sage: cp.input_xor_differential_constraints()
             (['array[0..31] of var 0..1: plaintext;',
               'array[0..63] of var 0..1: key;',

--- a/claasp/cipher_modules/models/cp/cp_models/cp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/cp_models/cp_xor_differential_model.py
@@ -22,6 +22,7 @@ import time as tm
 from sage.crypto.sbox import SBox
 
 from claasp.cipher_modules.models.cp.cp_model import CpModel, solve_satisfy
+from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, SBOX, MIX_COLUMN, WORD_OPERATION,
                                   XOR_DIFFERENTIAL, LINEAR_LAYER)
 
@@ -138,6 +139,8 @@ class CpXorDifferentialModel(CpModel):
     def build_xor_differential_trail_model_template(self, weight, fixed_variables):
         variables = []
         self._variables_list = []
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_constraints(fixed_variables)
         component_types = [CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_OPERATION]
         operation_types = ['AND', 'MODADD', 'MODSUB', 'NOT', 'OR', 'ROTATE', 'SHIFT', 'XOR']
@@ -210,6 +213,7 @@ class CpXorDifferentialModel(CpModel):
     def find_all_xor_differential_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='Chuffed'):
         """
         Return a list of solutions containing all the differential trails having the ``fixed_weight`` weight.
+        By default, the search is set in the single key setting.
 
         INPUT:
 
@@ -253,7 +257,7 @@ class CpXorDifferentialModel(CpModel):
                                                              solver_name='Chuffed'):
         """
         Return a list of solutions containing all the differential trails.
-
+        By default, the search is set in the single key setting.
         The differential trails having the weight of correlation lying in the interval ``[min_weight, max_weight]``.
 
         INPUT:
@@ -311,8 +315,9 @@ class CpXorDifferentialModel(CpModel):
 
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
-        Return the solution representing a differential trail with the lowest weight of correlation.
-
+        Return the solution representing a differential trail with the lowest probability weight.
+        By default, the search is set in the single key setting.
+        
         .. NOTE::
 
             There could be more than one trail with the lowest weight. In order to find all the lowest weight
@@ -361,6 +366,7 @@ class CpXorDifferentialModel(CpModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a differential trail with any weight.
+        By default, the search is set in the single key setting.
 
         INPUT:
 
@@ -403,7 +409,8 @@ class CpXorDifferentialModel(CpModel):
     def find_one_xor_differential_trail_with_fixed_weight(self, fixed_weight=-1, fixed_values=[],
                                                           solver_name='Chuffed'):
         """
-        Return the solution representing a differential trail with the weight of correlation equal to ``fixed_weight``.
+        Return the solution representing a differential trail with the weight of probability equal to ``fixed_weight``.
+        By default, the search is set in the single key setting.
 
         INPUT:
 

--- a/claasp/cipher_modules/models/cp/cp_models/cp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/cp_models/cp_xor_linear_model.py
@@ -234,13 +234,10 @@ class CpXorLinearModel(CpModel):
 
             sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_linear_model import CpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-            sage: speck = speck.remove_key_schedule()
             sage: cp = CpXorLinearModel(speck)
-            sage: fixed_variables = [set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'little'))]
-            sage: trails = cp.find_all_xor_linear_trails_with_fixed_weight(1, fixed_variables) # long
-            sage: len(trails) # long
+            sage: trails = cp.find_all_xor_linear_trails_with_fixed_weight(1) # long
+            sage: len(trails)
             12
         """
         start = tm.time()
@@ -274,13 +271,10 @@ class CpXorLinearModel(CpModel):
 
             sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_linear_model import CpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-            sage: speck = speck.remove_key_schedule()
             sage: cp = CpXorLinearModel(speck)
-            sage: fixed_variables = [set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'little'))]
-            sage: trails = cp.find_all_xor_linear_trails_with_weight_at_most(0, 1, fixed_variables) # long time
-            sage: len(trails) # long time
+            sage: trails = cp.find_all_xor_linear_trails_with_weight_at_most(0, 1)
+            sage: len(trails)
             13
         """
         start = tm.time()
@@ -318,19 +312,11 @@ class CpXorLinearModel(CpModel):
 
             sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_linear_model import CpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
-            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: speck = speck.remove_key_schedule()
+            sage: speck = SpeckBlockCipher(number_of_rounds=4)
             sage: cp= CpXorLinearModel(speck)
-            sage: fixed_variables = [set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-            sage: cp.find_lowest_weight_xor_linear_trail(fixed_variables) # random
-            {'building_time': 0.007994651794433594,
-             'cipher_id': 'speck_p32_k64_o32_r4',
-              'components_values': {'cipher_output_3_12_o': {'value': '38103010',
-              'weight': 0},
-               ...
-              'total_weight': 3.0
-              'building_time_seconds': 0.009123563766479492}
+            sage: trail = cp.find_lowest_weight_xor_linear_trail()
+            sage: trail['total_weight']
+            3.0
         """
         start = tm.time()
         self.build_xor_linear_trail_model(-1, fixed_values)
@@ -360,20 +346,9 @@ class CpXorLinearModel(CpModel):
 
             sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_linear_model import CpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: speck = speck.remove_key_schedule()
             sage: cp = CpXorLinearModel(speck)
-            sage: fixed_variables = [set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-            sage: cp.find_one_xor_linear_trail(fixed_variables) # random
-            {'cipher_id': 'speck_p32_k64_o32_r4',
-             ...
-             'memory': '0.0MB',
-             'components_values': {'plaintext': {'weight': 0, 'value': '0xffff'},
-              ...
-             'cipher_output_3_12': {'weight': 0, 'value': '0xffffffff'}},
-             'total_weight': 16.0
-             'building_time_seconds': 0.00975656509399414}
+            sage: cp.find_one_xor_linear_trail() # random
         """
         start = tm.time()
         self.build_xor_linear_trail_model(0, fixed_values)
@@ -404,18 +379,11 @@ class CpXorLinearModel(CpModel):
 
             sage: from claasp.cipher_modules.models.cp.cp_models.cp_xor_linear_model import CpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-            sage: speck = speck.remove_key_schedule()
             sage: cp = CpXorLinearModel(speck)
-            sage: fixed_variables = [set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-            sage: cp.find_one_xor_linear_trail_with_fixed_weight(3, fixed_variables) # random
-            {'cipher_id': 'speck_p32_k64_o32_r4',
-             'model_type': 'xor_linear_one_solution',
-             ...
-             'total_weight': 3.0,
-             'building_time_seconds': 0.005683183670043945}
-
+            sage: trail = cp.find_one_xor_linear_trail_with_fixed_weight(3) # random
+            sage: trail['total_weight']
+            '3.0'
         """
         start = tm.time()
         self.build_xor_linear_trail_model(fixed_weight, fixed_values)

--- a/claasp/cipher_modules/models/cp/cp_models/cp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/cp_models/cp_xor_linear_model.py
@@ -23,9 +23,10 @@ import time as tm
 from sage.crypto.sbox import SBox
 
 from claasp.cipher_modules.models.cp.cp_model import CpModel, solve_satisfy, constraint_type_error
-from claasp.cipher_modules.models.utils import get_bit_bindings
+from claasp.cipher_modules.models.utils import get_bit_bindings, \
+    get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import INTERMEDIATE_OUTPUT, XOR_LINEAR, CONSTANT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, \
-    MIX_COLUMN, WORD_OPERATION
+    MIX_COLUMN, WORD_OPERATION, INPUT_KEY
 
 
 class CpXorLinearModel(CpModel):
@@ -131,6 +132,13 @@ class CpXorLinearModel(CpModel):
         self.component_and_probability = {}
         self._variables_list = []
         variables = []
+        if INPUT_KEY not in [variable["component_id"] for variable in fixed_variables]:
+            cipher_without_key_schedule = self._cipher.remove_key_schedule()
+            self._cipher = cipher_without_key_schedule
+            self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(
+                self._cipher, lambda record: f'{record[0]}_{record[2]}[{record[1]}]')
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_xor_linear_constraints(fixed_variables)
         self._model_constraints = constraints
 
@@ -210,6 +218,7 @@ class CpXorLinearModel(CpModel):
     def find_all_xor_linear_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='Chuffed'):
         """
         Return a list of solutions containing all the linear trails having the ``fixed_weight`` weight of correlation.
+        By default, the search removes the key schedule, if any.
 
         INPUT:
 
@@ -248,6 +257,7 @@ class CpXorLinearModel(CpModel):
                                                        fixed_values=[], solver_name='Chuffed'):
         """
         Return a list of solutions containing all the linear trails having the weight of correlation lying in the interval ``[min_weight, max_weight]``.
+        By default, the search removes the key schedule, if any.
 
         INPUT:
 
@@ -288,6 +298,7 @@ class CpXorLinearModel(CpModel):
     def find_lowest_weight_xor_linear_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a linear trail with the lowest weight of correlation.
+        By default, the search removes the key schedule, if any.
 
         .. NOTE::
 
@@ -334,6 +345,7 @@ class CpXorLinearModel(CpModel):
     def find_one_xor_linear_trail(self, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a linear trail with any weight of correlation.
+        By default, the search removes the key schedule, if any.
 
         INPUT:
 
@@ -376,6 +388,7 @@ class CpXorLinearModel(CpModel):
     def find_one_xor_linear_trail_with_fixed_weight(self, fixed_weight=-1, fixed_values=[], solver_name='Chuffed'):
         """
         Return the solution representing a linear trail with the weight of correlation equal to ``fixed_weight``.
+        By default, the search removes the key schedule, if any.
 
         INPUT:
 

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
-
-
+import os
+import sys
 import time
 
 from bitstring import BitArray
@@ -127,7 +127,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                            solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return all the XOR differential trails with weight equal to ``fixed_weight`` as a list in standard format.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         .. SEEALSO::
 
@@ -146,15 +146,28 @@ class MilpXorDifferentialModel(MilpModel):
         - ``solver_name`` -- **string** (default: `GLPK`); the name of the solver (if needed)
 
         EXAMPLES::
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+
+            # single-key setting
+            from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: trails = milp.find_all_xor_differential_trails_with_fixed_weight(9) # long
+            ...
+            sage: len(trails) 
+            2
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trails = milp.find_all_xor_differential_trails_with_fixed_weight(1, get_single_key_scenario_format_for_fixed_values(speck)) # long
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trails = milp.find_all_xor_differential_trails_with_fixed_weight(2, fixed_values=[key]) # long
             ...
-            sage: len(trails) # long
-            6
+            sage: len(trails)
+            2
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)
@@ -180,7 +193,10 @@ class MilpXorDifferentialModel(MilpModel):
         looking_for_other_solutions = 1
         while looking_for_other_solutions:
             try:
+                f = open(os.devnull, 'w')
+                sys.stdout = f
                 solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
+                sys.stdout = sys.__stdout__
                 solution['building_time'] = building_time
                 solution['test_name'] = "find_all_xor_differential_trails_with_fixed_weight"
                 self._number_of_trails_found += 1
@@ -305,12 +321,11 @@ class MilpXorDifferentialModel(MilpModel):
           be fixed
 
         EXAMPLES::
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
-            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: milp.is_single_key(get_single_key_scenario_format_for_fixed_values(speck))
+            sage: milp.is_single_key(speck)
             True
         """
         cipher_inputs = self._cipher.inputs
@@ -328,7 +343,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                              fixed_values=[], solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return all XOR differential trails with weight greater than ``min_weight`` and lower/equal to ``max_weight``.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         The value returned is a list of solutions in standard format.
 
         .. SEEALSO::
@@ -351,15 +366,27 @@ class MilpXorDifferentialModel(MilpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+            # single-key setting
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(0, 1, get_single_key_scenario_format_for_fixed_values(speck)) # long
+            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(9, 10) # long
             ...
-            sage: len(trails) # long
-            7
+            sage: len(trails) 
+            28
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key]) # long
+            ...
+            sage: len(trails)
+            9
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)
@@ -385,7 +412,10 @@ class MilpXorDifferentialModel(MilpModel):
             number_new_constraints = len(weight_constraints)
             while looking_for_other_solutions:
                 try:
+                    f = open(os.devnull, 'w')
+                    sys.stdout = f
                     solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
+                    sys.stdout = sys.__stdout__
                     solution['building_time'] = building_time
                     solution['test_name'] = "find_all_xor_differential_trails_with_weight_at_most"
                     self._number_of_trails_found += 1
@@ -410,7 +440,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                   external_solver_name=False):
         """
         Return a XOR differential trail with the lowest weight in standard format, i.e. the solver solution.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         .. SEEALSO::
 
@@ -424,12 +454,24 @@ class MilpXorDifferentialModel(MilpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+            # single-key setting
+            from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: trail = milp.find_lowest_weight_xor_differential_trail()
+            ...
+            sage: trail["total_weight"]
+            9.0
+            
+            # related-key setting
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
-            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trail = milp.find_lowest_weight_xor_differential_trail(get_single_key_scenario_format_for_fixed_values(speck))
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trail = milp.find_lowest_weight_xor_differential_trail(fixed_values=[key])
             ...
             sage: trail["total_weight"]
             1.0
@@ -453,7 +495,7 @@ class MilpXorDifferentialModel(MilpModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return a XOR differential trail, not necessarily the one with the lowest weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -468,12 +510,21 @@ class MilpXorDifferentialModel(MilpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+            # single-key setting
+            from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: trail = milp.find_one_xor_differential_trail() # random
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
-            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trail = milp.find_one_xor_differential_trail(get_single_key_scenario_format_for_fixed_values(speck)) # random
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trail = milp.find_one_xor_differential_trail(fixed_values=[key]) # random
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)
@@ -493,7 +544,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                           solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return one XOR differential trail with weight equal to ``fixed_weight`` as a list in standard format.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -509,13 +560,25 @@ class MilpXorDifferentialModel(MilpModel):
 
         EXAMPLES::
 
-            sage: from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+            # single-key setting
+            from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: trail = milp.find_one_xor_differential_trail_with_fixed_weight(3) # random
+            sage: trail['total_weight']
+            3.0
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
-            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trail = milp.find_one_xor_differential_trail_with_fixed_weight(5, get_single_key_scenario_format_for_fixed_values(speck))
-            ...
+            sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
+            sage: trail = milp.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[key]) # random
+            sage: trail['total_weight']
+            3.0
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -25,7 +25,8 @@ from claasp.cipher_modules.models.milp.milp_model import MilpModel, verbose_prin
 from claasp.cipher_modules.models.milp.utils.milp_name_mappings import MILP_XOR_DIFFERENTIAL, MILP_PROBABILITY_SUFFIX, \
     MILP_BUILDING_MESSAGE, MILP_XOR_DIFFERENTIAL_OBJECTIVE
 from claasp.cipher_modules.models.milp.utils.utils import _string_to_hex, _get_variables_values_as_string
-from claasp.cipher_modules.models.utils import integer_to_bit_list, set_component_solution
+from claasp.cipher_modules.models.utils import integer_to_bit_list, set_component_solution, \
+    get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT,
                                   WORD_OPERATION, LINEAR_LAYER, SBOX, MIX_COLUMN)
 
@@ -99,6 +100,8 @@ class MilpXorDifferentialModel(MilpModel):
         """
         variables = []
         self._variables_list = []
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_constraints(fixed_variables)
         component_types = [CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_OPERATION]
         operation_types = ['AND', 'MODADD', 'MODSUB', 'NOT', 'OR', 'ROTATE', 'SHIFT', 'XOR']
@@ -124,6 +127,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                            solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return all the XOR differential trails with weight equal to ``fixed_weight`` as a list in standard format.
+        By default, the search is set in the single key setting.
 
         .. SEEALSO::
 
@@ -324,7 +328,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                              fixed_values=[], solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return all XOR differential trails with weight greater than ``min_weight`` and lower/equal to ``max_weight``.
-
+        By default, the search is set in the single key setting.
         The value returned is a list of solutions in standard format.
 
         .. SEEALSO::
@@ -365,6 +369,9 @@ class MilpXorDifferentialModel(MilpModel):
         self.add_constraints_to_build_in_sage_milp_class(-1, fixed_values)
         end = time.time()
         building_time = end - start
+
+        if fixed_values == []:
+            fixed_values = get_single_key_scenario_format_for_fixed_values(self._cipher)
         inputs_ids = self._cipher.inputs
         if self.is_single_key(fixed_values):
             inputs_ids = [i for i in self._cipher.inputs if "key" not in i]
@@ -403,6 +410,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                   external_solver_name=False):
         """
         Return a XOR differential trail with the lowest weight in standard format, i.e. the solver solution.
+        By default, the search is set in the single key setting.
 
         .. SEEALSO::
 
@@ -445,6 +453,7 @@ class MilpXorDifferentialModel(MilpModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return a XOR differential trail, not necessarily the one with the lowest weight.
+        By default, the search is set in the single key setting.
 
         INPUT:
 
@@ -484,6 +493,7 @@ class MilpXorDifferentialModel(MilpModel):
                                                           solver_name=SOLVER_DEFAULT, external_solver_name=None):
         """
         Return one XOR differential trail with weight equal to ``fixed_weight`` as a list in standard format.
+        By default, the search is set in the single key setting.
 
         INPUT:
 

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
@@ -1,4 +1,5 @@
-
+import os
+import sys
 # ****************************************************************************
 # Copyright 2023 Technology Innovation Institute
 # 
@@ -275,14 +276,10 @@ class MilpXorLinearModel(MilpModel):
         EXAMPLES::
 
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
-            sage: from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-            sage: milp = MilpXorLinearModel(speck.remove_key_schedule())
-            sage: plaintext = set_fixed_variables(
-            ....: component_id='plaintext', constraint_type='not equal',
-            ....: bit_positions=range(8), bit_values=integer_to_bit_list(0x0, 8, 'big'))
-            sage: trails = milp.find_all_xor_linear_trails_with_fixed_weight(1, fixed_values = [plaintext])  # long
+            sage: milp = MilpXorLinearModel(speck)
+            sage: trails = milp.find_all_xor_linear_trails_with_fixed_weight(1)
             ...
             sage: len(trails) # long
             12
@@ -306,7 +303,10 @@ class MilpXorLinearModel(MilpModel):
         looking_for_other_solutions = 1
         while looking_for_other_solutions:
             try:
+                f = open(os.devnull, 'w')
+                sys.stdout = f
                 solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
+                sys.stdout = sys.__stdout__
                 solution['building_time'] = building_time
                 solution['test_name'] = "find_all_xor_linear_trails_with_fixed_weight"
                 self._number_of_trails_found += 1
@@ -377,13 +377,11 @@ class MilpXorLinearModel(MilpModel):
 
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-            sage: milp = MilpXorLinearModel(speck.remove_key_schedule())
-            sage: plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not equal', bit_positions=range(8), bit_values=integer_to_bit_list(0x0, 8, 'big'))
-            sage: trails = milp.find_all_xor_linear_trails_with_weight_at_most(0,1,[plaintext]) # long
+            sage: milp = MilpXorLinearModel(speck)
+            sage: trails = milp.find_all_xor_linear_trails_with_weight_at_most(0,1)
             ...
-            sage: len(trails) # long
+            sage: len(trails)
             13
         """
         start = time.time()
@@ -407,7 +405,10 @@ class MilpXorLinearModel(MilpModel):
             number_new_constraints = len(weight_constraints)
             while looking_for_other_solutions:
                 try:
+                    f = open(os.devnull, 'w')
+                    sys.stdout = f
                     solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
+                    sys.stdout = sys.__stdout__
                     solution['building_time'] = building_time
                     solution['test_name'] = "find_all_xor_linear_trails_with_weight_at_most"
                     self._number_of_trails_found += 1
@@ -454,7 +455,7 @@ class MilpXorLinearModel(MilpModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=9)
-            sage: milp = MilpXorLinearModel(speck.remove_key_schedule())
+            sage: milp = MilpXorLinearModel(speck)
             sage: plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32), bit_values=integer_to_bit_list(0x03805224, 32, 'big'))
             sage: trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])  # doctest: +SKIP
             ...
@@ -466,7 +467,7 @@ class MilpXorLinearModel(MilpModel):
             sage: from claasp.ciphers.block_ciphers.simon_block_cipher import SimonBlockCipher
             sage: from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
             sage: simon = SimonBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=13)
-            sage: milp = MilpXorLinearModel(simon.remove_key_schedule())
+            sage: milp = MilpXorLinearModel(simon)
             sage: plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32), bit_values=integer_to_bit_list(0x00200000, 32, 'big'))
             sage: trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])  # doctest: +SKIP
             ...
@@ -508,11 +509,9 @@ class MilpXorLinearModel(MilpModel):
 
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-            sage: milp = MilpXorLinearModel(speck.remove_key_schedule())
-            sage: plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32), bit_values=integer_to_bit_list(0x03805224, 32, 'big'))
-            sage: trail = milp.find_one_xor_linear_trail(fixed_values=[plaintext]) # random
+            sage: milp = MilpXorLinearModel(speck)
+            sage: trail = milp.find_one_xor_linear_trail() # random
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)
@@ -551,9 +550,11 @@ class MilpXorLinearModel(MilpModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
             sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-            sage: milp = MilpXorLinearModel(speck.remove_key_schedule())
-            sage: trail = milp.find_one_xor_linear_trail_with_fixed_weight(6)
+            sage: milp = MilpXorLinearModel(speck)
+            sage: trail = milp.find_one_xor_linear_trail_with_fixed_weight(6) # random
             ...
+            sage: trail['total_weight']
+            6.0
         """
         start = time.time()
         self.init_model_in_sage_milp_class(solver_name)

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
@@ -1,5 +1,3 @@
-import os
-import sys
 # ****************************************************************************
 # Copyright 2023 Technology Innovation Institute
 # 
@@ -19,6 +17,8 @@ import sys
 
 
 import time
+import os
+import sys
 
 from bitstring import BitArray
 

--- a/claasp/cipher_modules/models/milp/utils/utils.py
+++ b/claasp/cipher_modules/models/milp/utils/utils.py
@@ -711,3 +711,12 @@ def _string_to_hex( string):
     except Exception:
         value = string
     return value
+
+def _filter_fixed_variables(fixed_values, fixed_variable, id):
+    fixed_values_to_keep = [variable for variable in fixed_values if variable["constraint_type"] == "equal"]
+    if id in [value["component_id"] for value in fixed_values_to_keep]:
+        input_index = [value["component_id"] for value in fixed_values_to_keep].index(id)
+        for bit in fixed_values_to_keep[input_index]["bit_positions"]:
+            bit_index = fixed_variable["bit_positions"].index(bit)
+            del fixed_variable["bit_values"][bit_index]
+            del fixed_variable["bit_positions"][bit_index]

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 
 from claasp.cipher_modules.models.sat.sat_model import SatModel
 from claasp.cipher_modules.models.sat.sat_models.sat_cipher_model import SatCipherModel
-from claasp.cipher_modules.models.utils import set_component_solution
+from claasp.cipher_modules.models.utils import set_component_solution, get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER,
                                   MIX_COLUMN, SBOX, WORD_OPERATION, XOR_DIFFERENTIAL)
 
@@ -57,6 +57,8 @@ class SatXorDifferentialModel(SatModel):
         """
         variables = []
         self._variables_list = []
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_constraints(fixed_variables)
         self._model_constraints = constraints
         component_types = (CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_OPERATION)
@@ -115,6 +117,7 @@ class SatXorDifferentialModel(SatModel):
                                                            solver_name='cryptominisat'):
         """
         Return a list of solutions containing all the XOR differential trails having the ``fixed_weight`` weight.
+        By default, the search is set in the single key setting.
 
         INPUT:
 
@@ -180,6 +183,7 @@ class SatXorDifferentialModel(SatModel):
                                                              solver_name='cryptominisat'):
         """
         Return a list of solutions.
+        By default, the search is set in the single key setting.
 
         The list contain all the XOR differential trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -231,6 +235,7 @@ class SatXorDifferentialModel(SatModel):
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a trail with the lowest weight.
+        By default, the search is set in the single key setting.
 
         .. NOTE::
 
@@ -293,7 +298,7 @@ class SatXorDifferentialModel(SatModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a XOR differential trail.
-
+        By default, the search is set in the single key setting.
         The solution probability is almost always lower than the one of a random guess of the longest input.
 
         INPUT:
@@ -340,7 +345,7 @@ class SatXorDifferentialModel(SatModel):
                                                           solver_name='cryptominisat'):
         """
         Return the solution representing a XOR differential trail whose probability is ``2 ** fixed_weight``.
-
+        By default, the search is set in the single key setting.
         INPUT:
 
         - ``fixed_weight`` -- **integer**; the weight to be fixed

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
@@ -117,7 +117,7 @@ class SatXorDifferentialModel(SatModel):
                                                            solver_name='cryptominisat'):
         """
         Return a list of solutions containing all the XOR differential trails having the ``fixed_weight`` weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -131,22 +131,27 @@ class SatXorDifferentialModel(SatModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: sat = SatXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
+            sage: trails = sat.find_all_xor_differential_trails_with_fixed_weight(9)
+            sage: len(trails) == 2
+            True
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: sat = SatXorDifferentialModel(speck)
             sage: key = set_fixed_variables(
             ....:     component_id='key',
-            ....:     constraint_type='equal',
+            ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
-            ....:     bit_values=integer_to_bit_list(0, 64, 'big'))
-            sage: trails = sat.find_all_xor_differential_trails_with_fixed_weight(9, fixed_values=[plaintext, key])
+            ....:     bit_values=[0]*64)
+            sage: trails = sat.find_all_xor_differential_trails_with_fixed_weight(2, fixed_values=[key])
             sage: len(trails) == 2
             True
         """
@@ -183,7 +188,7 @@ class SatXorDifferentialModel(SatModel):
                                                              solver_name='cryptominisat'):
         """
         Return a list of solutions.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         The list contain all the XOR differential trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -201,23 +206,28 @@ class SatXorDifferentialModel(SatModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: sat = SatXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
+            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10)
+            sage: len(trails) == 28
+            True
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: sat = SatXorDifferentialModel(speck)
             sage: key = set_fixed_variables(
             ....:     component_id='key',
-            ....:     constraint_type='equal',
+            ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
-            ....:     bit_values=integer_to_bit_list(0, 64, 'big'))
-            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10, fixed_values=[plaintext, key])
-            sage: len(trails) == 28
+            ....:     bit_values=[0]*64)
+            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key])
+            sage: len(trails) == 9
             True
         """
         solutions_list = []
@@ -235,7 +245,7 @@ class SatXorDifferentialModel(SatModel):
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a trail with the lowest weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         .. NOTE::
 
@@ -253,24 +263,29 @@ class SatXorDifferentialModel(SatModel):
 
         EXAMPLES::
 
+            # single-key setting
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: sat = SatXorDifferentialModel(speck)
+            sage: trail = sat.find_lowest_weight_xor_differential_trail()
+            sage: trail['total_weight']
+            9.0
+
+            # related-key setting
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
             sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: sat = SatXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=(0,)*32)
             sage: key = set_fixed_variables(
             ....:         component_id='key',
-            ....:         constraint_type='equal',
+            ....:         constraint_type='not_equal',
             ....:         bit_positions=range(64),
             ....:         bit_values=(0,)*64)
-            sage: trail = sat.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext, key])
+            sage: trail = sat.find_lowest_weight_xor_differential_trail(fixed_values=[key])
             sage: trail['total_weight']
-            9.0
+            1.0
         """
         current_weight = 0
         start_building_time = time.time()
@@ -298,7 +313,7 @@ class SatXorDifferentialModel(SatModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a XOR differential trail.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         The solution probability is almost always lower than the one of a random guess of the longest input.
 
         INPUT:
@@ -312,25 +327,26 @@ class SatXorDifferentialModel(SatModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: sat = SatXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
+            sage: sat.find_one_xor_differential_trail() # random
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: sat = SatXorDifferentialModel(speck)
+            sage: key = set_fixed_variables(
+            ....:     component_id='key',
             ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: sat.find_one_xor_differential_trail(fixed_values=[plaintext]) # random
-            {'cipher_id': 'speck_p32_k64_o32_r5',
-             'model_type': 'xor_differential',
-             'solver_name': 'cryptominisat',
-             'solving_time_seconds': 0.0,
-             'memory_megabytes': 7.09,
-             ...
-             'status': 'SATISFIABLE',
-             'building_time_seconds': 0.004874706268310547}
+            ....:     bit_positions=range(64),
+            ....:     bit_values=[0]*64)
+            sage: sat.find_one_xor_differential_trail(fixed_values=[key])
         """
         start_building_time = time.time()
         self.build_xor_differential_trail_model(fixed_variables=fixed_values)
@@ -345,7 +361,7 @@ class SatXorDifferentialModel(SatModel):
                                                           solver_name='cryptominisat'):
         """
         Return the solution representing a XOR differential trail whose probability is ``2 ** fixed_weight``.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         INPUT:
 
         - ``fixed_weight`` -- **integer**; the weight to be fixed
@@ -358,23 +374,28 @@ class SatXorDifferentialModel(SatModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: sat = SatXorDifferentialModel(speck, window_size_by_round=[0, 0, 0])
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=(0,)*32)
+            sage: trail = sat.find_one_xor_differential_trail_with_fixed_weight(3)
+            sage: trail['total_weight']
+            3.0
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: sat = SatXorDifferentialModel(speck)
             sage: key = set_fixed_variables(
             ....:     component_id='key',
-            ....:     constraint_type='equal',
+            ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
-            ....:     bit_values=(0,)*64)
-            sage: result = sat.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[plaintext, key])
-            sage: result['total_weight']
+            ....:     bit_values=[0]*64)
+            sage: trail = sat.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[key])
+            sage: trail['total_weight']
             3.0
         """
         start_building_time = time.time()

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
@@ -134,15 +134,9 @@ class SatXorLinearModel(SatModel):
 
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
-            sage: sat = SatXorLinearModel(speck.remove_key_schedule())
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trails = sat.find_all_xor_linear_trails_with_fixed_weight(1, fixed_values=[plaintext])
+            sage: sat = SatXorLinearModel(speck)
+            sage: trails = sat.find_all_xor_linear_trails_with_fixed_weight(1)
             sage: len(trails) == 4
             True
         """
@@ -197,17 +191,12 @@ class SatXorLinearModel(SatModel):
 
         EXAMPLES::
 
+            # without key schedule
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
-            sage: sat = SatXorLinearModel(speck.remove_key_schedule())
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trails = sat.find_all_xor_linear_trails_with_weight_at_most(0, 2, fixed_values=[plaintext])
+            sage: sat = SatXorLinearModel(speck)
+            sage: trails = sat.find_all_xor_linear_trails_with_weight_at_most(0, 2) # long
             sage: len(trails) == 187
             True
         """
@@ -246,17 +235,11 @@ class SatXorLinearModel(SatModel):
 
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: sat = SatXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trail = sat.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+            sage: trail = sat.find_lowest_weight_xor_linear_trail()
             sage: trail['total_weight']
-            2.0
+            1.0
         """
         current_weight = 0
         start_building_time = time.time()
@@ -302,15 +285,9 @@ class SatXorLinearModel(SatModel):
 
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=4)
             sage: sat = SatXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: sat.find_one_xor_linear_trail(fixed_values=[plaintext]) # random
+            sage: sat.find_one_xor_linear_trail() # random
             {'cipher_id': 'speck_p32_k64_o32_r4',
              'model_type': 'xor_linear',
              'solver_name': 'cryptominisat',
@@ -349,17 +326,11 @@ class SatXorLinearModel(SatModel):
         EXAMPLES::
 
             sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: sat = SatXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=(0,)*32)
-            sage: result = sat.find_one_xor_linear_trail_with_fixed_weight(7, fixed_values=[plaintext])
-            sage: result['total_weight']
+            sage: trail = sat.find_one_xor_linear_trail_with_fixed_weight(7)
+            sage: trail['total_weight']
             7.0
         """
         start_building_time = time.time()

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
@@ -21,10 +21,11 @@ import time
 
 from claasp.cipher_modules.models.sat.utils import constants, utils
 from claasp.cipher_modules.models.sat.sat_model import SatModel
-from claasp.cipher_modules.models.sat.utils.constants import INPUT_BIT_ID_SUFFIX, OUTPUT_BIT_ID_SUFFIX
-from claasp.cipher_modules.models.utils import get_bit_bindings, set_component_solution
+from claasp.cipher_modules.models.sat.utils.constants import OUTPUT_BIT_ID_SUFFIX, INPUT_BIT_ID_SUFFIX
+from claasp.cipher_modules.models.utils import get_bit_bindings, set_component_solution, \
+    get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER,
-                                  MIX_COLUMN, SBOX, WORD_OPERATION, XOR_LINEAR)
+                                  MIX_COLUMN, SBOX, WORD_OPERATION, XOR_LINEAR, INPUT_KEY)
 
 
 class SatXorLinearModel(SatModel):
@@ -85,6 +86,11 @@ class SatXorLinearModel(SatModel):
         """
         self._variables_list = []
         variables = []
+        if INPUT_KEY not in [variable["component_id"] for variable in fixed_variables]:
+            self._cipher = self._cipher.remove_key_schedule()
+            self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(self._cipher, '_'.join)
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_xor_linear_constraints(fixed_variables)
         self._model_constraints = constraints
         component_types = (CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_OPERATION)
@@ -111,6 +117,7 @@ class SatXorLinearModel(SatModel):
     def find_all_xor_linear_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='cryptominisat'):
         """
         Return a list of solutions containing all the XOR linear trails having weight equal to ``fixed_weight``.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail
 
         INPUT:
@@ -160,7 +167,7 @@ class SatXorLinearModel(SatModel):
                     suffix = component[-2:]
                 else:
                     component_id = component
-                    suffix = '_o'
+                    suffix = OUTPUT_BIT_ID_SUFFIX
                 literals.extend([f'{minus[i]}{component_id}_{i}{suffix}' for i in range(bit_len)])
             self._model_constraints.append(' '.join(literals))
             solution = self.solve(XOR_LINEAR, solver_name=solver_name)
@@ -172,6 +179,7 @@ class SatXorLinearModel(SatModel):
                                                        solver_name='cryptominisat'):
         """
         Return a list of solutions.
+        By default, the search removes the key schedule, if any.
 
         The list contains all the XOR linear trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -217,6 +225,7 @@ class SatXorLinearModel(SatModel):
     def find_lowest_weight_xor_linear_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a XOR LINEAR trail with the lowest possible weight.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         .. NOTE::
@@ -275,6 +284,7 @@ class SatXorLinearModel(SatModel):
     def find_one_xor_linear_trail(self, fixed_values=[], solver_name='cryptominisat'):
         """
         Return the solution representing a XOR linear trail.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         The solution probability is almost always lower than the one of a random guess of the longest input.
@@ -323,6 +333,7 @@ class SatXorLinearModel(SatModel):
                                                     solver_name='cryptominisat'):
         """
         Return the solution representing a XOR linear trail whose weight is ``fixed_weight``.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         INPUT:

--- a/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
+++ b/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
@@ -90,7 +90,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_all_xor_differential_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='z3'):
         """
         Return a list of solutions  containing all the XOR differential trails having the ``fixed_weight`` weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -104,22 +104,27 @@ class SmtXorDifferentialModel(SmtModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
+            sage: trails = smt.find_all_xor_differential_trails_with_fixed_weight(9)
+            sage: len(trails)
+            2
+                        
+            # related-key setting
+            sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: smt = SmtXorDifferentialModel(speck)
             sage: key = set_fixed_variables(
             ....:     component_id='key',
-            ....:     constraint_type='equal',
+            ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
-            ....:     bit_values=integer_to_bit_list(0, 64, 'big'))
-            sage: trails = smt.find_all_xor_differential_trails_with_fixed_weight(9, fixed_values=[plaintext, key])
+            ....:     bit_values=[0]*64)
+            sage: trails = smt.find_all_xor_differential_trails_with_fixed_weight(2, fixed_values=[key])
             sage: len(trails)
             2
         """
@@ -156,7 +161,7 @@ class SmtXorDifferentialModel(SmtModel):
                                                              solver_name='z3'):
         """
         Return a list of solutions.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         The list contains all the XOR differential trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -174,24 +179,29 @@ class SmtXorDifferentialModel(SmtModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: key = set_fixed_variables(
-            ....:     component_id='key',
-            ....:     constraint_type='equal',
-            ....:     bit_positions=range(64),
-            ....:     bit_values=integer_to_bit_list(0, 64, 'big'))
-            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10, fixed_values=[plaintext, key])
+            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10)
             sage: len(trails)
             28
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: smt = SmtXorDifferentialModel(speck)
+            sage: key = set_fixed_variables(
+            ....:     component_id='key',
+            ....:     constraint_type='not_equal',
+            ....:     bit_positions=range(64),
+            ....:     bit_values=[0]*64)
+            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key])
+            sage: len(trails)
+            9
         """
         solutions_list = []
         for weight in range(min_weight, max_weight + 1):
@@ -207,7 +217,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a trail with the lowest weight.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         .. NOTE::
 
@@ -225,24 +235,29 @@ class SmtXorDifferentialModel(SmtModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: key = set_fixed_variables(
-            ....:     component_id='key',
-            ....:     constraint_type='equal',
-            ....:     bit_positions=range(64),
-            ....:     bit_values=integer_to_bit_list(0, 64, 'big'))
-            sage: trail = smt.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext, key])
+            sage: trail = smt.find_lowest_weight_xor_differential_trail()
             sage: trail['total_weight']
             9.0
+
+            # related-key setting
+            sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: smt = SmtXorDifferentialModel(speck)
+            sage: key = set_fixed_variables(
+            ....:     component_id='key',
+            ....:     constraint_type='not_equal',
+            ....:     bit_positions=range(64),
+            ....:     bit_values=[0]*64)
+            sage: trail = smt.find_lowest_weight_xor_differential_trail(fixed_values=[key])
+            sage: trail['total_weight']
+            1.0
         """
         current_weight = 0
         start_building_time = time.time()
@@ -270,7 +285,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR differential trail.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
         The solution probability is almost always lower than the one of a random guess of the longest input.
 
         INPUT:
@@ -284,17 +299,12 @@ class SmtXorDifferentialModel(SmtModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: smt.find_one_xor_differential_trail(fixed_values=[plaintext]) # random
+            sage: smt.find_one_xor_differential_trail() # random
             {'cipher_id': 'speck_p32_k64_o32_r5',
              'model_type': 'xor_differential',
              'solver_name': 'z3',
@@ -303,6 +313,19 @@ class SmtXorDifferentialModel(SmtModel):
              ...
              'total_weight': 93,
              'building_time_seconds': 0.002946615219116211}
+
+             # related-key setting
+            sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: smt = SmtXorDifferentialModel(speck)
+            sage: key = set_fixed_variables(
+            ....:     component_id='key',
+            ....:     constraint_type='not_equal',
+            ....:     bit_positions=range(64),
+            ....:     bit_values=[0]*64)
+            sage: smt.find_one_xor_differential_trail(fixed_values=[key]) # random
         """
         start_building_time = time.time()
         self.build_xor_differential_trail_model(fixed_variables=fixed_values)
@@ -316,7 +339,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_one_xor_differential_trail_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR differential trail whose probability is ``2 ** fixed_weight``.
-        By default, the search is set in the single key setting.
+        By default, the search is set in the single-key setting.
 
         INPUT:
 
@@ -330,24 +353,29 @@ class SmtXorDifferentialModel(SmtModel):
 
         EXAMPLES::
 
+            # single-key setting
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:     component_id='plaintext',
-            ....:     constraint_type='not_equal',
-            ....:     bit_positions=range(32),
-            ....:     bit_values=(0,)*32)
+            sage: trail = smt.find_one_xor_differential_trail_with_fixed_weight(3)
+            sage: trail['total_weight']
+            3.0
+
+            sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
+            sage: speck = SpeckBlockCipher(number_of_rounds=5)
+            sage: smt = SmtXorDifferentialModel(speck)
             sage: key = set_fixed_variables(
             ....:     component_id='key',
-            ....:     constraint_type='equal',
+            ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
-            ....:     bit_values=(0,)*64)
-            sage: result = smt.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[plaintext, key])
-            sage: result['total_weight']
+            ....:     bit_values=[0]*64)
+            sage: trail = smt.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[key])
+            sage: trail['total_weight']
             3.0
+
         """
         start_building_time = time.time()
         self.build_xor_differential_trail_model(weight=fixed_weight, fixed_variables=fixed_values)

--- a/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
+++ b/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
@@ -21,7 +21,7 @@ import time
 
 from claasp.cipher_modules.models.smt.smt_model import SmtModel
 from claasp.cipher_modules.models.smt.utils import constants, utils
-from claasp.cipher_modules.models.utils import set_component_solution
+from claasp.cipher_modules.models.utils import set_component_solution, get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER,
                                   MIX_COLUMN, SBOX, WORD_OPERATION, XOR_DIFFERENTIAL)
 
@@ -59,6 +59,8 @@ class SmtXorDifferentialModel(SmtModel):
         """
         variables = []
         self._variables_list = []
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_constraints(fixed_variables)
         component_types = (CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_OPERATION)
         operation_types = ('AND', 'MODADD', 'MODSUB', 'NOT', 'OR', 'ROTATE', 'SHIFT', 'XOR')
@@ -88,6 +90,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_all_xor_differential_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='z3'):
         """
         Return a list of solutions  containing all the XOR differential trails having the ``fixed_weight`` weight.
+        By default, the search is set in the single key setting.
 
         INPUT:
 
@@ -153,6 +156,7 @@ class SmtXorDifferentialModel(SmtModel):
                                                              solver_name='z3'):
         """
         Return a list of solutions.
+        By default, the search is set in the single key setting.
 
         The list contains all the XOR differential trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -203,6 +207,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_lowest_weight_xor_differential_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a trail with the lowest weight.
+        By default, the search is set in the single key setting.
 
         .. NOTE::
 
@@ -265,7 +270,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_one_xor_differential_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR differential trail.
-
+        By default, the search is set in the single key setting.
         The solution probability is almost always lower than the one of a random guess of the longest input.
 
         INPUT:
@@ -311,6 +316,7 @@ class SmtXorDifferentialModel(SmtModel):
     def find_one_xor_differential_trail_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR differential trail whose probability is ``2 ** fixed_weight``.
+        By default, the search is set in the single key setting.
 
         INPUT:
 

--- a/claasp/cipher_modules/models/smt/smt_models/smt_xor_linear_model.py
+++ b/claasp/cipher_modules/models/smt/smt_models/smt_xor_linear_model.py
@@ -22,9 +22,10 @@ import time
 from claasp.cipher_modules.models.smt.utils import constants, utils
 from claasp.cipher_modules.models.smt.smt_model import SmtModel
 from claasp.cipher_modules.models.smt.utils.constants import INPUT_BIT_ID_SUFFIX, OUTPUT_BIT_ID_SUFFIX
-from claasp.cipher_modules.models.utils import get_bit_bindings, set_component_solution
+from claasp.cipher_modules.models.utils import get_bit_bindings, set_component_solution, \
+    get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER,
-                                  MIX_COLUMN, SBOX, WORD_OPERATION, XOR_LINEAR)
+                                  MIX_COLUMN, SBOX, WORD_OPERATION, XOR_LINEAR, INPUT_KEY)
 
 
 class SmtXorLinearModel(SmtModel):
@@ -85,6 +86,11 @@ class SmtXorLinearModel(SmtModel):
         """
         self._variables_list = []
         variables = []
+        if INPUT_KEY not in [variable["component_id"] for variable in fixed_variables]:
+            self._cipher = self._cipher.remove_key_schedule()
+            self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(self._cipher, '_'.join)
+        if fixed_variables == []:
+            fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_xor_linear_constraints(fixed_variables)
         self._model_constraints = constraints
 
@@ -145,6 +151,7 @@ class SmtXorLinearModel(SmtModel):
     def find_all_xor_linear_trails_with_fixed_weight(self, fixed_weight, fixed_values=[], solver_name='z3'):
         """
         Return a list of solutions containing all the XOR linear trails having weight equal to ``fixed_weight``.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         INPUT:
@@ -210,6 +217,7 @@ class SmtXorLinearModel(SmtModel):
     def find_all_xor_linear_trails_with_weight_at_most(self, min_weight, max_weight, fixed_values=[], solver_name='z3'):
         """
         Return a list of solutions.
+        By default, the search removes the key schedule, if any.
 
         The list contains all the XOR linear trails having the weight lying in the interval
         ``[min_weight, max_weight]``.
@@ -255,6 +263,7 @@ class SmtXorLinearModel(SmtModel):
     def find_lowest_weight_xor_linear_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR LINEAR trail with the lowest possible weight.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         .. NOTE::
@@ -313,6 +322,7 @@ class SmtXorLinearModel(SmtModel):
     def find_one_xor_linear_trail(self, fixed_values=[], solver_name='z3'):
         """
         Return the solution representing a XOR linear trail.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         The solution probability is almost always lower than the one of a random guess of the longest input.
@@ -361,6 +371,7 @@ class SmtXorLinearModel(SmtModel):
                                                     solver_name='z3'):
         """
         Return the solution representing a XOR linear trail whose weight is ``fixed_weight``.
+        By default, the search removes the key schedule, if any.
         By default, the weight corresponds to the negative base-2 logarithm of the correlation of the trail.
 
         INPUT:

--- a/claasp/cipher_modules/models/smt/smt_models/smt_xor_linear_model.py
+++ b/claasp/cipher_modules/models/smt/smt_models/smt_xor_linear_model.py
@@ -168,17 +168,11 @@ class SmtXorLinearModel(SmtModel):
 
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import SmtXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: smt = SmtXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trails = smt.find_all_xor_linear_trails_with_fixed_weight(2, fixed_values=[plaintext])
+            sage: trails = smt.find_all_xor_linear_trails_with_fixed_weight(1)
             sage: len(trails)
-            2
+            4
         """
         start_building_time = time.time()
         self.build_xor_linear_trail_model(weight=fixed_weight, fixed_variables=fixed_values)
@@ -237,17 +231,11 @@ class SmtXorLinearModel(SmtModel):
 
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import SmtXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: smt = SmtXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trails = smt.find_all_xor_linear_trails_with_weight_at_most(2, 3, fixed_values=[plaintext])
+            sage: trails = smt.find_all_xor_linear_trails_with_weight_at_most(0, 2) # long
             sage: len(trails)
-            11
+            187
         """
         solutions_list = []
         for weight in range(min_weight, max_weight + 1):
@@ -284,15 +272,9 @@ class SmtXorLinearModel(SmtModel):
 
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import SmtXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: smt = SmtXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: trail = smt.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+            sage: trail = smt.find_lowest_weight_xor_linear_trail)
             sage: trail['total_weight']
             2.0
         """
@@ -340,15 +322,9 @@ class SmtXorLinearModel(SmtModel):
 
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import SmtXorLinearModel
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
             sage: speck = SpeckBlockCipher(number_of_rounds=4)
             sage: smt = SmtXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=integer_to_bit_list(0, 32, 'big'))
-            sage: smt.find_one_xor_linear_trail(fixed_values=[plaintext]) #random
+            sage: smt.find_one_xor_linear_trail() #random
             {'cipher_id': 'speck_p32_k64_o32_r4',
              'model_type': 'xor_linear',
              'solver_name': 'z3',
@@ -387,16 +363,10 @@ class SmtXorLinearModel(SmtModel):
         EXAMPLES::
 
             sage: from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import SmtXorLinearModel
-            sage: from claasp.cipher_modules.models.utils import set_fixed_variables
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=3)
             sage: smt = SmtXorLinearModel(speck)
-            sage: plaintext = set_fixed_variables(
-            ....:         component_id='plaintext',
-            ....:         constraint_type='not_equal',
-            ....:         bit_positions=range(32),
-            ....:         bit_values=(0,)*32)
-            sage: result = smt.find_one_xor_linear_trail_with_fixed_weight(7, fixed_values=[plaintext])
+            sage: result = smt.find_one_xor_linear_trail_with_fixed_weight(7)
             sage: result['total_weight']
             7.0
         """

--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -22,7 +22,8 @@ import sys
 import math
 from copy import deepcopy
 
-from claasp.name_mappings import CONSTANT, CIPHER_OUTPUT, INTERMEDIATE_OUTPUT
+from claasp.name_mappings import CONSTANT, CIPHER_OUTPUT, INTERMEDIATE_OUTPUT, INPUT_KEY, INPUT_PLAINTEXT, \
+    INPUT_MESSAGE, INPUT_STATE
 
 
 def add_arcs(arcs, component, curr_input_bit_ids, input_bit_size, intermediate_output_arcs, previous_output_bit_ids):
@@ -737,15 +738,17 @@ def get_single_key_scenario_format_for_fixed_values(_cipher):
         'not_equal'
     """
     fixed_variables = []
-    if 'key' in _cipher.inputs:
-        input_size = _cipher.inputs_bit_size[_cipher.inputs.index("key")]
+    if INPUT_KEY in _cipher.inputs:
+        input_size = _cipher.inputs_bit_size[_cipher.inputs.index(INPUT_KEY)]
         list_of_0s = [0] * input_size
-        fixed_variable = set_fixed_variables("key", "equal", list(range(input_size)), list_of_0s)
+        fixed_variable = set_fixed_variables(INPUT_KEY, "equal", list(range(input_size)), list_of_0s)
         fixed_variables.append(fixed_variable)
-    input_size = _cipher.inputs_bit_size[_cipher.inputs.index("plaintext")]
-    list_of_0s = [0] * input_size
-    fixed_variable = set_fixed_variables("plaintext", "not_equal", list(range(input_size)), list_of_0s)
-    fixed_variables.append(fixed_variable)
+    possible_inputs = {INPUT_PLAINTEXT, INPUT_MESSAGE, INPUT_STATE}
+    for input in set(_cipher.inputs).intersection(possible_inputs):
+        input_size = _cipher.inputs_bit_size[_cipher.inputs.index(input)]
+        list_of_0s = [0] * input_size
+        fixed_variable = set_fixed_variables(input, "not_equal", list(range(input_size)), list_of_0s)
+        fixed_variables.append(fixed_variable)
 
     return fixed_variables
 

--- a/tests/unit/cipher_modules/models/cp/cp_models/cp_xor_differential_trail_search_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/cp_models/cp_xor_differential_trail_search_model_test.py
@@ -1,5 +1,5 @@
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
+from claasp.cipher_modules.models.utils import set_fixed_variables
 from claasp.cipher_modules.models.cp.cp_models.cp_xor_differential_model import (
     CpXorDifferentialModel, and_xor_differential_probability_ddt)
 
@@ -11,18 +11,14 @@ def test_and_xor_differential_probability_ddt():
 def test_find_all_xor_differential_trails_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     cp = CpXorDifferentialModel(speck)
-    fixed_values = [set_fixed_variables('key', 'equal', list(range(16)), integer_to_bit_list(0, 16, 'big')),
-                    set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'big'))]
-    trails = cp.find_all_xor_differential_trails_with_fixed_weight(1, fixed_values, 'Chuffed')
+    trails = cp.find_all_xor_differential_trails_with_fixed_weight(1, solver_name='Chuffed')
 
     assert len(trails) == 6
     
 def test_solving_unsatisfiability():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=4)
     cp = CpXorDifferentialModel(speck)
-    fixed_values = [set_fixed_variables('key', 'equal', list(range(16)), integer_to_bit_list(0, 16, 'big')),
-                    set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'big'))]
-    trails = cp.find_one_xor_differential_trail_with_fixed_weight(1, fixed_values, 'Chuffed')
+    trails = cp.find_one_xor_differential_trail_with_fixed_weight(1, solver_name='Chuffed')
 
     assert trails['status'] == 'UNSATISFIABLE'
 
@@ -30,9 +26,7 @@ def test_solving_unsatisfiability():
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     cp = CpXorDifferentialModel(speck)
-    fixed_values = [set_fixed_variables('key', 'equal', list(range(16)), integer_to_bit_list(0, 16, 'big')),
-                    set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'big'))]
-    trails = cp.find_all_xor_differential_trails_with_weight_at_most(0, 1, fixed_values, 'Chuffed')
+    trails = cp.find_all_xor_differential_trails_with_weight_at_most(0, 1, solver_name='Chuffed')
 
     assert len(trails) == 7
 
@@ -40,9 +34,7 @@ def test_find_all_xor_differential_trails_with_weight_at_most():
 def test_find_lowest_weight_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=5)
     cp = CpXorDifferentialModel(speck)
-    fixed_values = [set_fixed_variables('key', 'equal', list(range(64)), integer_to_bit_list(0, 64, 'big')),
-                    set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'big'))]
-    trail = cp.find_lowest_weight_xor_differential_trail(fixed_values, 'Chuffed')
+    trail = cp.find_lowest_weight_xor_differential_trail(solver_name='Chuffed')
 
     assert trail['cipher_id'] == 'speck_p32_k64_o32_r5'
     assert trail['total_weight'] == '9.0'

--- a/tests/unit/cipher_modules/models/cp/cp_models/cp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/cp_models/cp_xor_linear_model_test.py
@@ -14,11 +14,8 @@ def test_and_xor_linear_probability_lat():
 
 def test_final_xor_linear_constraints():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-    cp.build_xor_linear_trail_model(-1, fixed_variables)
+    cp.build_xor_linear_trail_model(-1)
 
     assert cp.final_xor_linear_constraints(-1)[:-1] == \
            ['solve:: int_search(p, smallest, indomain_min, complete) minimize sum(p);']
@@ -26,33 +23,24 @@ def test_final_xor_linear_constraints():
 
 def test_find_all_xor_linear_trails_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'little'))]
-    trails = cp.find_all_xor_linear_trails_with_fixed_weight(1, fixed_variables)
+    trails = cp.find_all_xor_linear_trails_with_fixed_weight(1)
 
     assert len(trails) == 12
 
 
 def test_find_all_xor_linear_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(8)), integer_to_bit_list(0, 8, 'little'))]
-    trails = cp.find_all_xor_linear_trails_with_weight_at_most(0, 1, fixed_variables)
+    trails = cp.find_all_xor_linear_trails_with_weight_at_most(0, 1)
 
     assert len(trails) == 13
 
 
 def test_find_lowest_weight_xor_linear_trail():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-    trail = cp.find_lowest_weight_xor_linear_trail(fixed_variables)
+    trail = cp.find_lowest_weight_xor_linear_trail()
 
     assert trail['cipher_id'] == 'speck_p32_k64_o32_r4'
     assert eval('0x' + trail['components_values']['cipher_output_3_12_o']['value']) >= 0
@@ -62,11 +50,8 @@ def test_find_lowest_weight_xor_linear_trail():
 
 def test_find_one_xor_linear_trail():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-    trail = cp.find_one_xor_linear_trail(fixed_variables)
+    trail = cp.find_one_xor_linear_trail()
 
     assert trail['cipher_id'] == 'speck_p32_k64_o32_r4'
     assert trail['components_values']['plaintext']['weight'] == 0
@@ -78,11 +63,8 @@ def test_find_one_xor_linear_trail():
 
 def test_find_one_xor_linear_trail_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-    speck = speck.remove_key_schedule()
     cp = CpXorLinearModel(speck)
-    fixed_variables = [
-        set_fixed_variables('plaintext', 'not_equal', list(range(32)), integer_to_bit_list(0, 32, 'little'))]
-    trail = cp.find_one_xor_linear_trail_with_fixed_weight(3, fixed_variables)
+    trail = cp.find_one_xor_linear_trail_with_fixed_weight(3)
     assert trail['cipher_id'] == 'speck_p32_k64_o32_r4'
     assert trail['model_type'] == 'xor_linear_one_solution'
     assert trail['total_weight'] == '3.0'

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
@@ -1,4 +1,4 @@
-from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
+from claasp.cipher_modules.models.utils import set_fixed_variables
 from claasp.ciphers.block_ciphers.present_block_cipher import PresentBlockCipher
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
@@ -8,8 +8,7 @@ from claasp.ciphers.block_ciphers.tea_block_cipher import TeaBlockCipher
 def test_find_all_xor_differential_trails_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trail = milp.find_all_xor_differential_trails_with_fixed_weight(
-        1, get_single_key_scenario_format_for_fixed_values(speck))
+    trail = milp.find_all_xor_differential_trails_with_fixed_weight(1)
 
     assert len(trail) == 6
     for i in range(len(trail)):
@@ -26,8 +25,7 @@ def test_find_all_xor_differential_trails_with_fixed_weight():
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trails = milp.find_all_xor_differential_trails_with_weight_at_most(
-        0, 1, get_single_key_scenario_format_for_fixed_values(speck))
+    trails = milp.find_all_xor_differential_trails_with_weight_at_most(0, 1)
     assert len(trails) == 7
     for i in range(len(trails)):
         assert trails[i]['total_weight'] <= 1.0
@@ -37,27 +35,24 @@ def test_find_all_xor_differential_trails_with_weight_at_most():
 def test_find_lowest_weight_xor_differential_trail():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trail = milp.find_lowest_weight_xor_differential_trail(
-        get_single_key_scenario_format_for_fixed_values(speck))
+    trail = milp.find_lowest_weight_xor_differential_trail()
     assert trail["total_weight"] == 1.0
 
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck, n_window_heuristic=3)
-    trail = milp.find_lowest_weight_xor_differential_trail(
-        get_single_key_scenario_format_for_fixed_values(speck))
+    trail = milp.find_lowest_weight_xor_differential_trail()
     assert trail["total_weight"] == 1.0
 
     present = PresentBlockCipher(number_of_rounds=2)
     milp = MilpXorDifferentialModel(present)
-    trail = milp.find_lowest_weight_xor_differential_trail(
-        get_single_key_scenario_format_for_fixed_values(present))
+    trail = milp.find_lowest_weight_xor_differential_trail()
     assert trail["total_weight"] == 4.0
 
 
 def test_find_one_xor_differential_trail():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trail = milp.find_one_xor_differential_trail(get_single_key_scenario_format_for_fixed_values(speck))
+    trail = milp.find_one_xor_differential_trail()
     assert trail["total_weight"] >= 1.0
 
     tea = TeaBlockCipher(block_bit_size=16, key_bit_size=32, number_of_rounds=2)
@@ -74,8 +69,7 @@ def test_find_one_xor_differential_trail():
 def test_find_one_xor_differential_trail_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    fixed_values = get_single_key_scenario_format_for_fixed_values(speck)
-    trail = milp.find_one_xor_differential_trail_with_fixed_weight(5, fixed_values)
+    trail = milp.find_one_xor_differential_trail_with_fixed_weight(5)
     assert trail["total_weight"] == 5.0
 
     tea = TeaBlockCipher(block_bit_size=16, key_bit_size=32, number_of_rounds=2)
@@ -85,5 +79,7 @@ def test_find_one_xor_differential_trail_with_fixed_weight():
     #
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trail = milp.find_one_xor_differential_trail_with_fixed_weight(5)
+    key = set_fixed_variables(component_id='key', constraint_type='not_equal',
+                                    bit_positions=range(64), bit_values=[0] * 64)
+    trail = milp.find_one_xor_differential_trail_with_fixed_weight(5, fixed_values=[key])
     assert trail["total_weight"] == 5.0

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -10,19 +10,17 @@ def test_build_xor_linear_trail_model():
     milp.init_model_in_sage_milp_class()
     milp.build_xor_linear_trail_model()
 
-    assert str(milp.model_constraints[0]) == 'x_16 == x_9'
-    assert str(milp.model_constraints[1]) == 'x_17 == x_10'
-    assert str(milp.model_constraints[2]) == 'x_18 == x_11'
-    assert str(milp.model_constraints[23759]) == 'x_12127 == x_12191'
-    assert str(milp.model_constraints[23760]) == 'x_12128 == x_12192'
+    assert str(milp.model_constraints[0]) == 'x_0 == x_1'
+    assert str(milp.model_constraints[1]) == 'x_2 == x_3'
+    assert str(milp.model_constraints[2]) == 'x_4 == x_5'
+    assert str(milp.model_constraints[12369]) == 'x_6400 == x_6432'
+    assert str(milp.model_constraints[12370]) == 'x_6401 == x_6433'
 
 
 def test_find_all_xor_linear_trails_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not equal',
-                                    bit_positions=range(8), bit_values=integer_to_bit_list(0x0, 8, 'big'))
-    trails = milp.find_all_xor_linear_trails_with_fixed_weight(1, fixed_values=[plaintext])
+    milp = MilpXorLinearModel(speck)
+    trails = milp.find_all_xor_linear_trails_with_fixed_weight(1)
 
     assert len(trails) == 12
     for i in range(len(trails)):
@@ -39,10 +37,8 @@ def test_find_all_xor_linear_trails_with_fixed_weight():
 
 def test_find_all_xor_linear_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=3)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not equal',
-                                    bit_positions=range(8), bit_values=integer_to_bit_list(0x0, 8, 'big'))
-    trails = milp.find_all_xor_linear_trails_with_weight_at_most(0, 1, [plaintext])
+    milp = MilpXorLinearModel(speck)
+    trails = milp.find_all_xor_linear_trails_with_weight_at_most(0, 1)
 
     assert len(trails) == 13
     for i in range(len(trails)):
@@ -60,28 +56,26 @@ def test_find_all_xor_linear_trails_with_weight_at_most():
 
 def test_find_lowest_weight_xor_linear_trail():
     # speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=9)
-    # milp = MilpXorLinearModel(speck.remove_key_schedule())
+    # milp = MilpXorLinearModel(speck)
     # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32),
     #                                 bit_values=integer_to_bit_list(0x03805224, 32, 'big'))
     # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
     # assert trail["total_weight"] == 14.0
 
     # simon = SimonBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=13)
-    # milp = MilpXorLinearModel(simon.remove_key_schedule())
+    # milp = MilpXorLinearModel(simon)
     # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32),
     #                                 bit_values=integer_to_bit_list(0x00200000, 32, 'big'))
     # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
     # assert trail["total_weight"] == 18.0
     #
-    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=3)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not equal', bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0x0, 32, 'big'))
-    trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
-    assert trail["total_weight"] == 1.0
+    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
+    milp = MilpXorLinearModel(speck)
+    trail = milp.find_lowest_weight_xor_linear_trail()
+    assert trail["total_weight"] == 3.0
     #
     # present = PresentBlockCipher(number_of_rounds=3)
-    # milp = MilpXorLinearModel(present.remove_key_schedule())
+    # milp = MilpXorLinearModel(present)
     # plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(64),
     #                                 bit_values=integer_to_bit_list(0x0d00000000000000, 64, 'big'))
     # trail = milp.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
@@ -90,7 +84,7 @@ def test_find_lowest_weight_xor_linear_trail():
 
 def test_find_one_xor_linear_trail():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
+    milp = MilpXorLinearModel(speck)
     plaintext = set_fixed_variables(component_id='plaintext', constraint_type='equal', bit_positions=range(32),
                                     bit_values=integer_to_bit_list(0x03805224, 32, 'big'))
     trail = milp.find_one_xor_linear_trail(fixed_values=[plaintext])
@@ -99,19 +93,19 @@ def test_find_one_xor_linear_trail():
 
 def test_find_one_xor_linear_trail_with_fixed_weight():
     # speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-    # milp = MilpXorLinearModel(speck.remove_key_schedule())
+    # milp = MilpXorLinearModel(speck)
     # trail = milp.find_one_xor_linear_trail_with_fixed_weight(6)
     # assert len(trail) == 9
     # assert trail["total_weight"] == 6.0
 
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
+    milp = MilpXorLinearModel(speck)
     trail = milp.find_one_xor_linear_trail_with_fixed_weight(1)
     assert len(trail) == 10
     assert trail["total_weight"] == 1.0
     #
     # speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
-    # milp = MilpXorLinearModel(speck.remove_key_schedule())
+    # milp = MilpXorLinearModel(speck)
     # trail = milp.find_one_xor_linear_trail_with_fixed_weight(10)
     # assert len(trail) == 9
     # assert trail["total_weight"] == 10.0
@@ -119,7 +113,7 @@ def test_find_one_xor_linear_trail_with_fixed_weight():
 
 def test_find_one_xor_linear_trail_with_fixed_weight_with_external_solver():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-    milp = MilpXorLinearModel(speck.remove_key_schedule())
+    milp = MilpXorLinearModel(speck)
     trail = milp.find_one_xor_linear_trail_with_fixed_weight(1, external_solver_name="glpk")
     assert len(trail) == 10
     assert trail["total_weight"] == 1.0
@@ -128,20 +122,20 @@ def test_find_one_xor_linear_trail_with_fixed_weight_with_external_solver():
 def test_find_one_xor_linear_trail_with_fixed_weight_with_supported_but_not_installed_external_solver():
     with pytest.raises(Exception) as e_info:
         speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-        milp = MilpXorLinearModel(speck.remove_key_schedule())
+        milp = MilpXorLinearModel(speck)
         trail = milp.find_one_xor_linear_trail_with_fixed_weight(1, external_solver_name="cplex")
 
 
 def test_find_one_xor_linear_trail_with_fixed_weight_with_installed_external_solver_but_missing_license():
     with pytest.raises(Exception) as e_info:
         speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-        milp = MilpXorLinearModel(speck.remove_key_schedule())
+        milp = MilpXorLinearModel(speck)
         trail = milp.find_one_xor_linear_trail_with_fixed_weight(1, external_solver_name="Gurobi")
 
 def test_find_one_xor_linear_trail_with_fixed_weight_with_unsupported_external_solver():
     with pytest.raises(Exception) as e_info:
         speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
-        milp = MilpXorLinearModel(speck.remove_key_schedule())
+        milp = MilpXorLinearModel(speck)
         trail = milp.find_one_xor_linear_trail_with_fixed_weight(1, external_solver_name="unsupported_solver")
 
 

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
@@ -8,23 +8,15 @@ speck_5rounds = SpeckBlockCipher(number_of_rounds=5)
 def test_find_all_xor_differential_trails_with_fixed_weight():
     speck = SpeckBlockCipher(number_of_rounds=5)
     sat = SatXorDifferentialModel(speck, window_size_weight_pr_vars=1)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=(0,) * 32)
-    key = set_fixed_variables(component_id='key', constraint_type='equal',
-                              bit_positions=range(64), bit_values=(0,) * 64)
 
     assert int(sat.find_all_xor_differential_trails_with_fixed_weight(
-        9, fixed_values=[plaintext, key])[0]['total_weight']) == int(9.0)
+        9)[0]['total_weight']) == int(9.0)
 
 
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=integer_to_bit_list(0, 32, 'big'))
-    key = set_fixed_variables(component_id='key', constraint_type='equal', bit_positions=range(64),
-                              bit_values=integer_to_bit_list(0, 64, 'big'))
-    trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10, fixed_values=[plaintext, key])
+    trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10)
 
     assert len(trails) == 28
 
@@ -32,11 +24,7 @@ def test_find_all_xor_differential_trails_with_weight_at_most():
 def test_find_lowest_weight_xor_differential_trail():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=(0,) * 32)
-    key = set_fixed_variables(component_id='key', constraint_type='equal',
-                              bit_positions=range(64), bit_values=(0,) * 64)
-    trail = sat.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext, key])
+    trail = sat.find_lowest_weight_xor_differential_trail()
 
     assert int(trail['total_weight']) == int(9.0)
 
@@ -61,11 +49,7 @@ def test_find_one_xor_differential_trail():
 def test_find_one_xor_differential_trail_with_fixed_weight():
     speck = SpeckBlockCipher(number_of_rounds=3)
     sat = SatXorDifferentialModel(speck, window_size_by_round=[0, 0, 0])
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=(0,) * 32)
-    key = set_fixed_variables(component_id='key', constraint_type='equal',
-                              bit_positions=range(64), bit_values=(0,) * 64)
-    result = sat.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[plaintext, key])
+    result = sat.find_one_xor_differential_trail_with_fixed_weight(3)
 
     assert int(result['total_weight']) == int(3.0)
 
@@ -77,11 +61,7 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_window_heuristic_
     for component_id in filtered_objects:
         dict_of_window_heuristic_per_component[component_id] = 0
     sat = SatXorDifferentialModel(speck, window_size_by_component_id=dict_of_window_heuristic_per_component)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=(0,) * 32)
-    key = set_fixed_variables(component_id='key', constraint_type='equal',
-                              bit_positions=range(64), bit_values=(0,) * 64)
-    result = sat.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[plaintext, key])
+    result = sat.find_one_xor_differential_trail_with_fixed_weight(3)
     assert int(result['total_weight']) == int(3.0)
 
 
@@ -89,17 +69,7 @@ def test_build_xor_differential_trail_model_fixed_weight_and_parkissat():
     number_of_cores = 2
     speck = SpeckBlockCipher(number_of_rounds=3)
     sat = SatXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='not_equal',
-        bit_positions=range(32),
-        bit_values=integer_to_bit_list(0, 32, 'big'))
-    key = set_fixed_variables(
-        component_id='key',
-        constraint_type='equal',
-        bit_positions=range(64),
-        bit_values=(0,) * 64)
-    sat.build_xor_differential_trail_model(3, fixed_variables=[plaintext, key])
+    sat.build_xor_differential_trail_model(3)
     result = sat._solve_with_external_sat_solver("xor_differential", "parkissat", [f'-c={number_of_cores}'])
 
     assert int(result['total_weight']) == int(3.0)

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
@@ -18,30 +18,24 @@ def test_branch_xor_linear_constraints():
 
 def test_find_all_xor_linear_trails_with_weight_at_most():
     speck = SpeckBlockCipher(number_of_rounds=3)
-    sat = SatXorLinearModel(speck.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=integer_to_bit_list(0, 32, 'big'))
-    trails = sat.find_all_xor_linear_trails_with_weight_at_most(0, 2, fixed_values=[plaintext])
+    sat = SatXorLinearModel(speck)
+    trails = sat.find_all_xor_linear_trails_with_weight_at_most(0, 2)
 
     assert len(trails) == 187
 
 
 def test_find_lowest_weight_xor_linear_trail():
-    speck = SpeckBlockCipher(number_of_rounds=3)
+    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
     sat = SatXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=integer_to_bit_list(0, 32, 'big'))
-    trail = sat.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+    trail = sat.find_lowest_weight_xor_linear_trail()
 
-    assert trail['total_weight'] == 2.0
+    assert trail['total_weight'] == 3.0
 
 
 def test_find_one_xor_linear_trail():
     speck = SpeckBlockCipher(number_of_rounds=4)
     sat = SatXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=integer_to_bit_list(0, 32, 'big'))
-    trail = sat.find_one_xor_linear_trail(fixed_values=[plaintext])
+    trail = sat.find_one_xor_linear_trail()
 
     assert trail['cipher_id'] == 'speck_p32_k64_o32_r4'
     assert trail['model_type'] == 'xor_linear'
@@ -52,9 +46,7 @@ def test_find_one_xor_linear_trail():
 def test_find_one_xor_linear_trail_with_fixed_weight():
     speck = SpeckBlockCipher(number_of_rounds=3)
     sat = SatXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=(0,) * 32)
-    result = sat.find_one_xor_linear_trail_with_fixed_weight(7, fixed_values=[plaintext])
+    result = sat.find_one_xor_linear_trail_with_fixed_weight(7)
 
     assert result['total_weight'] == 7.0
 

--- a/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_differential_model_test.py
@@ -1,46 +1,25 @@
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 from claasp.cipher_modules.models.smt.smt_models.smt_xor_differential_model import SmtXorDifferentialModel
 
 
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(number_of_rounds=5)
     smt = SmtXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    key = set_fixed_variables(component_id='key',
-                              constraint_type='equal',
-                              bit_positions=range(64),
-                              bit_values=integer_to_bit_list(0, 64, 'big'))
-    trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10, fixed_values=[plaintext, key])
+    trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10)
     assert len(trails) == 28
 
 
 def test_find_lowest_weight_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=5)
     smt = SmtXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    key = set_fixed_variables(component_id='key',
-                              constraint_type='equal',
-                              bit_positions=range(64),
-                              bit_values=integer_to_bit_list(0, 64, 'big'))
-    trail = smt.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext, key])
+    trail = smt.find_lowest_weight_xor_differential_trail()
     assert trail['total_weight'] == 9.0
 
 
 def test_find_one_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=5)
     smt = SmtXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    solution = smt.find_one_xor_differential_trail(fixed_values=[plaintext])
+    solution = smt.find_one_xor_differential_trail()
     assert solution['cipher_id'] == 'speck_p32_k64_o32_r5'
     assert solution['solver_name'] == 'z3'
     assert eval('0x' + solution['components_values']['intermediate_output_0_6']['value']) >= 0
@@ -52,13 +31,5 @@ def test_find_one_xor_differential_trail():
 def test_find_one_xor_differential_trail_with_fixed_weight():
     speck = SpeckBlockCipher(number_of_rounds=3)
     smt = SmtXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=(0,) * 32)
-    key = set_fixed_variables(component_id='key',
-                              constraint_type='equal',
-                              bit_positions=range(64),
-                              bit_values=(0,) * 64)
-    result = smt.find_one_xor_differential_trail_with_fixed_weight(3, fixed_values=[plaintext, key])
+    result = smt.find_one_xor_differential_trail_with_fixed_weight(3)
     assert result['total_weight'] == 3.0

--- a/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_linear_model_test.py
@@ -5,34 +5,22 @@ from claasp.cipher_modules.models.smt.smt_models.smt_xor_linear_model import Smt
 
 def test_find_all_xor_linear_trails_with_weight_at_most():
     speck = SpeckBlockCipher(number_of_rounds=3)
-    smt = SmtXorLinearModel(speck.remove_key_schedule())
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    trails = smt.find_all_xor_linear_trails_with_weight_at_most(0, 2, fixed_values=[plaintext])
+    smt = SmtXorLinearModel(speck)
+    trails = smt.find_all_xor_linear_trails_with_weight_at_most(0, 2)
     assert len(trails) == 187
 
 
 def test_find_lowest_weight_xor_linear_trail():
     speck = SpeckBlockCipher(number_of_rounds=3)
     smt = SmtXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    trail = smt.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
-    assert trail['total_weight'] == 2.0
+    trail = smt.find_lowest_weight_xor_linear_trail()
+    assert trail['total_weight'] == 1.0
 
 
 def test_find_one_xor_linear_trail():
     speck = SpeckBlockCipher(number_of_rounds=4)
     smt = SmtXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=integer_to_bit_list(0, 32, 'big'))
-    solution = smt.find_one_xor_linear_trail(fixed_values=[plaintext])
+    solution = smt.find_one_xor_linear_trail()
     assert solution['cipher_id'] == 'speck_p32_k64_o32_r4'
     assert solution['solver_name'] == 'z3'
     assert eval('0x' + solution['components_values']['modadd_0_1_i']['value']) >= 0
@@ -46,11 +34,7 @@ def test_find_one_xor_linear_trail():
 def test_find_one_xor_linear_trail_with_fixed_weight():
     speck = SpeckBlockCipher(number_of_rounds=3)
     smt = SmtXorLinearModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext',
-                                    constraint_type='not_equal',
-                                    bit_positions=range(32),
-                                    bit_values=(0,) * 32)
-    result = smt.find_one_xor_linear_trail_with_fixed_weight(7, fixed_values=[plaintext])
+    result = smt.find_one_xor_linear_trail_with_fixed_weight(7)
     assert result['total_weight'] == 7.0
 
 


### PR DESCRIPTION
All XOR Linear and XOR Differential trail search is now performed in the single key setting by default for SAT, SMT, CP and MILP