### PR TITLE
FIX/Fix: 'plaintext' key error when using vectorized evaluation on a …

### DIFF
--- a/claasp/cipher_modules/code_generator.py
+++ b/claasp/cipher_modules/code_generator.py
@@ -393,7 +393,7 @@ def generate_byte_based_vectorized_python_code_string(cipher, store_intermediate
     if store_intermediate_outputs:
         code.append('  return intermediateOutputs')
     elif CIPHER_INVERSE_SUFFIX in cipher.id:
-        code.append('  return intermediateOutputs["plaintext"]')
+        code.append('  return intermediateOutputs[list(intermediateOutputs.keys())[-1]]')
     else:
         code.append('  return intermediateOutputs["cipher_output"]')
    # print('\n'.join(code))

--- a/claasp/cipher_modules/code_generator.py
+++ b/claasp/cipher_modules/code_generator.py
@@ -393,7 +393,13 @@ def generate_byte_based_vectorized_python_code_string(cipher, store_intermediate
     if store_intermediate_outputs:
         code.append('  return intermediateOutputs')
     elif CIPHER_INVERSE_SUFFIX in cipher.id:
-        code.append('  return intermediateOutputs[list(intermediateOutputs.keys())[-1]]')
+        # full inversion
+        if 'plaintext' in cipher.get_all_components_ids():
+            code.append('  return intermediateOutputs["plaintext"]')
+        # in partial inversion
+        else:
+            code.append('  last_inter_output = [output for output in list(intermediateOutputs.keys()) if \'intermediate_output\' in output][0]')
+            code.append('  return intermediateOutputs[last_inter_output]')
     else:
         code.append('  return intermediateOutputs["cipher_output"]')
    # print('\n'.join(code))


### PR DESCRIPTION
This PR fixes an issue encountered when calling the evaluate_vectorized method on a partially inverted cipher (i.e. a cipher object that does not necessarily contain a 'cipher_output' or a 'plaintext' component)