### PR TITLE
FIX/Refactor: Remove window_size_weight_pr_vars

### DIFF
--- a/claasp/cipher_modules/models/sat/cms_models/cms_bitwise_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/cms_models/cms_bitwise_deterministic_truncated_xor_differential_model.py
@@ -51,9 +51,8 @@ from claasp.cipher_modules.models.sat.sat_models.sat_bitwise_deterministic_trunc
 
 class CmsSatDeterministicTruncatedXorDifferentialModel(SatBitwiseDeterministicTruncatedXorDifferentialModel):
 
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
 
         print("\n*** WARNING ***\n"
               "At the best of the authors knowldege, deterministic truncated XOR differential model "

--- a/claasp/cipher_modules/models/sat/cms_models/cms_cipher_model.py
+++ b/claasp/cipher_modules/models/sat/cms_models/cms_cipher_model.py
@@ -50,9 +50,8 @@ from claasp.name_mappings import (CONSTANT, SBOX, INTERMEDIATE_OUTPUT, CIPHER_OU
 
 class CmsSatCipherModel(SatCipherModel):
 
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
 
     def _add_clauses_to_solver(self, numerical_cnf, solver):
         """

--- a/claasp/cipher_modules/models/sat/cms_models/cms_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/cms_models/cms_xor_differential_model.py
@@ -50,9 +50,8 @@ from claasp.name_mappings import WORD_OPERATION, CONSTANT, INTERMEDIATE_OUTPUT, 
 
 class CmsSatXorDifferentialModel(SatXorDifferentialModel):
 
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
 
     def _add_clauses_to_solver(self, numerical_cnf, solver):
         """

--- a/claasp/cipher_modules/models/sat/cms_models/cms_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/cms_models/cms_xor_linear_model.py
@@ -50,9 +50,8 @@ from claasp.name_mappings import CONSTANT, LINEAR_LAYER, SBOX, MIX_COLUMN, WORD_
 
 class CmsSatXorLinearModel(SatXorLinearModel):
 
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
         self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(cipher, '_'.join)
 
     def _add_clauses_to_solver(self, numerical_cnf, solver):

--- a/claasp/cipher_modules/models/sat/sat_model.py
+++ b/claasp/cipher_modules/models/sat/sat_model.py
@@ -69,16 +69,13 @@ from claasp.name_mappings import SBOX
 
 
 class SatModel:
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential',
-                 compact=False):
+    def __init__(self, cipher, counter='sequential', compact=False):
         """
         Initialise the sat model.
 
         INPUT:
 
         - ``cipher`` -- **Cipher object**; an instance of the cipher.
-        - ``window_size_weight_pr_vars`` -- **integer** (default: `-1`)
         - ``counter`` -- **string** (default: `sequential`)
         - ``compact`` -- **boolean** (default: False); set to True for using a simplified cipher (it will remove
           rotations and permutations)
@@ -100,7 +97,6 @@ class SatModel:
         self._model_constraints = []
         self._sboxes_ddt_templates = {}
         self._sboxes_lat_templates = {}
-        self.window_size_weight_pr_vars = window_size_weight_pr_vars
 
     def _add_clauses_to_solver(self, numerical_cnf, solver):
         """

--- a/claasp/cipher_modules/models/sat/sat_models/sat_bitwise_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_bitwise_deterministic_truncated_xor_differential_model.py
@@ -27,8 +27,8 @@ from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, DETERMINISTIC_TRUNCAT
 
 
 class SatBitwiseDeterministicTruncatedXorDifferentialModel(SatModel):
-    def __init__(self, cipher, window_size_weight_pr_vars=-1, counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
 
     def build_bitwise_deterministic_truncated_xor_differential_trail_model(self, number_of_unknown_variables=None,
                                                                            fixed_variables=[]):

--- a/claasp/cipher_modules/models/sat/sat_models/sat_cipher_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_cipher_model.py
@@ -27,9 +27,8 @@ from claasp.name_mappings import (CIPHER, WORD_OPERATION, CIPHER_OUTPUT, CONSTAN
 
 
 class SatCipherModel(SatModel):
-    def __init__(self, cipher,  window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
 
     def build_cipher_model(self, fixed_variables=[]):
         """

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
@@ -28,13 +28,14 @@ from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, 
 
 
 class SatXorDifferentialModel(SatModel):
-    def __init__(self, cipher, window_size_weight_pr_vars=-1, counter='sequential', compact=False):
+    def __init__(self, cipher, counter='sequential', compact=False):
         self._window_size_by_component_id_values = None
         self._window_size_by_round_values = None
         self._window_size_full_window_vars = None
         self._window_size_number_of_full_window = None
         self._window_size_full_window_operator = None
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+        self._window_size_weight_pr_vars = -1
+        super().__init__(cipher, counter, compact)
 
     def build_xor_differential_trail_model(self, weight=-1, fixed_variables=[]):
         """
@@ -60,7 +61,7 @@ class SatXorDifferentialModel(SatModel):
         """
         variables = []
         self._variables_list = []
-        if fixed_variables == []:
+        if not fixed_variables:
             fixed_variables = get_single_key_scenario_format_for_fixed_values(self._cipher)
         constraints = self.fix_variables_value_constraints(fixed_variables)
         self._model_constraints = constraints
@@ -90,7 +91,6 @@ class SatXorDifferentialModel(SatModel):
                 self._variables_list.extend([])
                 self._model_constraints.extend([f'-{variable}' for variable in self._window_size_full_window_vars])
                 return
-
 
             if self._window_size_full_window_operator == 'at_least':
                 all_ones_dummy_variables, all_ones_constraints = self._sequential_counter_algorithm(
@@ -123,7 +123,6 @@ class SatXorDifferentialModel(SatModel):
                 all_ones_constraints = all_ones_constraints1 + all_ones_constraints2
             else:
                 raise ValueError(f'Unknown operator {self._window_size_full_window_operator}')
-
 
             self._variables_list.extend(all_ones_dummy_variables)
             self._model_constraints.extend(all_ones_constraints)
@@ -495,6 +494,13 @@ class SatXorDifferentialModel(SatModel):
             self._window_size_full_window_vars = []
             self._window_size_number_of_full_window = number_of_full_windows
             self._window_size_full_window_operator = full_window_operator
+
+    def set_window_size_weight_pr_vars(self, window_size_weight_pr_vars):
+        self._window_size_weight_pr_vars = window_size_weight_pr_vars
+
+    @property
+    def window_size_weight_pr_vars(self):
+        return self._window_size_weight_pr_vars
 
     @property
     def window_size_number_of_full_window(self):

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
@@ -30,9 +30,8 @@ from claasp.name_mappings import (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, 
 
 
 class SatXorLinearModel(SatModel):
-    def __init__(self, cipher, window_size_weight_pr_vars=-1,
-                 counter='sequential', compact=False):
-        super().__init__(cipher, window_size_weight_pr_vars, counter, compact)
+    def __init__(self, cipher, counter='sequential', compact=False):
+        super().__init__(cipher, counter, compact)
         self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(cipher, '_'.join)
 
     def branch_xor_linear_constraints(self):

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -914,13 +914,15 @@ class Modular(Component):
         constraints.extend(sat_utils.cnf_xor(output_bit_ids[output_bit_len - 1],
                                              [input_bit_ids[output_bit_len - 1],
                                               input_bit_ids[2 * output_bit_len - 1]]))
-        if model.window_size_weight_pr_vars != -1:
-            for i in range(output_bit_len - model.window_size_weight_pr_vars):
-                constraints.extend(sat_utils.cnf_n_window_heuristic_on_w_vars(
-                    hw_bit_ids[i: i + (model.window_size_weight_pr_vars + 1)]))
-        component_round_number = model._cipher.get_round_from_component_id(self.id)
 
         from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model import SatXorDifferentialModel
+        if type(model) is SatXorDifferentialModel and model.window_size_by_round_values is not None:
+            if model.window_size_weight_pr_vars != -1:
+                for i in range(output_bit_len - model.window_size_weight_pr_vars):
+                    constraints.extend(sat_utils.cnf_n_window_heuristic_on_w_vars(
+                        hw_bit_ids[i: i + (model.window_size_weight_pr_vars + 1)]))
+        component_round_number = model._cipher.get_round_from_component_id(self.id)
+
         if type(model) is SatXorDifferentialModel and model.window_size_by_round_values is not None:
             window_size = model.window_size_by_round_values[component_round_number]
             if window_size != -1:

--- a/tests/benchmark/sat_xor_differential_model_test.py
+++ b/tests/benchmark/sat_xor_differential_model_test.py
@@ -38,7 +38,8 @@ def test_build_xor_differential_trail_model_with_aes_cipher(benchmark):
 
 
 def test_find_all_xor_differential_trails_with_fixed_weight_with_speck_cipher(benchmark):
-    sat = SatXorDifferentialModel(speck, window_size_weight_pr_vars=1)
+    sat = SatXorDifferentialModel(speck)
+    sat.set_window_size_weight_pr_vars(1)
     plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
                                     bit_positions=range(32), bit_values=(0,) * 32)
     key = set_fixed_variables(component_id='key', constraint_type='equal',
@@ -47,7 +48,8 @@ def test_find_all_xor_differential_trails_with_fixed_weight_with_speck_cipher(be
 
 
 def test_find_all_xor_differential_trails_with_fixed_weight_with_aes_cipher(benchmark):
-    sat = SatXorDifferentialModel(aes, window_size_weight_pr_vars=1)
+    sat = SatXorDifferentialModel(aes)
+    sat.set_window_size_weight_pr_vars(1)
     plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
                                     bit_positions=range(32), bit_values=(0,) * 32)
     key = set_fixed_variables(component_id='key', constraint_type='equal',

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from claasp.utils.utils import get_k_th_bit
 from claasp.components.modadd_component import MODADD
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
@@ -62,9 +61,13 @@ def compute_modadd_xor(modadd_objects, component_values):
         result.append({f"{modadd_id}": bin(xor_result)})
     return result
 
+
 speck_5rounds = SpeckBlockCipher(number_of_rounds=5)
+
+
 def test_find_all_xor_differential_trails_with_fixed_weight():
-    sat = SatXorDifferentialModel(speck_5rounds, window_size_weight_pr_vars=1)
+    sat = SatXorDifferentialModel(speck_5rounds)
+    sat.set_window_size_weight_pr_vars(1)
 
     assert int(sat.find_all_xor_differential_trails_with_fixed_weight(
         9)[0]['total_weight']) == int(9.0)
@@ -116,10 +119,11 @@ def test_find_one_xor_differential_trail_with_fixed_weight_with_at_least_one_ful
     speck = SpeckBlockCipher(number_of_rounds=9)
     sat = SatXorDifferentialModel(speck)
     sat.set_window_size_heuristic_by_round(
-        [2 for i in range(9)], number_of_full_windows=1
+        [2 for _ in range(9)], number_of_full_windows=1
     )
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name="CADICAL_EXT")
     assert int(result['total_weight']) == int(30.0)
+
 
 def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_three_full_2_window():
     speck = SpeckBlockCipher(number_of_rounds=9)
@@ -127,7 +131,7 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_thre
     number_of_full_windows = 3
     window_size = 2
     sat.set_window_size_heuristic_by_round(
-        [window_size for i in range(9)], number_of_full_windows=number_of_full_windows
+        [window_size for _ in range(9)], number_of_full_windows=number_of_full_windows
     )
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name="CADICAL_EXT")
     speck_components = speck.get_all_components()
@@ -171,21 +175,23 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_one_
     assert int(result['total_weight']) == int(probability_weight)
     assert computed_number_of_full_windows == number_of_full_windows
 
+
 def test_find_one_xor_differential_trail_with_fixed_weight_9_rounds():
     speck = SpeckBlockCipher(number_of_rounds=9)
     sat = SatXorDifferentialModel(speck)
 
     sat.set_window_size_heuristic_by_round(
-        [2 for i in range(9)]
+        [2 for _ in range(9)]
     )
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name="CADICAL_EXT")
     assert int(result['total_weight']) == int(30.0)
+
 
 def test_find_one_xor_differential_trail_with_fixed_weight_with_at_least_one_full_window_parallel():
     speck = SpeckBlockCipher(number_of_rounds=10)
     sat = SatXorDifferentialModel(speck)
     sat.set_window_size_heuristic_by_round(
-        [3 for i in range(10)], number_of_full_windows=1
+        [3 for _ in range(10)], number_of_full_windows=1
     )
     plaintext = set_fixed_variables(
         component_id='plaintext',
@@ -225,11 +231,13 @@ def test_build_xor_differential_trail_model_fixed_weight_and_parkissat():
 
     assert int(result['total_weight']) == int(3.0)
 
+
 def repeat_input_difference(input_difference_, number_of_samples_, number_of_bytes_):
     bytes_array = input_difference_.to_bytes(number_of_bytes_, 'big')
     np_array = np.array(list(bytes_array), dtype=np.uint8)
     column_array = np_array.reshape(-1, 1)
     return np.tile(column_array, (1, number_of_samples_))
+
 
 def test_differential_in_related_key_scenario_speck3264():
     rng = np.random.default_rng(seed=42)
@@ -250,6 +258,7 @@ def test_differential_in_related_key_scenario_speck3264():
     import math
     total_prob_weight = math.log(total/number_of_samples, 2)
     assert 21 > abs(total_prob_weight) > 12
+
 
 def test_differential_in_single_key_scenario_speck3264():
     rng = np.random.default_rng(seed=42)


### PR DESCRIPTION
The `window_size_weight_pr_vars` parameter, previously used in multiple SAT models, has been left only in the `sat_xor_differential_model`, where it is more applicable and beneficial. This change improves the modularity and clarity of SAT models.