### PR TITLE
FEATURE: run Docker image without pre-building

### DIFF
--- a/.github/workflows/build-claasp-base-image.yaml
+++ b/.github/workflows/build-claasp-base-image.yaml
@@ -1,4 +1,4 @@
-name: Build and push image for testing
+name: Build and push Intel and M1 images for testing
 on:
   push:
     branches:
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -25,11 +28,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
-    - name: Login dockerhub
+    - name: Login Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_REGISTRY_USER }}
-        password: ${{  secrets.DOCKER_REGISTRY_PASSWORD }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
 
     - name: Build & Push
       uses: docker/build-push-action@v4
@@ -38,7 +41,7 @@ jobs:
         context: .
         file: ./docker/Dockerfile
         push: true
-        tags: tiicrc/claasp-base:latest
+        tags: ${{ matrix.os == 'ubuntu-latest' && 'tiicrc/claasp-base:latest' || 'tiicrc/claasp-m1-base:latest' }}
         target: claasp-base
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ rundocker: builddocker
 	docker run -i -p 8887:8887 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 
+rundockerhub:
+	docker pull tiicrc/claasp-base \
+	docker run -i -p 8887:8887 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
+	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
+
 builddocker-m1:
 	docker build -f docker/Dockerfile --platform linux/x86_64 --target claasp-base -t $(DOCKER_IMG_NAME) .
 
@@ -32,13 +37,8 @@ rundocker-m1: builddocker-m1
 	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 
-rundockerhub:
-	docker pull tiicrc/claasp-base \
-	docker run -i -p 8887:8887 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
-	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
-
 rundockerhub-m1:
-	docker pull tiicrc/claasp-base \
+	docker pull tiicrc/claasp-m1-base \
 	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@
 # Package folder
 PACKAGE=claasp
 
-# change to your sage command if needed
+# Change to your sage command if needed
 SAGE_BIN=`if [ -s SAGE_BIN_PATH ]; then cat SAGE_BIN_PATH; else echo sage; fi`
 MODULE?=$(PACKAGE)
 
 DOCKER_IMG_NAME=claasp
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
 
 all: install
 	if [ $(CURRENT_BRANCH) == "main" ]; then\
@@ -28,6 +29,16 @@ builddocker-m1:
 	docker build -f docker/Dockerfile --platform linux/x86_64 --target claasp-base -t $(DOCKER_IMG_NAME) .
 
 rundocker-m1: builddocker-m1
+	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
+	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
+
+rundockerhub:
+	docker pull tiicrc/claasp-base \
+	docker run -i -p 8887:8887 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
+	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
+
+rundockerhub-m1:
+	docker pull tiicrc/claasp-base \
 	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 


### PR DESCRIPTION
I've changed the Github workflow `build-claasp-base-image.yaml`:
- now the workflow push ***two*** images in the Docker Hub, one for Intel architecture and one for M1 architecture;
- the first image is `claasp-base`, the second image is `claasp-m1-base`.

I've also changed the `Makefile`: now you can run `CLAASP` without building the Docker image locally because you will download the last Docker image from the Docker Hub. I've added two commands:
- `rundockerhub` for `claasp-base` image;
- `rundockerhub-m1` for `claasp-m1-base` image.