### PR TITLE
Feature/differential-linear sat model

### DIFF
--- a/claasp/cipher_modules/models/sat/sat_models/sat_differential_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_differential_linear_model.py
@@ -214,11 +214,11 @@ class SatDifferentialLinearModel(SatModel):
             self._variables_list.extend(variables)
             self._model_constraints.extend(constraints)
 
-        #ciphertext_output_vars = [f'cipher_output_7_25_{i}_o' for i in range(512)]
+        ciphertext_output_vars = [f'cipher_output_7_24_{i}_o' for i in range(512)]
 #
-        #variables, constraints = self._sequential_counter_algorithm(ciphertext_output_vars, 9, 'dummy_hw_ac')
-        #self._variables_list.extend(variables)
-        #self._model_constraints.extend(constraints)
+        variables, constraints = self._sequential_counter_algorithm(ciphertext_output_vars, 5, 'dummy_hw_ac')
+        self._variables_list.extend(variables)
+        self._model_constraints.extend(constraints)
 
 
 

--- a/claasp/cipher_modules/models/sat/sat_models/sat_differential_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_differential_linear_model.py
@@ -1,0 +1,388 @@
+import time
+from claasp.cipher_modules.models.sat import solvers
+from claasp.cipher_modules.models.sat.sat_model import SatModel
+from claasp.cipher_modules.models.sat.sat_models.sat_bitwise_deterministic_truncated_xor_differential_model import (
+    SatBitwiseDeterministicTruncatedXorDifferentialModel
+)
+from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
+from claasp.cipher_modules.models.utils import set_component_solution, get_bit_bindings
+from claasp.cipher_modules.models.sat.utils import utils as sat_utils, constants
+
+
+class SatDifferentialLinearModel(SatModel):
+    """
+    Model that combines regular XOR differential constraints with bitwise deterministic truncated XOR differential constraints.
+    """
+
+    def __init__(self, cipher, dict_of_components):
+        """
+        Initializes the model with cipher and components.
+
+        INPUT:
+        - ``cipher`` -- **object**; The cipher model used in the SAT-based differential trail search.
+        - ``dict_of_components`` -- **dict**; Dictionary mapping component IDs to their respective models and types.
+        """
+        self.dict_of_components = dict_of_components
+        self.regular_components = self._get_components_by_type('sat_xor_differential_propagation_constraints')
+        self.truncated_components = self._get_components_by_type(
+            'sat_bitwise_deterministic_truncated_xor_differential_constraints')
+        self.linear_components = self._get_components_by_type(
+            'sat_xor_linear_mask_propagation_constraints')
+        self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(cipher, '_'.join)
+        super().__init__(cipher, "sequential", False)
+
+    def _get_components_by_type(self, model_type):
+        """
+        Retrieves components based on their model type.
+
+        INPUT:
+        - ``model_type`` -- **str**; The model type to filter components.
+
+        RETURN:
+        - **list**; A list of components of the specified type.
+        """
+        return [component for component in self.dict_of_components if component['model_type'] == model_type]
+
+    def _get_regular_xor_differential_components_in_border(self):
+        """
+        Retrieves regular components that are connected to truncated components (border components).
+
+        RETURN:
+        - **list**; A list of regular components at the border.
+        """
+        regular_component_ids = {item['component_id'] for item in self.regular_components}
+        border_components = []
+
+        for truncated_component in self.truncated_components:
+            component_obj = self.cipher.get_component_from_id(truncated_component['component_id'])
+            for input_id in component_obj.input_id_links:
+                if input_id in regular_component_ids:
+                    border_components.append(input_id)
+
+        return list(set(border_components))
+
+    def _get_truncated_xor_differential_components_in_border(self):
+        """
+        Retrieves regular components that are connected to truncated components (border components).
+
+        RETURN:
+        - **list**; A list of regular components at the border.
+        """
+        truncated_component_ids = {item['component_id'] for item in self.truncated_components}
+        border_components = []
+
+        for linear_component in self.linear_components:
+            component_obj = self.cipher.get_component_from_id(linear_component['component_id'])
+            for input_id in component_obj.input_id_links:
+                if input_id in truncated_component_ids:
+                    border_components.append(input_id)
+
+        return list(set(border_components))
+
+    def _get_connecting_constraints(self):
+        """
+        Adds constraints for connecting regular and truncated components.
+        """
+        border_components = self._get_regular_xor_differential_components_in_border()
+
+        for component_id in border_components:
+            component = self.cipher.get_component_from_id(component_id)
+            for idx in range(component.output_bit_size):
+                constraints = sat_utils.get_cnf_bitwise_truncate_constraints(
+                    f'{component_id}_{idx}', f'{component_id}_{idx}_0', f'{component_id}_{idx}_1'
+                )
+                self._model_constraints.extend(constraints)
+                self._variables_list.extend([
+                    f'{component_id}_{idx}', f'{component_id}_{idx}_0', f'{component_id}_{idx}_1'
+                ])
+
+        border_components = self._get_truncated_xor_differential_components_in_border()
+
+        for component_id in border_components:
+            component = self.cipher.get_component_from_id(component_id)
+            for idx in range(component.output_bit_size):
+                print(f'{component_id}_{idx}', f'{component_id}_{idx}_0')
+                constraints = sat_utils.get_cnf_truncated_linear_constraints(
+                    f'{component_id}_{idx}', f'{component_id}_{idx}_0'
+                )
+                self._model_constraints.extend(constraints)
+                self._variables_list.extend([
+                    f'{component_id}_{idx}', f'{component_id}_{idx}_0'
+                ])
+
+
+    def _build_weight_constraints(self, weight):
+        """
+        Builds weight constraints for the model based on the specified weight.
+
+        INPUT:
+        - ``weight`` -- **int**; The weight to constrain the search. If set to 0, the hardware variables are negated.
+
+        RETURN:
+        - **tuple**; A tuple containing a list of variables and a list of constraints.
+        """
+        hw_variables = [var_id for var_id in self._variables_list if var_id.startswith('hw_')]
+
+        if weight == 0:
+            return [], [f'-{var}' for var in hw_variables]
+
+        return self._counter(hw_variables, weight)
+
+    def _build_unknown_variable_constraints(self, num_unknowns):
+        """
+        Adds constraints for limiting the number of unknown variables.
+
+        INPUT:
+        - ``num_unknowns`` -- **int**; The number of unknown variables allowed.
+
+        RETURN:
+        - **tuple**; A tuple containing a list of variables and a list of constraints.
+        """
+        border_components = self._get_truncated_xor_differential_components_in_border()
+        minimize_vars = []
+        for border_component in border_components:
+            output_id = border_component
+            minimize_vars.extend([bit_id for bit_id in self._variables_list if
+                             bit_id.startswith(output_id) and bit_id.endswith("_0")])
+        return self._sequential_counter(minimize_vars, num_unknowns, "dummy_id_unknown")
+
+    def build_xor_differential_linear_model(self, weight=-1, num_unknown_vars=None):
+        """
+        Constructs a model to search for probabilistic truncated XOR differential trails.
+        This model is a combination of the regular XOR differential model and of the bitwise truncated deterministic model.
+
+        INPUT:
+        - ``weight`` -- **integer** (default: `-1`); specifies the maximum probability weight. If set to a non-negative
+        integer, it constrains the search to trails with the fixed probability weight.
+        - ``number_of_unknown_variables`` -- **int** (default: None); specifies the upper limit on the number of unknown
+        variables allowed in the differential trail.
+        - ``fixed_variables`` -- **list** (default: `[]`); specifies a list of variables that should be fixed to specific
+        values. Each entry in the list should be a dictionary representing constraints for specific components, written
+        in the CLAASP constraining syntax.
+
+
+        .. SEEALSO::
+
+            :py:meth:`~cipher_modules.models.utils.set_fixed_variables`
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_regular_and_deterministic_xor_truncated_differential import SatRegularAndDeterministicXorTruncatedDifferential
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=4)
+            sage: component_model_types = []
+            sage: for component in speck.get_all_components():
+            ....:     component_model_type = {
+            ....:         "component_id": component.id,
+            ....:         "component_object": component,
+            ....:         "model_type": "sat_xor_differential_propagation_constraints"
+            ....:     }
+            ....:     component_model_types.append(component_model_type)
+            sage: sat = SatRegularAndDeterministicXorTruncatedDifferential(speck, component_model_types)
+            sage: sat.build_xor_regular_and_deterministic_truncated_differential_model()
+            ...
+        """
+        self.build_generic_sat_model_from_dictionary(self.dict_of_components)
+        constraints = self.branch_xor_linear_constraints()
+        self._model_constraints.extend(constraints)
+
+        if num_unknown_vars is not None:
+            variables, constraints = self._build_unknown_variable_constraints(num_unknown_vars)
+            self._variables_list.extend(variables)
+            self._model_constraints.extend(constraints)
+
+        if weight != -1:
+            variables, constraints = self._build_weight_constraints(weight)
+            self._variables_list.extend(variables)
+            self._model_constraints.extend(constraints)
+
+        self._get_connecting_constraints()
+
+    @staticmethod
+    def fix_variables_value_constraints(
+            fixed_variables, regular_components=None, truncated_components=None, linear_components=None
+    ):
+        """
+        Fixes variable value constraints for regular and truncated components.
+
+        INPUT:
+        - ``fixed_variables`` -- **list** (default: `[]`); specifies a list of variables that should be fixed to specific values. Each entry in the list should be a dictionary representing constraints for specific components, written in the CLAASP constraining syntax.
+        - ``regular_components`` -- **list** (default: None); list of regular components.
+        - ``truncated_components`` -- **list** (default: None); list of truncated components.
+
+        RETURN:
+        - **list**; A list of constraints for the model.
+        """
+        truncated_vars = []
+        regular_vars = []
+        linear_vars = []
+        for var in fixed_variables:
+            component_id = var["component_id"]
+
+            if component_id in [comp["component_id"] for comp in regular_components] and 2 in var['bit_values']:
+                raise ValueError("The fixed value in a regular XOR differential component cannot be 2")
+
+            if component_id in [comp["component_id"] for comp in truncated_components]:
+                truncated_vars.append(var)
+            elif component_id in [comp["component_id"] for comp in linear_components]:
+                linear_vars.append(var)
+            elif component_id in [comp["component_id"] for comp in regular_components]:
+                regular_vars.append(var)
+            else:
+                regular_vars.append(var)
+        #import ipdb; ipdb.set_trace()
+        regular_constraints = SatModel.fix_variables_value_constraints(regular_vars)
+        truncated_constraints = SatBitwiseDeterministicTruncatedXorDifferentialModel.fix_variables_value_constraints(
+            truncated_vars)
+        linear_constraints = SatXorLinearModel.fix_variables_value_xor_linear_constraints1(linear_vars)
+
+        return regular_constraints + truncated_constraints + linear_constraints
+    # TODO fix plaintext
+    def _parse_solver_output(self, variable2value):
+        """
+        Parses the solver's output and returns component solutions and total weight.
+
+        INPUT:
+        - ``variable2value`` -- **dict**; mapping of solver's variables to their values.
+
+        RETURN:
+        - **tuple**; a tuple containing the dictionary of component solutions and the total weight.
+        """
+        out_suffix = ''
+        components_solutions = self._get_cipher_inputs_components_solutions(out_suffix, variable2value)
+        total_weight_diff = 0
+        total_weight_lin = 0
+
+        for component in self._cipher.get_all_components():
+            if component.id in [d['component_id'] for d in self.regular_components]:
+                hex_value = self._get_component_hex_value(component, '', variable2value)
+                weight = self.calculate_component_weight(component, '', variable2value)
+                components_solutions[component.id] = set_component_solution(hex_value, weight)
+                total_weight_diff += weight
+            elif component.id in [d['component_id'] for d in self.truncated_components]:
+                value = self._get_component_value_double_ids(component, variable2value)
+                components_solutions[component.id] = set_component_solution(value)
+            if component.id in [d['component_id'] for d in self.linear_components]:
+                out_sufix = constants.OUTPUT_BIT_ID_SUFFIX
+                hex_value = self._get_component_hex_value(component, out_sufix, variable2value)
+                weight = self.calculate_component_weight(component, out_sufix, variable2value)
+                total_weight_lin += weight
+                components_solutions[component.id] = set_component_solution(hex_value, weight)
+
+        return components_solutions, total_weight_diff + 2*total_weight_lin
+
+    def find_one_differential_linear_trail_with_fixed_weight(
+            self, weight, num_unknown_vars=None, fixed_values=[], solver_name=solvers.SOLVER_DEFAULT):
+        """
+        Finds one XOR regular truncated differential trail with a fixed weight.
+
+        INPUT:
+        - ``weight`` -- **int**; Maximum probability weight for the regular xor differential part.
+        - ``num_unknown_vars`` -- **int** (default: None); Upper limit on the number of unknown variables allowed.
+        - ``fixed_values`` -- **list** (default: `[]`); specifies a list of variables that should be fixed to specific values. Each entry in the list should be a dictionary representing constraints for specific components, written in the CLAASP constraining syntax.
+        - ``solver_name`` -- **str** (default: ``solvers.SOLVER_DEFAULT``); The name of the SAT solver to use.
+
+        RETURN:
+        - **dict**; Solution returned by the solver, including the trail and additional metadata.
+        """
+        start_time = time.time()
+
+        self.build_xor_differential_linear_model(weight, num_unknown_vars)
+        constraints = self.fix_variables_value_constraints(
+            fixed_values,
+            self.regular_components,
+            self.truncated_components,
+            self.linear_components
+        )
+        self.model_constraints.extend(constraints)
+
+        solution = self.solve("XOR_REGULAR_DETERMINISTIC_DIFFERENTIAL", solver_name=solver_name)
+        solution['building_time_seconds'] = time.time() - start_time
+        solution['test_name'] = "find_one_regular_truncated_xor_differential_trail"
+
+        return solution
+
+    def find_lowest_weight_xor_regular_truncated_differential_trail(self, fixed_values=[],
+                                                                    solver_name=solvers.SOLVER_DEFAULT):
+        """
+        Finds the XOR regular truncated differential trail with the lowest weight.
+
+        INPUT:
+        - ``fixed_values`` -- **list** (default: `[]`); specifies a list of variables that should be fixed to specific values. Each entry in the list should be a dictionary representing constraints for specific components, written in the CLAASP constraining syntax.
+        - ``solver_name`` -- **str** (default: ``solvers.SOLVER_DEFAULT``); The SAT solver to use.
+
+        RETURN:
+        - **dict**; Solution with the trail and metadata (weight, time, memory usage).
+        """
+        current_weight = 0
+        start_time = time.time()
+
+        self.build_xor_regular_and_deterministic_truncated_differential_model(current_weight)
+        constraints = self.fix_variables_value_constraints(fixed_values, self.regular_components,
+                                                           self.truncated_components)
+        self.model_constraints.extend(constraints)
+
+        solution = self.solve("XOR_REGULAR_DETERMINISTIC_DIFFERENTIAL", solver_name=solver_name)
+        total_time = solution['solving_time_seconds']
+        max_memory = solution['memory_megabytes']
+
+        while solution['total_weight'] is None:
+            current_weight += 1
+            start_building_time = time.time()
+            self.build_xor_regular_and_deterministic_truncated_differential_model(current_weight)
+            self.model_constraints.extend(constraints)  # Reapply constraints for each iteration
+            solution = self.solve("XOR_REGULAR_DETERMINISTIC_DIFFERENTIAL", solver_name=solver_name)
+            end_building_time = time.time()
+
+            solution['building_time_seconds'] = end_building_time - start_building_time
+            total_time += solution['solving_time_seconds']
+            max_memory = max(max_memory, solution['memory_megabytes'])
+
+        solution['solving_time_seconds'] = total_time
+        solution['memory_megabytes'] = max_memory
+        solution['test_name'] = "find_lowest_weight_xor_regular_truncated_differential_trail"
+
+        return solution
+
+    @property
+    def cipher(self):
+        """
+        Returns the cipher instance associated with the model.
+
+        RETURN:
+        - **object**; The cipher object being used in this model.
+        """
+        return self._cipher
+
+    def branch_xor_linear_constraints(self):
+        """
+        Return lists of variables and clauses for branch in XOR LINEAR model.
+
+        .. SEEALSO::
+
+            :ref:`sat-standard` for the format
+
+        INPUT:
+
+        - None
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: sat = SatXorLinearModel(speck)
+            sage: sat.branch_xor_linear_constraints()
+            ['-plaintext_0_o rot_0_0_0_i',
+             'plaintext_0_o -rot_0_0_0_i',
+             '-plaintext_1_o rot_0_0_1_i',
+             ...
+             'xor_2_10_14_o -cipher_output_2_12_30_i',
+             '-xor_2_10_15_o cipher_output_2_12_31_i',
+             'xor_2_10_15_o -cipher_output_2_12_31_i']
+        """
+        constraints = []
+        for output_bit, input_bits in self.bit_bindings.items():
+            constraints.extend(sat_utils.cnf_xor(output_bit, input_bits))
+
+        return constraints

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
@@ -453,6 +453,61 @@ class SatXorLinearModel(SatModel):
 
         return constraints
 
+    @staticmethod
+    def fix_variables_value_xor_linear_constraints1(fixed_variables=[]):
+        """
+        Return lists variables and clauses for fixing variables in XOR LINEAR model.
+
+        .. SEEALSO::
+
+            :ref:`sat-standard` for the format
+
+        INPUT:
+
+        - ``fixed_variables`` -- **list** (default: `[]`); variables in default format
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher(number_of_rounds=3)
+            sage: sat = SatXorLinearModel(speck)
+            sage: fixed_variables = [{
+            ....:    'component_id': 'plaintext',
+            ....:    'constraint_type': 'equal',
+            ....:    'bit_positions': [0, 1, 2, 3],
+            ....:    'bit_values': [1, 0, 1, 1]
+            ....: }, {
+            ....:    'component_id': 'ciphertext',
+            ....:    'constraint_type': 'not_equal',
+            ....:    'bit_positions': [0, 1, 2, 3],
+            ....:    'bit_values': [1, 1, 1, 0]
+            ....: }]
+            sage: sat.fix_variables_value_xor_linear_constraints(fixed_variables)
+            ['plaintext_0_o',
+             '-plaintext_1_o',
+             'plaintext_2_o',
+             'plaintext_3_o',
+             '-ciphertext_0_o -ciphertext_1_o -ciphertext_2_o ciphertext_3_o']
+        """
+        constraints = []
+        out_suffix = constants.OUTPUT_BIT_ID_SUFFIX
+        for variable in fixed_variables:
+            component_id = variable['component_id']
+            is_equal = (variable['constraint_type'] == 'equal')
+            bit_positions = variable['bit_positions']
+            bit_values = variable['bit_values']
+            variables_ids = []
+            for position, value in zip(bit_positions, bit_values):
+                is_negative = '-' * (value ^ is_equal)
+                variables_ids.append(f'{is_negative}{component_id}_{position}{out_suffix}')
+            if is_equal:
+                constraints.extend(variables_ids)
+            else:
+                constraints.append(' '.join(variables_ids))
+
+        return constraints
+
     def weight_xor_linear_constraints(self, weight):
         return self.weight_constraints(weight)
 

--- a/claasp/cipher_modules/models/sat/utils/utils.py
+++ b/claasp/cipher_modules/models/sat/utils/utils.py
@@ -825,3 +825,29 @@ def run_yices(solver_specs, options, dimacs_input, input_file_name):
     os.remove(input_file_name)
 
     return status, time, memory, values
+
+
+def _generate_component_model_types(speck_cipher):
+    """Generates the component model types for a given Speck cipher."""
+    component_model_types = []
+    for component in speck_cipher.get_all_components():
+        component_model_types.append({
+            "component_id": component.id,
+            "component_object": component,
+            "model_type": "sat_xor_differential_propagation_constraints"
+        })
+    return component_model_types
+
+
+def _update_component_model_types_for_truncated_components(component_model_types, truncated_components):
+    """Updates the component model types for truncated components."""
+    for component_model_type in component_model_types:
+        if component_model_type["component_id"] in truncated_components:
+            component_model_type["model_type"] = "sat_bitwise_deterministic_truncated_xor_differential_constraints"
+
+
+def _update_component_model_types_for_linear_components(component_model_types, linear_components):
+    """Updates the component model types for linear components."""
+    for component_model_type in component_model_types:
+        if component_model_type["component_id"] in linear_components:
+            component_model_type["model_type"] = "sat_xor_linear_mask_propagation_constraints"

--- a/claasp/cipher_modules/models/sat/utils/utils.py
+++ b/claasp/cipher_modules/models/sat/utils/utils.py
@@ -659,6 +659,12 @@ def get_cnf_bitwise_truncate_constraints(a, a_0, a_1):
     ]
 
 
+def get_cnf_truncated_linear_constraints(a, a_0):
+    return [
+        f'-{a}   -{a_0}'
+    ]
+
+
 def modadd_truncated_lsb(result, variable_0, variable_1, next_carry):
     return [f'{next_carry[0]} -{next_carry[1]}',
             f'{next_carry[0]} -{variable_1[1]}',

--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -832,7 +832,7 @@ def differential_linear_checker_for_permutation(
         cipher, input_difference, output_mask, number_of_samples, state_size
 ):
     """
-    This method helps to verify experimentally differential-linear distinguishers for permutations using evaluate vectorized evaluator
+    This method helps to verify experimentally differential-linear distinguishers for permutations using the vectorized evaluator
     """
     if state_size % 8 != 0:
         raise ValueError("State size must be a multiple of 8.")
@@ -857,7 +857,7 @@ def differential_linear_checker_for_block_cipher_single_key(
         cipher, input_difference, output_mask, number_of_samples, block_size, key_size, fixed_key
 ):
     """
-    This method helps to verify experimentally differential-linear distinguishers for block ciphers using evaluate vectorized evaluator
+    This method helps to verify experimentally differential-linear distinguishers for block ciphers using the vectorized evaluator
     """
     if block_size % 8 != 0:
         raise ValueError("State size must be a multiple of 8.")

--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -22,6 +22,8 @@ import sys
 import math
 from copy import deepcopy
 
+import numpy as np
+
 from claasp.name_mappings import CONSTANT, CIPHER_OUTPUT, INTERMEDIATE_OUTPUT, WORD_OPERATION, LINEAR_LAYER, SBOX, MIX_COLUMN, \
     INPUT_KEY, INPUT_PLAINTEXT, INPUT_MESSAGE, INPUT_STATE
 
@@ -791,3 +793,90 @@ def get_related_key_scenario_format_for_fixed_values(_cipher):
             fixed_variables.append(fixed_variable)
 
     return fixed_variables
+
+
+def _extract_bits(columns, positions):
+    """Extracts bits from columns at specified positions using vectorization."""
+    bit_size = columns.shape[0] * 8
+    positions = np.array(positions)
+    byte_indices = (bit_size - positions - 1) // 8
+    bit_indices = positions % 8
+    if np.any(byte_indices < 0) or np.any(byte_indices >= columns.shape[0]):
+        raise IndexError("Byte index out of range.")
+    bytes_at_positions = columns[byte_indices][:, :]
+    bits = (bytes_at_positions >> bit_indices[:, np.newaxis]) & 1
+
+    return bits
+
+
+def _number_to_n_bit_binary_string(number, n_bits):
+    """Converts a number to an n-bit binary string with leading zero padding."""
+    return format(number, f'0{n_bits}b')
+
+
+def _extract_bit_positions(hex_number, state_size):
+    binary_str = _number_to_n_bit_binary_string(hex_number, state_size)
+    binary_str = binary_str[::-1]
+    positions = [i for i, bit in enumerate(binary_str) if bit == '1']
+    return positions
+
+
+def _repeat_input_difference(input_difference, num_samples, num_bytes):
+    """Function to repeat the input difference for a large sample size."""
+    bytes_array = np.frombuffer(input_difference.to_bytes(num_bytes, 'big'), dtype=np.uint8)
+    repeated_array = np.broadcast_to(bytes_array[:, np.newaxis], (num_bytes, num_samples))
+    return repeated_array
+
+
+def differential_linear_checker_for_permutation(
+        cipher, input_difference, output_mask, number_of_samples, state_size
+):
+    """
+    This method helps to verify experimentally differential-linear distinguishers for permutations using evaluate vectorized evaluator
+    """
+    if state_size % 8 != 0:
+        raise ValueError("State size must be a multiple of 8.")
+    num_bytes = int(state_size/8)
+
+    rng = np.random.default_rng()
+    input_difference_data = _repeat_input_difference(input_difference, number_of_samples, num_bytes)
+    plaintext1 = rng.integers(low=0, high=256, size=(num_bytes, number_of_samples), dtype=np.uint8)
+    plaintext2 = plaintext1 ^ input_difference_data
+    ciphertext1 = cipher.evaluate_vectorized([plaintext1])
+    ciphertext2 = cipher.evaluate_vectorized([plaintext2])
+    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
+    bit_positions_ciphertext = _extract_bit_positions(output_mask, state_size)
+    ccc = _extract_bits(ciphertext3.T, bit_positions_ciphertext)
+    parities = np.bitwise_xor.reduce(ccc, axis=0)
+    count = np.count_nonzero(parities == 0)
+    corr = 2*count/number_of_samples*1.0-1
+    return corr
+
+
+def differential_linear_checker_for_block_cipher_single_key(
+        cipher, input_difference, output_mask, number_of_samples, block_size, key_size, fixed_key
+):
+    """
+    This method helps to verify experimentally differential-linear distinguishers for block ciphers using evaluate vectorized evaluator
+    """
+    if block_size % 8 != 0:
+        raise ValueError("State size must be a multiple of 8.")
+    if key_size % 8 != 0:
+        raise ValueError("Key size must be a multiple of 8.")
+    state_num_bytes = int(block_size / 8)
+    key_num_bytes = int(key_size / 8)
+
+    rng = np.random.default_rng()
+    fixed_key_data = _repeat_input_difference(fixed_key, number_of_samples, key_num_bytes)
+    input_difference_data = _repeat_input_difference(input_difference, number_of_samples, state_num_bytes)
+    plaintext1 = rng.integers(low=0, high=256, size=(state_num_bytes, number_of_samples), dtype=np.uint8)
+    plaintext2 = plaintext1 ^ input_difference_data
+    ciphertext1 = cipher.evaluate_vectorized([plaintext1, fixed_key_data])
+    ciphertext2 = cipher.evaluate_vectorized([plaintext2, fixed_key_data])
+    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
+    bit_positions_ciphertext = _extract_bit_positions(output_mask, block_size)
+    ccc = _extract_bits(ciphertext3.T, bit_positions_ciphertext)
+    parities = np.bitwise_xor.reduce(ccc, axis=0)
+    count = np.count_nonzero(parities == 0)
+    corr = 2*count/number_of_samples*1.0-1
+    return corr

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -1,36 +1,12 @@
 from claasp.cipher_modules.models.sat.sat_models.sat_differential_linear_model import SatDifferentialLinearModel
+from claasp.cipher_modules.models.sat.utils.utils import _generate_component_model_types, \
+    _update_component_model_types_for_truncated_components, _update_component_model_types_for_linear_components
 from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list, \
     differential_linear_checker_for_permutation, differential_linear_checker_for_block_cipher_single_key
 from claasp.ciphers.block_ciphers.aradi_block_cipher_sbox import AradiBlockCipherSBox
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.ciphers.permutations.chacha_permutation import ChachaPermutation
 import itertools
-
-
-def generate_component_model_types(speck_cipher):
-    """Generates the component model types for a given Speck cipher."""
-    component_model_types = []
-    for component in speck_cipher.get_all_components():
-        component_model_types.append({
-            "component_id": component.id,
-            "component_object": component,
-            "model_type": "sat_xor_differential_propagation_constraints"
-        })
-    return component_model_types
-
-
-def update_component_model_types_for_truncated_components(component_model_types, truncated_components):
-    """Updates the component model types for truncated components."""
-    for component_model_type in component_model_types:
-        if component_model_type["component_id"] in truncated_components:
-            component_model_type["model_type"] = "sat_bitwise_deterministic_truncated_xor_differential_constraints"
-
-
-def update_component_model_types_for_linear_components(component_model_types, linear_components):
-    """Updates the component model types for linear components."""
-    for component_model_type in component_model_types:
-        if component_model_type["component_id"] in linear_components:
-            component_model_type["model_type"] = "sat_xor_linear_mask_propagation_constraints"
 
 
 def test_differential_linear_trail_with_fixed_weight_6_rounds_speck():
@@ -77,9 +53,9 @@ def test_differential_linear_trail_with_fixed_weight_6_rounds_speck():
         bit_values=integer_to_bit_list(0x02000201, 32, 'big')
     )
 
-    component_model_types = generate_component_model_types(speck)
-    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
-    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+    component_model_types = _generate_component_model_types(speck)
+    _update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    _update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
 
     sat_heterogeneous_model = SatDifferentialLinearModel(speck, component_model_types)
 
@@ -130,9 +106,9 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
         bit_values=[0] * 32
     )
 
-    component_model_types = generate_component_model_types(chacha)
-    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
-    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+    component_model_types = _generate_component_model_types(chacha)
+    _update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    _update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
 
     sat_heterogeneous_model = SatDifferentialLinearModel(chacha, component_model_types)
 
@@ -190,9 +166,9 @@ def test_differential_linear_trail_with_fixed_weight_4_rounds_aradi():
         bit_values=[0] * 4
     )
 
-    component_model_types = generate_component_model_types(aradi)
-    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
-    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+    component_model_types = _generate_component_model_types(aradi)
+    _update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    _update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
 
     sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
 
@@ -243,9 +219,9 @@ def test_differential_linear_trail_with_fixed_weight_4_rounds_chacha():
         bit_values=[0] * 32
     )
 
-    component_model_types = generate_component_model_types(chacha)
-    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
-    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+    component_model_types = _generate_component_model_types(chacha)
+    _update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    _update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
 
     sat_heterogeneous_model = SatDifferentialLinearModel(chacha, component_model_types)
 

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -280,7 +280,7 @@ def test_diff_lin_speck():
     """
     input_difference = 0x02110a04
     output_mask = 0x02000201
-    number_of_samples = 2 ** 12
+    number_of_samples = 2 ** 15
     number_of_rounds = 6
     fixed_key = 0x0
     speck = SpeckBlockCipher(number_of_rounds=number_of_rounds)
@@ -291,7 +291,7 @@ def test_diff_lin_speck():
     )
     import math
     abs_corr = abs(corr)
-    assert abs(math.log(abs_corr, 2)) < 8
+    assert abs(math.log(abs_corr, 2)) <= 8
 
 
 def test_diff_lin_aradi():

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -1,15 +1,10 @@
-import time
-
-import numpy as np
-
 from claasp.cipher_modules.models.sat.sat_models.sat_differential_linear_model import SatDifferentialLinearModel
-from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
+from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list, \
+    differential_linear_checker_for_permutation, differential_linear_checker_for_block_cipher_single_key
 from claasp.ciphers.block_ciphers.aradi_block_cipher_sbox import AradiBlockCipherSBox
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.ciphers.permutations.chacha_permutation import ChachaPermutation
-from claasp.ciphers.permutations.gaston_sbox_permutation import GastonSboxPermutation
-from claasp.ciphers.permutations.gaston_sbox_permutation_top import GastonSboxPermutationTop
-from claasp.utils.utils import get_k_th_bit
+import itertools
 
 
 def generate_component_model_types(speck_cipher):
@@ -38,68 +33,16 @@ def update_component_model_types_for_linear_components(component_model_types, li
             component_model_type["model_type"] = "sat_xor_linear_mask_propagation_constraints"
 
 
-def extract_bits(columns, positions):
-    num_positions = len(positions)
-    num_columns = columns.shape[1]
-    bit_size = columns.shape[0] * 8
-    # Initialize the result array
-    result = np.zeros((num_positions, num_columns), dtype=np.uint8)
-
-    # Loop to fill the result array with the required bits
-    for i in range(num_positions):
-        for j in range(num_columns):
-            byte_index = (bit_size - positions[i] -1) // 8
-            bit_index = positions[i] % 8
-            result[i, j] = get_k_th_bit(columns[:, j][byte_index], bit_index)
-    return result
-def number_to_n_bit_binary_string(number, n_bits):
-    """Converts a number to an n-bit binary string with leading zero padding."""
-    return format(number, f'0{n_bits}b')
-
-def extract_bit_positions1(binary_str):
-    """Extracts bit positions from a binary+unknows string."""
-    binary_str = binary_str[::-1]
-
-    positions = [i for i, bit in enumerate(binary_str) if bit in ['1']]
-    return positions
-
-def extract_bit_positions(hex_number):
-    binary_str = number_to_n_bit_binary_string(hex_number, 512)
-    print(len(binary_str), binary_str)
-    #binary_str = bin(hex_number)[2:]  # bin() converts to binary, [2:] strips the '0b' prefix
-
-    # Reverse the binary string to make the least significant bit at index 0
-    binary_str = binary_str[::-1]
-
-    # Find positions of '1's
-    positions = [i for i, bit in enumerate(binary_str) if bit == '1']
-
-    return positions
-
-
-def repeat_input_difference(input_difference, num_samples, num_bytes):
-    """Repeats the input difference to generate a large sample for testing."""
-    bytes_array = input_difference.to_bytes(num_bytes, 'big')
-    np_array = np.array(list(bytes_array), dtype=np.uint8)
-    column_array = np_array.reshape(-1, 1)
-    return np.tile(column_array, (1, num_samples))
-
-
-def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
-    """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    aradi = SpeckBlockCipher(number_of_rounds=5)
-    import itertools
-
-    top_part_components = []
+def test_differential_linear_trail_with_fixed_weight_6_rounds_speck():
+    """Test for finding a differential-linear trail with fixed weight for 6 rounds of Speck."""
+    speck = SpeckBlockCipher(number_of_rounds=6)
     middle_part_components = []
     bottom_part_components = []
-    for round_number in range(2):
-        top_part_components.append(aradi.get_components_in_round(round_number))
     for round_number in range(2, 4):
-        middle_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(4, 5):
-        bottom_part_components.append(aradi.get_components_in_round(round_number))
-    top_part_components = list(itertools.chain(*top_part_components))
+        middle_part_components.append(speck.get_components_in_round(round_number))
+    for round_number in range(4, 6):
+        bottom_part_components.append(speck.get_components_in_round(round_number))
+
     middle_part_components = list(itertools.chain(*middle_part_components))
     bottom_part_components = list(itertools.chain(*bottom_part_components))
 
@@ -108,9 +51,9 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
 
     plaintext = set_fixed_variables(
         component_id='plaintext',
-        constraint_type='not_equal',
+        constraint_type='equal',
         bit_positions=range(32),
-        bit_values=[0] * 32
+        bit_values=integer_to_bit_list(0x02110a04, 32, 'big')
     )
 
     key = set_fixed_variables(
@@ -127,91 +70,29 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
         bit_values=[0] * 4
     )
 
-    component_model_types = generate_component_model_types(aradi)
+    ciphertext_difference = set_fixed_variables(
+        component_id='cipher_output_5_12',
+        constraint_type='equal',
+        bit_positions=range(32),
+        bit_values=integer_to_bit_list(0x02000201, 32, 'big')
+    )
+
+    component_model_types = generate_component_model_types(speck)
     update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
     update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
 
-    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
+    sat_heterogeneous_model = SatDifferentialLinearModel(speck, component_model_types)
 
     trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=4, fixed_values=[key, plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=31
+        weight=8, fixed_values=[key, plaintext, modadd_2_7, ciphertext_difference], solver_name="CADICAL_EXT", num_unknown_vars=31
     )
-    print(trail)
     assert trail["status"] == 'SATISFIABLE'
 
-def test_differential_linear_trail_with_fixed_weight_3_rounds_ascon():
-    """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    aradi = GastonSboxPermutationTop(number_of_rounds=3)
-    import itertools
-
-    top_part_components = []
-    middle_part_components = []
-    bottom_part_components = []
-    for round_number in range(1):
-        top_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(1, 2):
-        middle_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(2, 3):
-        bottom_part_components.append(aradi.get_components_in_round(round_number))
-    top_part_components = list(itertools.chain(*top_part_components))
-    middle_part_components = list(itertools.chain(*middle_part_components))
-    bottom_part_components = list(itertools.chain(*bottom_part_components))
-
-    middle_part_components = [component.id for component in middle_part_components]
-    bottom_part_components = [component.id for component in bottom_part_components]
-
-    plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='not_equal',
-        bit_positions=range(640),
-        bit_values=[0] * 640
-    )
-
-
-    modadd_2_7 = set_fixed_variables(
-        component_id='sbox_2_88',
-        constraint_type='not_equal',
-        bit_positions=range(5),
-        bit_values=[0] * 5
-    )
-
-    component_model_types = generate_component_model_types(aradi)
-    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
-    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
-
-    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
-
-    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=4, fixed_values=[plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=639
-    )
-    print(trail)
-    assert trail["status"] == 'SATISFIABLE'
-
-
-def generate_uint32_array_from_hex(prefix, hex_string):
-    # Ensure the hex string is exactly 512 bits (128 hex characters)
-    if len(hex_string) < 128:
-        hex_string = hex_string.zfill(128)  # Pad with leading zeros if necessary
-
-    # Split the hex string into 32-bit chunks (8 hex characters each)
-    chunks = [hex_string[i:i + 8] for i in range(0, len(hex_string), 8)]
-
-    # Convert each chunk to a 32-bit integer with '0x' format for C-like output
-    formatted_chunks = ["0x" + chunk.upper() for chunk in chunks]
-
-    # Construct the C-style uint32_t array as a string
-    uint32_array = f"uint32_t {prefix}[16] = {{ " + ", ".join(formatted_chunks) + " };"
-
-    return uint32_array
 
 def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
-    """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    nr = 6
-    chacha = ChachaPermutation(number_of_rounds=nr)
-    #import ipdb; ipdb.set_trace()
-    #chacha.print()
+    """Test for finding a differential-linear trail with fixed weight for 3 rounds of ChaCha permutation."""
+    chacha = ChachaPermutation(number_of_rounds=6)
     import itertools
-
     top_part_components = []
     middle_part_components = []
     bottom_part_components = []
@@ -222,7 +103,6 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
     for round_number in range(3, 6):
         bottom_part_components.append(chacha.get_components_in_round(round_number))
 
-    top_part_components = list(itertools.chain(*top_part_components))
     middle_part_components = list(itertools.chain(*middle_part_components))
     bottom_part_components = list(itertools.chain(*bottom_part_components))
 
@@ -232,19 +112,18 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
     plaintext = set_fixed_variables(
         component_id='plaintext',
         constraint_type='equal',
-        bit_positions=range(384),
+        bit_positions=range(512),
         bit_values=integer_to_bit_list(0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000, 512, 'big')
     )
 
     cipher_output_5_24 = set_fixed_variables(
         component_id='cipher_output_5_24',
         constraint_type='equal',
-        bit_positions=range(384),
+        bit_positions=range(512),
         bit_values=integer_to_bit_list(0x00010000000100010000000100030003000000800000008000000000000001800000000000000001000000010000000201000101010000000000010103000101, 512, 'big')
     )
 
-
-    modadd_2_7 = set_fixed_variables(
+    modadd_3_15 = set_fixed_variables(
         component_id=f'modadd_3_15',
         constraint_type='not_equal',
         bit_positions=range(32),
@@ -258,84 +137,179 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
     sat_heterogeneous_model = SatDifferentialLinearModel(chacha, component_model_types)
 
     trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=5, fixed_values=[plaintext, modadd_2_7, cipher_output_5_24], solver_name="CADICAL_EXT", num_unknown_vars=511
+        weight=5, fixed_values=[plaintext, modadd_3_15, cipher_output_5_24], solver_name="CADICAL_EXT", num_unknown_vars=511
     )
-    print(trail)
-    print(generate_uint32_array_from_hex("ID", trail["components_values"]["plaintext"]["value"]))
-    print(generate_uint32_array_from_hex("ODmask", trail["components_values"][f"cipher_output_{nr-1}_24"]["value"]))
     assert trail["status"] == 'SATISFIABLE'
     assert trail["total_weight"] <= 5
 
 
-def test_diff_lin_gaston():
-    """
-    # input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000001
-    # output_mask = 0x00000000000000000000000000000000000000000000000000000100000000000000002000000000
-    """
+def test_differential_linear_trail_with_fixed_weight_4_rounds_aradi():
+    """Test for finding a differential-linear trail with fixed weight for 4 rounds of Aradi block cipher."""
+    aradi = AradiBlockCipherSBox(number_of_rounds=4)
+    import itertools
+    top_part_components = []
+    middle_part_components = []
+    bottom_part_components = []
+    for round_number in range(1):
+        top_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(1, 3):
+        middle_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(3, 4):
+        bottom_part_components.append(aradi.get_components_in_round(round_number))
+    middle_part_components = list(itertools.chain(*middle_part_components))
+    bottom_part_components = list(itertools.chain(*bottom_part_components))
 
-    input_difference = 0x0020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    output_mask =      0x0000000000000040000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    middle_part_components = [component.id for component in middle_part_components]
+    bottom_part_components = [component.id for component in bottom_part_components]
 
-    number_of_samples = 2 ** 12
-    start_building_time = time.time()
-    rng = np.random.default_rng()
-    input_difference_data = repeat_input_difference(input_difference, number_of_samples, 80)
-    end_building_time = time.time()
-    sat_time = end_building_time - start_building_time
-    print("Time in seconds", sat_time)
-    nr = 3
-    gaston = GastonSboxPermutationTop(number_of_rounds=nr)
-    plaintext1 = rng.integers(low=0, high=256, size=(80, number_of_samples), dtype=np.uint8)
-    plaintext2 = plaintext1 ^ input_difference_data
-    start_building_time = time.time()
-    ciphertext1 = gaston.evaluate_vectorized([plaintext1])
-    sat_time = end_building_time - start_building_time
-    print("Time in seconds", sat_time)
-    ciphertext2 = gaston.evaluate_vectorized([plaintext2])
-    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
-    bit_positions_ciphertext = extract_bit_positions(output_mask)
-    ccc = extract_bits(ciphertext3.T, bit_positions_ciphertext)
-    print(ccc)
-    count = 0
-    for i in range(number_of_samples):
-        c_xor = np.bitwise_xor.reduce(ccc.T[i])
-        if c_xor == 0:
-            count += 1
-    corr = 2*count/number_of_samples*1.0-1
-    import math
-    print("Correlation:", corr, "Exponent of 2", math.log(abs(corr), 2))
+    plaintext = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='equal',
+        bit_positions=range(128),
+        bit_values=integer_to_bit_list(0x00000000000080000000000000008000, 128, 'big')
+    )
+
+    cipher_output_3_86 = set_fixed_variables(
+        component_id='cipher_output_3_86',
+        constraint_type='equal',
+        bit_positions=range(128),
+        bit_values=integer_to_bit_list(0x90900120800000011010002000000000, 128, 'big')
+    )
+
+    key = set_fixed_variables(
+        component_id='key',
+        constraint_type='equal',
+        bit_positions=range(256),
+        bit_values=[0] * 256
+    )
+
+    sbox_4_8 = set_fixed_variables(
+        component_id=f'sbox_3_8',
+        constraint_type='not_equal',
+        bit_positions=range(4),
+        bit_values=[0] * 4
+    )
+
+    component_model_types = generate_component_model_types(aradi)
+    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+
+    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
+
+    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
+        weight=10, fixed_values=[key, plaintext, sbox_4_8, cipher_output_3_86], solver_name="CADICAL_EXT", num_unknown_vars=128-1
+    )
+    assert trail["status"] == 'SATISFIABLE'
+    assert trail["total_weight"] <= 10
+
+
+def test_differential_linear_trail_with_fixed_weight_4_rounds_chacha():
+    """Test for finding a differential-linear trail with fixed weight for 4 rounds of ChaCha permutation."""
+    chacha = ChachaPermutation(number_of_rounds=8)
+
+    import itertools
+
+    top_part_components = []
+    middle_part_components = []
+    bottom_part_components = []
+    for round_number in range(2):
+        top_part_components.append(chacha.get_components_in_round(round_number))
+    for round_number in range(2, 4):
+        middle_part_components.append(chacha.get_components_in_round(round_number))
+    for round_number in range(4, 8):
+        bottom_part_components.append(chacha.get_components_in_round(round_number))
+
+    middle_part_components = list(itertools.chain(*middle_part_components))
+    bottom_part_components = list(itertools.chain(*bottom_part_components))
+
+    middle_part_components = [component.id for component in middle_part_components]
+    bottom_part_components = [component.id for component in bottom_part_components]
+
+    plaintext = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='equal',
+        bit_positions=range(512),
+        bit_values=integer_to_bit_list(
+            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000088088780,
+            512,
+            'big'
+        )
+    )
+
+    modadd_4_15 = set_fixed_variables(
+        component_id=f'modadd_4_15',
+        constraint_type='not_equal',
+        bit_positions=range(32),
+        bit_values=[0] * 32
+    )
+
+    component_model_types = generate_component_model_types(chacha)
+    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+
+    sat_heterogeneous_model = SatDifferentialLinearModel(chacha, component_model_types)
+
+    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
+        weight=32, fixed_values=[plaintext, modadd_4_15], solver_name="CADICAL_EXT", num_unknown_vars=511
+    )
+    assert trail["status"] == 'SATISFIABLE'
+    assert trail["total_weight"] <= 32
 
 
 def test_diff_lin_chacha():
     """
-    # input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000001
-    # output_mask = 0x00000000000000000000000000000000000000000000000000000100000000000000002000000000
+    This test is verifying experimentally the test test_differential_linear_trail_with_fixed_weight_3_rounds_chacha
     """
-
     input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000
-    output_mask =      0x00010000000100010000000100030003000000800000008000000000000001800000000000000001000000010000000201000101010000000000010103000101
+    output_mask = 0x00010000000100010000000100030003000000800000008000000000000001800000000000000001000000010000000201000101010000000000010103000101
     number_of_samples = 2 ** 12
-    start_building_time = time.time()
-    rng = np.random.default_rng()
-    input_difference_data = repeat_input_difference(input_difference, number_of_samples, 64)
-    end_building_time = time.time()
-    sat_time = end_building_time - start_building_time
-    nr = 6
-    gaston = ChachaPermutation(number_of_rounds=nr)
-    plaintext1 = rng.integers(low=0, high=256, size=(64, number_of_samples), dtype=np.uint8)
-    plaintext2 = plaintext1 ^ input_difference_data
-    start_building_time = time.time()
-    ciphertext1 = gaston.evaluate_vectorized([plaintext1])
-    sat_time = end_building_time - start_building_time
-    ciphertext2 = gaston.evaluate_vectorized([plaintext2])
-    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
-    bit_positions_ciphertext = extract_bit_positions(output_mask)
-    ccc = extract_bits(ciphertext3.T, bit_positions_ciphertext)
-    count = 0
-    for i in range(number_of_samples):
-        c_xor = np.bitwise_xor.reduce(ccc.T[i])
-        if c_xor == 0:
-            count += 1
-    corr = 2*count/number_of_samples*1.0-1
+    number_of_rounds = 6
+    state_size = 512
+    chacha = ChachaPermutation(number_of_rounds=number_of_rounds)
+    corr = differential_linear_checker_for_permutation(
+        chacha, input_difference, output_mask, number_of_samples, state_size
+    )
     import math
-    print("Correlation:", corr, "Exponent of 2", math.log(abs(corr), 2))
+    abs_corr = abs(corr)
+    assert abs(math.log(abs_corr, 2)) < 3
+
+
+def test_diff_lin_speck():
+    """
+    This test is verifying experimentally the test test_differential_linear_trail_with_fixed_weight_6_rounds_speck
+    """
+    input_difference = 0x02110a04
+    output_mask = 0x02000201
+    number_of_samples = 2 ** 12
+    number_of_rounds = 6
+    fixed_key = 0x0
+    speck = SpeckBlockCipher(number_of_rounds=number_of_rounds)
+    block_size = speck.inputs_bit_size[0]
+    key_size = speck.inputs_bit_size[1]
+    corr = differential_linear_checker_for_block_cipher_single_key(
+        speck, input_difference, output_mask, number_of_samples, block_size, key_size, fixed_key
+    )
+    import math
+    abs_corr = abs(corr)
+    assert abs(math.log(abs_corr, 2)) < 8
+
+
+def test_diff_lin_aradi():
+    """
+    This test is verifying experimentally the test test_differential_linear_trail_with_fixed_weight_4_rounds_aradi
+    """
+    input_difference = 0x00000000000080000000000000008000
+    output_mask = 0x90900120800000011010002000000000
+    number_of_samples = 2 ** 12
+    number_of_rounds = 4
+    fixed_key = 0x90900120800000011010002000000000
+    speck = AradiBlockCipherSBox(number_of_rounds=number_of_rounds)
+    block_size = speck.inputs_bit_size[0]
+    key_size = speck.inputs_bit_size[1]
+    corr = differential_linear_checker_for_block_cipher_single_key(
+        speck, input_difference, output_mask, number_of_samples, block_size, key_size, fixed_key
+    )
+    import math
+    abs_corr = abs(corr)
+    print(corr, abs_corr, abs(math.log(abs_corr, 2)))
+    assert abs(math.log(abs_corr, 2)) < 8

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -1,10 +1,14 @@
+import time
+
 import numpy as np
 
 from claasp.cipher_modules.models.sat.sat_models.sat_differential_linear_model import SatDifferentialLinearModel
-from claasp.cipher_modules.models.utils import set_fixed_variables
+from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 from claasp.ciphers.block_ciphers.aradi_block_cipher_sbox import AradiBlockCipherSBox
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+from claasp.ciphers.permutations.chacha_permutation import ChachaPermutation
 from claasp.ciphers.permutations.gaston_sbox_permutation import GastonSboxPermutation
+from claasp.ciphers.permutations.gaston_sbox_permutation_top import GastonSboxPermutationTop
 from claasp.utils.utils import get_k_th_bit
 
 
@@ -35,25 +39,41 @@ def update_component_model_types_for_linear_components(component_model_types, li
 
 
 def extract_bits(columns, positions):
-    """Extracts the bits from columns at the specified positions."""
     num_positions = len(positions)
     num_columns = columns.shape[1]
     bit_size = columns.shape[0] * 8
-
+    # Initialize the result array
     result = np.zeros((num_positions, num_columns), dtype=np.uint8)
 
+    # Loop to fill the result array with the required bits
     for i in range(num_positions):
         for j in range(num_columns):
-            byte_index = (bit_size - positions[i] - 1) // 8
+            byte_index = (bit_size - positions[i] -1) // 8
             bit_index = positions[i] % 8
             result[i, j] = get_k_th_bit(columns[:, j][byte_index], bit_index)
     return result
+def number_to_n_bit_binary_string(number, n_bits):
+    """Converts a number to an n-bit binary string with leading zero padding."""
+    return format(number, f'0{n_bits}b')
 
-
-def extract_bit_positions(binary_str):
+def extract_bit_positions1(binary_str):
     """Extracts bit positions from a binary+unknows string."""
     binary_str = binary_str[::-1]
-    positions = [i for i, bit in enumerate(binary_str) if bit in ['1', '0']]
+
+    positions = [i for i, bit in enumerate(binary_str) if bit in ['1']]
+    return positions
+
+def extract_bit_positions(hex_number):
+    binary_str = number_to_n_bit_binary_string(hex_number, 512)
+    print(len(binary_str), binary_str)
+    #binary_str = bin(hex_number)[2:]  # bin() converts to binary, [2:] strips the '0b' prefix
+
+    # Reverse the binary string to make the least significant bit at index 0
+    binary_str = binary_str[::-1]
+
+    # Find positions of '1's
+    positions = [i for i, bit in enumerate(binary_str) if bit == '1']
+
     return positions
 
 
@@ -67,17 +87,17 @@ def repeat_input_difference(input_difference, num_samples, num_bytes):
 
 def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
     """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    aradi = SpeckBlockCipher(number_of_rounds=8)
+    aradi = SpeckBlockCipher(number_of_rounds=5)
     import itertools
 
     top_part_components = []
     middle_part_components = []
     bottom_part_components = []
-    for round_number in range(3):
+    for round_number in range(2):
         top_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(3, 5):
+    for round_number in range(2, 4):
         middle_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(5, 8):
+    for round_number in range(4, 5):
         bottom_part_components.append(aradi.get_components_in_round(round_number))
     top_part_components = list(itertools.chain(*top_part_components))
     middle_part_components = list(itertools.chain(*middle_part_components))
@@ -101,7 +121,7 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
     )
 
     modadd_2_7 = set_fixed_variables(
-        component_id='modadd_7_7',
+        component_id='modadd_4_7',
         constraint_type='not_equal',
         bit_positions=range(4),
         bit_values=[0] * 4
@@ -114,23 +134,24 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
     sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
 
     trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=14, fixed_values=[key, plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=31
+        weight=4, fixed_values=[key, plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=31
     )
+    print(trail)
     assert trail["status"] == 'SATISFIABLE'
 
 def test_differential_linear_trail_with_fixed_weight_3_rounds_ascon():
     """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    aradi = GastonSboxPermutation(number_of_rounds=4)
+    aradi = GastonSboxPermutationTop(number_of_rounds=3)
     import itertools
 
     top_part_components = []
     middle_part_components = []
     bottom_part_components = []
-    for round_number in range(2):
+    for round_number in range(1):
         top_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(2, 3):
+    for round_number in range(1, 2):
         middle_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(3, 4):
+    for round_number in range(2, 3):
         bottom_part_components.append(aradi.get_components_in_round(round_number))
     top_part_components = list(itertools.chain(*top_part_components))
     middle_part_components = list(itertools.chain(*middle_part_components))
@@ -142,13 +163,13 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_ascon():
     plaintext = set_fixed_variables(
         component_id='plaintext',
         constraint_type='not_equal',
-        bit_positions=range(320),
-        bit_values=[0] * 320
+        bit_positions=range(640),
+        bit_values=[0] * 640
     )
-    import ipdb; ipdb.set_trace()
+
 
     modadd_2_7 = set_fixed_variables(
-        component_id='sbox_3_88',
+        component_id='sbox_2_88',
         constraint_type='not_equal',
         bit_positions=range(5),
         bit_values=[0] * 5
@@ -161,7 +182,169 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_ascon():
     sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
 
     trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=20, fixed_values=[plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=319
+        weight=4, fixed_values=[plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=639
     )
     print(trail)
     assert trail["status"] == 'SATISFIABLE'
+
+
+def generate_uint32_array_from_hex(prefix, hex_string):
+    # Ensure the hex string is exactly 512 bits (128 hex characters)
+    if len(hex_string) < 128:
+        hex_string = hex_string.zfill(128)  # Pad with leading zeros if necessary
+
+    # Split the hex string into 32-bit chunks (8 hex characters each)
+    chunks = [hex_string[i:i + 8] for i in range(0, len(hex_string), 8)]
+
+    # Convert each chunk to a 32-bit integer with '0x' format for C-like output
+    formatted_chunks = ["0x" + chunk.upper() for chunk in chunks]
+
+    # Construct the C-style uint32_t array as a string
+    uint32_array = f"uint32_t {prefix}[16] = {{ " + ", ".join(formatted_chunks) + " };"
+
+    return uint32_array
+
+def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
+    """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
+    nr = 8
+    aradi = ChachaPermutation(number_of_rounds=nr)
+
+    #aradi.print()
+    import itertools
+
+    top_part_components = []
+    middle_part_components = []
+    bottom_part_components = []
+    for round_number in range(3):
+        top_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(3, 5):
+        middle_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(5, 8):
+        bottom_part_components.append(aradi.get_components_in_round(round_number))
+    top_part_components = list(itertools.chain(*top_part_components))
+    middle_part_components = list(itertools.chain(*middle_part_components))
+    bottom_part_components = list(itertools.chain(*bottom_part_components))
+
+    middle_part_components = [component.id for component in middle_part_components]
+    bottom_part_components = [component.id for component in bottom_part_components]
+
+    plaintext1 = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='not_equal',
+        bit_positions=range(512),
+        bit_values=[0] * 512
+    )
+
+    plaintext2 = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='equal',
+        bit_positions=range(384),
+        bit_values=[0] * 384
+    )
+
+
+    modadd_2_7 = set_fixed_variables(
+        component_id=f'modadd_5_15',
+        constraint_type='not_equal',
+        bit_positions=range(32),
+        bit_values=[0] * 32
+    )
+
+    #modadd_2_7 = set_fixed_variables(
+    #    component_id=f'f"cipher_output_{nr-1}_24"',
+    #    constraint_type='not_equal',
+    #    bit_positions=range(512),
+    #    bit_values=[0] * 512
+    #)
+
+    component_model_types = generate_component_model_types(aradi)
+    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+
+    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
+
+    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
+        weight=90, fixed_values=[plaintext1, plaintext2, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=511
+    )
+    print(trail)
+    print(generate_uint32_array_from_hex("ID", trail["components_values"]["plaintext"]["value"]))
+    print(generate_uint32_array_from_hex("ODmask", trail["components_values"][f"cipher_output_{nr-1}_24"]["value"]))
+    assert trail["status"] == 'SATISFIABLE'
+
+
+def test_diff_lin_gaston():
+    """
+    # input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000001
+    # output_mask = 0x00000000000000000000000000000000000000000000000000000100000000000000002000000000
+    """
+
+    input_difference = 0x0020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    output_mask =      0x0000000000000040000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+
+    number_of_samples = 2 ** 12
+    start_building_time = time.time()
+    rng = np.random.default_rng()
+    input_difference_data = repeat_input_difference(input_difference, number_of_samples, 80)
+    end_building_time = time.time()
+    sat_time = end_building_time - start_building_time
+    print("Time in seconds", sat_time)
+    nr = 3
+    gaston = GastonSboxPermutationTop(number_of_rounds=nr)
+    plaintext1 = rng.integers(low=0, high=256, size=(80, number_of_samples), dtype=np.uint8)
+    plaintext2 = plaintext1 ^ input_difference_data
+    start_building_time = time.time()
+    ciphertext1 = gaston.evaluate_vectorized([plaintext1])
+    sat_time = end_building_time - start_building_time
+    print("Time in seconds", sat_time)
+    ciphertext2 = gaston.evaluate_vectorized([plaintext2])
+    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
+    bit_positions_ciphertext = extract_bit_positions(output_mask)
+    ccc = extract_bits(ciphertext3.T, bit_positions_ciphertext)
+    print(ccc)
+    count = 0
+    for i in range(number_of_samples):
+        c_xor = np.bitwise_xor.reduce(ccc.T[i])
+        if c_xor == 0:
+            count += 1
+    corr = 2*count/number_of_samples*1.0-1
+    import math
+    print("Correlation:", corr, "Exponent of 2", math.log(abs(corr), 2))
+
+
+def test_diff_lin_chacha():
+    """
+    # input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000001
+    # output_mask = 0x00000000000000000000000000000000000000000000000000000100000000000000002000000000
+    """
+
+    input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080088008
+    output_mask =      0x00010001000000010000000000000000000000000000008000000000000000000000000000000000000000010000000100000101000000000000000001000000
+
+    number_of_samples = 2 ** 21
+    start_building_time = time.time()
+    rng = np.random.default_rng()
+    input_difference_data = repeat_input_difference(input_difference, number_of_samples, 64)
+    end_building_time = time.time()
+    sat_time = end_building_time - start_building_time
+    print("Time in seconds", sat_time)
+    nr = 8
+    gaston = ChachaPermutation(number_of_rounds=nr)
+    plaintext1 = rng.integers(low=0, high=256, size=(64, number_of_samples), dtype=np.uint8)
+    plaintext2 = plaintext1 ^ input_difference_data
+    start_building_time = time.time()
+    ciphertext1 = gaston.evaluate_vectorized([plaintext1])
+    sat_time = end_building_time - start_building_time
+    print("Time in seconds", sat_time)
+    ciphertext2 = gaston.evaluate_vectorized([plaintext2])
+    ciphertext3 = ciphertext1[0] ^ ciphertext2[0]
+    bit_positions_ciphertext = extract_bit_positions(output_mask)
+    ccc = extract_bits(ciphertext3.T, bit_positions_ciphertext)
+    print(ccc)
+    count = 0
+    for i in range(number_of_samples):
+        c_xor = np.bitwise_xor.reduce(ccc.T[i])
+        if c_xor == 0:
+            count += 1
+    corr = 2*count/number_of_samples*1.0-1
+    import math
+    print("Correlation:", corr, "Exponent of 2", math.log(abs(corr), 2))

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -206,27 +206,45 @@ def generate_uint32_array_from_hex(prefix, hex_string):
 
 def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
     """Test for finding a differential-linear trail with fixed weight for 8 rounds of Speck."""
-    nr = 8
+    nr = 10
     aradi = ChachaPermutation(number_of_rounds=nr)
-
+    #import ipdb; ipdb.set_trace()
     #aradi.print()
     import itertools
 
     top_part_components = []
     middle_part_components = []
     bottom_part_components = []
-    for round_number in range(3):
+    for round_number in range(2):
         top_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(3, 5):
+    for round_number in range(2, 4):
         middle_part_components.append(aradi.get_components_in_round(round_number))
-    for round_number in range(5, 8):
+    for round_number in range(4, 10):
         bottom_part_components.append(aradi.get_components_in_round(round_number))
+
+    top_part_special = [
+        'modadd_2_0', 'rot_2_2', 'rot_2_2', 'modadd_2_3', 'rot_2_5', 'rot_2_5', 'modadd_2_6', 'rot_2_8', 'rot_2_8', 'modadd_2_9', 'rot_2_11', 'rot_2_11', 'xor_2_1', 'xor_2_4', 'xor_2_7', 'xor_2_10'
+    ]
+
+    middle_part_special = [
+        'modadd_4_0', 'rot_4_2', 'rot_4_2', 'modadd_4_3', 'rot_4_5', 'rot_4_5', 'modadd_4_6', 'rot_4_8', 'rot_4_8', 'xor_4_1', 'xor_4_4', 'xor_4_7', 'xor_4_10', 'modadd_4_9', 'rot_4_11', 'rot_4_11'
+    ]
+
+
+
     top_part_components = list(itertools.chain(*top_part_components))
     middle_part_components = list(itertools.chain(*middle_part_components))
     bottom_part_components = list(itertools.chain(*bottom_part_components))
 
     middle_part_components = [component.id for component in middle_part_components]
     bottom_part_components = [component.id for component in bottom_part_components]
+
+    #import ipdb;
+    #ipdb.set_trace()
+    middle_part_components = list(set(middle_part_components) - set(top_part_special))
+    middle_part_components.extend(middle_part_special)
+    bottom_part_components = list(set(bottom_part_components) - set(middle_part_special))
+    #top_part_components.extend(top_part_special)
 
     plaintext1 = set_fixed_variables(
         component_id='plaintext',
@@ -244,7 +262,7 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
 
 
     modadd_2_7 = set_fixed_variables(
-        component_id=f'modadd_5_15',
+        component_id=f'modadd_4_12',
         constraint_type='not_equal',
         bit_positions=range(32),
         bit_values=[0] * 32
@@ -264,7 +282,7 @@ def test_differential_linear_trail_with_fixed_weight_3_rounds_chacha():
     sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
 
     trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
-        weight=90, fixed_values=[plaintext1, plaintext2, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=511
+        weight=80, fixed_values=[plaintext1, plaintext2, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=511
     )
     print(trail)
     print(generate_uint32_array_from_hex("ID", trail["components_values"]["plaintext"]["value"]))
@@ -317,10 +335,10 @@ def test_diff_lin_chacha():
     # output_mask = 0x00000000000000000000000000000000000000000000000000000100000000000000002000000000
     """
 
-    input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080088008
-    output_mask =      0x00010001000000010000000000000000000000000000008000000000000000000000000000000000000000010000000100000101000000000000000001000000
+    input_difference = 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008008000000000000000000000000
+    output_mask =      0x0000000100000000000000010000000000000000000000000400000000080080000010000000000000000001000800c000000080000000010000000000000101
 
-    number_of_samples = 2 ** 21
+    number_of_samples = 2 ** 14
     start_building_time = time.time()
     rng = np.random.default_rng()
     input_difference_data = repeat_input_difference(input_difference, number_of_samples, 64)

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_differential_linear_test.py
@@ -1,0 +1,178 @@
+import numpy as np
+
+from claasp.cipher_modules.models.sat.sat_models.sat_differential_linear_model import SatDifferentialLinearModel
+from claasp.cipher_modules.models.utils import set_fixed_variables
+from claasp.ciphers.block_ciphers.aradi_block_cipher_sbox import AradiBlockCipherSBox
+from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+from claasp.utils.utils import get_k_th_bit
+
+def generate_component_model_types(speck_cipher):
+    """Generates the component model types for a given Speck cipher."""
+    component_model_types = []
+    for component in speck_cipher.get_all_components():
+        component_model_types.append({
+            "component_id": component.id,
+            "component_object": component,
+            "model_type": "sat_xor_differential_propagation_constraints"
+        })
+    return component_model_types
+
+
+def update_component_model_types_for_truncated_components(component_model_types, truncated_components):
+    """Updates the component model types for truncated components."""
+    for component_model_type in component_model_types:
+        if component_model_type["component_id"] in truncated_components:
+            component_model_type["model_type"] = "sat_bitwise_deterministic_truncated_xor_differential_constraints"
+
+def update_component_model_types_for_linear_components(component_model_types, linear_components):
+    """Updates the component model types for linear components."""
+    for component_model_type in component_model_types:
+        if component_model_type["component_id"] in linear_components:
+            component_model_type["model_type"] = "sat_xor_linear_mask_propagation_constraints"
+
+
+def extract_bits(columns, positions):
+    """Extracts the bits from columns at the specified positions."""
+    num_positions = len(positions)
+    num_columns = columns.shape[1]
+    bit_size = columns.shape[0] * 8
+
+    result = np.zeros((num_positions, num_columns), dtype=np.uint8)
+
+    for i in range(num_positions):
+        for j in range(num_columns):
+            byte_index = (bit_size - positions[i] - 1) // 8
+            bit_index = positions[i] % 8
+            result[i, j] = get_k_th_bit(columns[:, j][byte_index], bit_index)
+    return result
+
+
+def extract_bit_positions(binary_str):
+    """Extracts bit positions from a binary+unknows string."""
+    binary_str = binary_str[::-1]
+    positions = [i for i, bit in enumerate(binary_str) if bit in ['1', '0']]
+    return positions
+
+
+def repeat_input_difference(input_difference, num_samples, num_bytes):
+    """Repeats the input difference to generate a large sample for testing."""
+    bytes_array = input_difference.to_bytes(num_bytes, 'big')
+    np_array = np.array(list(bytes_array), dtype=np.uint8)
+    column_array = np_array.reshape(-1, 1)
+    return np.tile(column_array, (1, num_samples))
+
+
+def test_differential_linear_trail_with_fixed_weight_3_rounds_aradi():
+    """Test for finding a XOR regular truncated differential trail with fixed weight for 5 rounds."""
+    aradi = AradiBlockCipherSBox(number_of_rounds=3)
+    import itertools
+
+    top_part_components = []
+    middle_part_components = []
+    bottom_part_components = []
+    for round_number in range(1):
+        top_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(1, 2):
+        middle_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(2, 3):
+        bottom_part_components.append(aradi.get_components_in_round(round_number))
+    top_part_components = list(itertools.chain(*top_part_components))
+    middle_part_components = list(itertools.chain(*middle_part_components))
+    bottom_part_components = list(itertools.chain(*bottom_part_components))
+
+    top_part_components = [component.id for component in top_part_components]
+    middle_part_components = [component.id for component in middle_part_components]
+    bottom_part_components = [component.id for component in bottom_part_components]
+
+    plaintext = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='not_equal',
+        bit_positions=range(128),
+        bit_values=[0] * 128
+    )
+
+    key = set_fixed_variables(
+        component_id='key',
+        constraint_type='equal',
+        bit_positions=range(256),
+        bit_values=(0,) * 256
+    )
+
+    sbox_4_5 = set_fixed_variables(
+        component_id='sbox_2_5',
+        constraint_type='not_equal',
+        bit_positions=range(4),
+        bit_values=[0] * 4
+    )
+
+
+    component_model_types = generate_component_model_types(aradi)
+    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+
+    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
+
+    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
+        weight=15, fixed_values=[key, plaintext, sbox_4_5], solver_name="CADICAL_EXT"
+    )
+    import ipdb;
+    ipdb.set_trace()
+    assert trail['components_values']['cipher_output_4_12']['value'] == '???????????????0????????????????'
+
+
+def test_differential_linear_trail_with_fixed_weight_3_rounds_speck():
+    """Test for finding a XOR regular truncated differential trail with fixed weight for 5 rounds."""
+    aradi = SpeckBlockCipher(number_of_rounds=8)
+    import itertools
+
+    top_part_components = []
+    middle_part_components = []
+    bottom_part_components = []
+    for round_number in range(3):
+        top_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(3, 6):
+        middle_part_components.append(aradi.get_components_in_round(round_number))
+    for round_number in range(6, 8):
+        bottom_part_components.append(aradi.get_components_in_round(round_number))
+    top_part_components = list(itertools.chain(*top_part_components))
+    middle_part_components = list(itertools.chain(*middle_part_components))
+    bottom_part_components = list(itertools.chain(*bottom_part_components))
+
+    top_part_components = [component.id for component in top_part_components]
+    middle_part_components = [component.id for component in middle_part_components]
+    bottom_part_components = [component.id for component in bottom_part_components]
+
+    plaintext = set_fixed_variables(
+        component_id='plaintext',
+        constraint_type='not_equal',
+        bit_positions=range(32),
+        bit_values=[0] * 32
+    )
+
+    key = set_fixed_variables(
+        component_id='key',
+        constraint_type='equal',
+        bit_positions=range(64),
+        bit_values=(0,) * 64
+    )
+
+    modadd_2_7 = set_fixed_variables(
+        component_id='modadd_5_7',
+        constraint_type='not_equal',
+        bit_positions=range(4),
+        bit_values=[0] * 4
+    )
+
+
+    component_model_types = generate_component_model_types(aradi)
+    update_component_model_types_for_truncated_components(component_model_types, middle_part_components)
+    update_component_model_types_for_linear_components(component_model_types, bottom_part_components)
+
+    sat_heterogeneous_model = SatDifferentialLinearModel(aradi, component_model_types)
+
+    trail = sat_heterogeneous_model.find_one_differential_linear_trail_with_fixed_weight(
+        weight=10, fixed_values=[key, plaintext, modadd_2_7], solver_name="CADICAL_EXT", num_unknown_vars=31
+    )
+    print(trail)
+    import ipdb;
+    ipdb.set_trace()

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
@@ -6,7 +6,8 @@ from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import Sat
 def test_branch_xor_linear_constraints():
     speck = SpeckBlockCipher(number_of_rounds=3)
     sat = SatXorLinearModel(speck)
-    constraints = sat.branch_xor_linear_constraints()
+
+    constraints = SatXorLinearModel.branch_xor_linear_constraints(sat.bit_bindings)
 
     assert constraints[0] == '-plaintext_0_o rot_0_0_0_i'
     assert constraints[1] == 'plaintext_0_o -rot_0_0_0_i'
@@ -62,7 +63,7 @@ def test_fix_variables_value_xor_linear_constraints():
                         'constraint_type': 'not_equal',
                         'bit_positions': [0, 1, 2, 3],
                         'bit_values': [1, 1, 1, 0]}]
-    constraints = sat.fix_variables_value_xor_linear_constraints(fixed_variables)
+    constraints = SatXorLinearModel.fix_variables_value_xor_linear_constraints(fixed_variables)
 
     assert constraints == ['plaintext_0_o', '-plaintext_1_o', 'plaintext_2_o', 'plaintext_3_o',
                            '-ciphertext_0_o -ciphertext_1_o -ciphertext_2_o ciphertext_3_o']


### PR DESCRIPTION
 Feature/Add: SAT model for differential-linear distinguishers
 
 - Introduced a new feature in CLAASP allowing the creation of models to search for differential-linear distinguishers under specific conditions.
 - The middle part of the model is constrained to be deterministic, integrating both differential and linear distinguishers within the SAT-based model.
 - Also, added the ability to check differential-linear distinguisher experimentally in any CLAASP cipher using the vectorized evaluator.
