### PR TITLE
Add PyPi Github Action

### DIFF
--- a/.github/workflows/publish-claasp-on-pypi.yaml
+++ b/.github/workflows/publish-claasp-on-pypi.yaml
@@ -1,0 +1,37 @@
+name: Publish CLAASP package on PyPi
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install build tools
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install setuptools wheel
+
+      - name: Install twine
+        run: sudo apt install twine
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python3 setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
I've added a GH that automatically push the CLAASP library in the PyPi repository when we push to main branch or we push a tag/release.

@peacker has to add the secret `PYPI_API_TOKEN` to the repository.