### PR TITLE
FIX/fix: calculate_component_weight

### DIFF
--- a/claasp/cipher_modules/models/sat/sat_model.py
+++ b/claasp/cipher_modules/models/sat/sat_model.py
@@ -397,7 +397,7 @@ class SatModel:
 
     def calculate_component_weight(self, component, out_suffix, output_values_dict):
         weight = 0
-        if ('MODADD' in component.description or 'AND' in component.description
+        if ('MODSUB' in component.description or 'MODADD' in component.description or 'AND' in component.description
                 or 'OR' in component.description or SBOX in component.type):
             weight = sum([output_values_dict[f'hw_{component.id}_{i}{out_suffix}']
                           for i in range(component.output_bit_size)])


### PR DESCRIPTION
The method `calculate_component_weight` from `claasp/cipher_modules/models/sat/sat_model.py` calculates the the Hamming weight in the output of a component modeled with SAT. Besides that, It checks whether the component is non-linear. Although CLAASP supported the non-linear component MODSUB, it was not included in this method. This PR fixes that issue.