### PR TITLE
Add coverage run config to fix sonarcloud action

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ max-line-length = 120
 
 [pydocstyle]
 add-ignore = D100, D101, D102, D103, D107, D202
+
+[coverage:run]
+relative_files = True
+source = claasp/
+branch = True


### PR DESCRIPTION
This pull request includes a configuration change to the `setup.cfg` file to improve code coverage settings.

Configuration changes:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R6-R10): Added `[coverage:run]` section with `relative_files`, `source`, and `branch` settings to enhance code coverage tracking.