### PR TITLE
Fix pytest to the new hex value representation

### DIFF
--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_linear_model.py
@@ -149,7 +149,7 @@ class SatXorLinearModel(SatModel):
             sage: speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=4)
             sage: sat = SatXorLinearModel(speck)
             sage: key = set_fixed_variables('key', 'not_equal', list(range(16)), [0] * 16)
-            sage: trails = sat.find_all_xor_linear_trails_with_fixed_weight(2, fixed_values=[key]) # long
+            sage: trails = sat.find_all_xor_linear_trails_with_fixed_weight(2, fixed_values=[key])
             sage: len(trails) == 8
             True
         """
@@ -167,7 +167,7 @@ class SatXorLinearModel(SatModel):
             for component in solution['components_values']:
                 value_as_hex_string = solution['components_values'][component]['value']
                 value_to_avoid = int(value_as_hex_string, base=16)
-                bit_len = len(value_as_hex_string) * 4
+                bit_len = (len(value_as_hex_string) - 2) * 4
                 minus = ['-' * (value_to_avoid >> i & 1) for i in reversed(range(bit_len))]
                 if CONSTANT in component and component.endswith(INPUT_BIT_ID_SUFFIX):
                     continue

--- a/tests/unit/cipher_modules/models/sat/sat_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_model_test.py
@@ -14,36 +14,44 @@ def test_solve():
     tea = TeaBlockCipher(number_of_rounds=32)
     sat = SatCipherModel(tea)
     sat.build_cipher_model()
-    solution = sat.solve('cipher', solver_name='CRYPTOMINISAT_EXT')
-    assert str(solution['cipher']) == 'tea_p64_k128_o64_r32'
-    assert solution['solver_name'] == 'CRYPTOMINISAT_EXT'
-    assert eval('0x' + solution['components_values']['modadd_0_3']['value']) >= 0
-    assert eval('0x' + solution['components_values']['cipher_output_31_16']['value']) >= 0
+    solution = sat.solve("cipher", solver_name="CRYPTOMINISAT_EXT")
+    assert str(solution["cipher"]) == "tea_p64_k128_o64_r32"
+    assert solution["solver_name"] == "CRYPTOMINISAT_EXT"
+    assert eval(solution["components_values"]["modadd_0_3"]["value"]) >= 0
+    assert eval(solution["components_values"]["cipher_output_31_16"]["value"]) >= 0
     # testing with sage solver
     simon = SimonBlockCipher(number_of_rounds=32)
     sat = SatCipherModel(simon)
     sat.build_cipher_model()
-    solution = sat.solve('cipher', solver_name='cryptominisat')
-    assert str(solution['cipher']) == 'simon_p32_k64_o32_r32'
-    assert solution['solver_name'] == 'cryptominisat'
-    assert eval('0x' + solution['components_values']['rot_0_3']['value']) >= 0
-    assert eval('0x' + solution['components_values']['cipher_output_31_13']['value']) >= 0
+    solution = sat.solve("cipher", solver_name="cryptominisat")
+    assert str(solution["cipher"]) == "simon_p32_k64_o32_r32"
+    assert solution["solver_name"] == "cryptominisat"
+    assert eval(solution["components_values"]["rot_0_3"]["value"]) >= 0
+    assert eval(solution["components_values"]["cipher_output_31_13"]["value"]) >= 0
 
 
 def test_fix_variables_value_constraints():
-    speck = SpeckBlockCipher(number_of_rounds=3)
-    sat = SatModel(speck)
-    fixed_variables = [{'component_id': 'plaintext',
-                        'constraint_type': 'equal',
-                        'bit_positions': [0, 1, 2, 3],
-                        'bit_values': [1, 0, 1, 1]},
-                       {'component_id': 'ciphertext',
-                        'constraint_type': 'not_equal',
-                        'bit_positions': [0, 1, 2, 3],
-                        'bit_values': [1, 1, 1, 0]}]
+    fixed_variables = [
+        {
+            "component_id": "plaintext",
+            "constraint_type": "equal",
+            "bit_positions": [0, 1, 2, 3],
+            "bit_values": [1, 0, 1, 1],
+        },
+        {
+            "component_id": "ciphertext",
+            "constraint_type": "not_equal",
+            "bit_positions": [0, 1, 2, 3],
+            "bit_values": [1, 1, 1, 0],
+        },
+    ]
     assert SatModel.fix_variables_value_constraints(fixed_variables) == [
-        'plaintext_0', '-plaintext_1', 'plaintext_2', 'plaintext_3',
-        '-ciphertext_0 -ciphertext_1 -ciphertext_2 ciphertext_3']
+        "plaintext_0",
+        "-plaintext_1",
+        "plaintext_2",
+        "plaintext_3",
+        "-ciphertext_0 -ciphertext_1 -ciphertext_2 ciphertext_3",
+    ]
 
 
 def test_build_xor_differential_sat_model_from_dictionary():
@@ -51,31 +59,29 @@ def test_build_xor_differential_sat_model_from_dictionary():
     speck = SpeckBlockCipher(number_of_rounds=3)
 
     plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='equal',
+        component_id="plaintext",
+        constraint_type="equal",
         bit_positions=range(32),
-        bit_values=integer_to_bit_list(0x00400000, 32, 'big')
+        bit_values=integer_to_bit_list(0x00400000, 32, "big"),
     )
 
     cipher_output = set_fixed_variables(
-        component_id='cipher_output_2_12',
-        constraint_type='equal',
+        component_id="cipher_output_2_12",
+        constraint_type="equal",
         bit_positions=range(32),
-        bit_values=integer_to_bit_list(0x8000840a, 32, 'big')
+        bit_values=integer_to_bit_list(0x8000840A, 32, "big"),
     )
 
     key = set_fixed_variables(
-        component_id='key',
-        constraint_type='equal',
-        bit_positions=range(64),
-        bit_values=(0,) * 64)
+        component_id="key", constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
 
     for component in speck.get_all_components():
         print(component.id)
         component_model_type = {
             "component_id": component.id,
             "component_object": component,
-            "model_type": "sat_xor_differential_propagation_constraints"
+            "model_type": "sat_xor_differential_propagation_constraints",
         }
         component_model_types.append(component_model_type)
     sat_model = SatCipherModel(speck)
@@ -83,10 +89,8 @@ def test_build_xor_differential_sat_model_from_dictionary():
     variables, constraints = sat_model.weight_constraints(3)
     sat_model._variables_list.extend(variables)
     sat_model._model_constraints.extend(constraints)
-    result = sat_model._solve_with_external_sat_solver(
-        "xor_differential", "PARKISSAT_EXT", ["-c=6"]
-    )
-    assert result['status'] == 'SATISFIABLE'
+    result = sat_model._solve_with_external_sat_solver("xor_differential", "PARKISSAT_EXT", ["-c=6"])
+    assert result["status"] == "SATISFIABLE"
 
 
 def test_build_generic_sat_model_from_dictionary():
@@ -94,56 +98,49 @@ def test_build_generic_sat_model_from_dictionary():
     speck = SpeckBlockCipher(number_of_rounds=3)
 
     plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='equal',
+        component_id="plaintext",
+        constraint_type="equal",
         bit_positions=range(32),
-        bit_values=integer_to_bit_list(0x00400000, 32, 'big')
-    )
-
-    cipher_output = set_fixed_variables(
-        component_id='cipher_output_2_12',
-        constraint_type='equal',
-        bit_positions=range(32),
-        bit_values=integer_to_bit_list(0x8000840a, 32, 'big')
+        bit_values=integer_to_bit_list(0x00400000, 32, "big"),
     )
 
     key = set_fixed_variables(
-        component_id='key',
-        constraint_type='equal',
-        bit_positions=range(64),
-        bit_values=(0,) * 64
+        component_id="key", constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
     )
 
-    xor_2_5 = set_fixed_variables(
-        component_id='xor_2_5',
-        constraint_type='equal',
-        bit_positions=range(16),
-        bit_values=integer_to_bit_list(0x7780, 16, 'big')
-    )
     for component in speck.get_all_components():
         component_model_type = {
             "component_id": component.id,
             "component_object": component,
-            "model_type": "sat_xor_differential_propagation_constraints"
+            "model_type": "sat_xor_differential_propagation_constraints",
         }
         component_model_types.append(component_model_type)
 
     for component_model_type in component_model_types:
-        if component_model_type["component_id"] in ['xor_2_10',
-            'rot_2_9', 'xor_2_8', 'modadd_2_7', 'rot_2_6', 'xor_2_5', 'rot_2_4', 'xor_2_3', 'modadd_2_2', 'rot_2_1',
-            'constant_2_0', 'cipher_output_2_12', 'intermediate_output_2_11'
+        if component_model_type["component_id"] in [
+            "xor_2_10",
+            "rot_2_9",
+            "xor_2_8",
+            "modadd_2_7",
+            "rot_2_6",
+            "xor_2_5",
+            "rot_2_4",
+            "xor_2_3",
+            "modadd_2_2",
+            "rot_2_1",
+            "constant_2_0",
+            "cipher_output_2_12",
+            "intermediate_output_2_11",
         ]:
             component_model_type["model_type"] = "sat_bitwise_deterministic_truncated_xor_differential_constraints"
 
     sat_model = SatCipherModel(speck)
     sat_model.build_generic_sat_model_from_dictionary([plaintext, key], component_model_types)
-    #variables, constraints = sat_model.weight_constraints(3)
-    #sat_model._variables_list.extend(variables)
-    #sat_model._model_constraints.extend(constraints)
-    result = sat_model._solve_with_external_sat_solver(
-        "xor_differential", "KISSAT_EXT", []
-    )
-    assert result['status'] == 'SATISFIABLE'
+    # variables, constraints = sat_model.weight_constraints(3)
+    # sat_model._variables_list.extend(variables)
+    # sat_model._model_constraints.extend(constraints)
+    result = sat_model._solve_with_external_sat_solver("xor_differential", "KISSAT_EXT", [])
+    assert result["status"] == "SATISFIABLE"
 
 
 def test_model_constraints():

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_cipher_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_cipher_model_test.py
@@ -7,15 +7,17 @@ def test_find_missing_bits():
     speck = SpeckBlockCipher(number_of_rounds=22)
     cipher_output_id = speck.get_all_components_ids()[-1]
     sat = SatCipherModel(speck)
-    ciphertext = set_fixed_variables(component_id=cipher_output_id,
-                                     constraint_type='equal',
-                                     bit_positions=range(32),
-                                     bit_values=integer_to_bit_list(0x1234abcd, 32, 'big'))
+    ciphertext = set_fixed_variables(
+        component_id=cipher_output_id,
+        constraint_type="equal",
+        bit_positions=range(32),
+        bit_values=integer_to_bit_list(0x1234ABCD, 32, "big"),
+    )
 
     missing_bits = sat.find_missing_bits(fixed_values=[ciphertext])
 
-    assert str(missing_bits['cipher']) == 'speck_p32_k64_o32_r22'
-    assert missing_bits['model_type'] == 'cipher'
-    assert missing_bits['solver_name'] == 'CRYPTOMINISAT_EXT'
-    assert missing_bits['components_values'][cipher_output_id] == {'value': '1234abcd'}
-    assert missing_bits['status'] == 'SATISFIABLE'
+    assert str(missing_bits["cipher"]) == "speck_p32_k64_o32_r22"
+    assert missing_bits["model_type"] == "cipher"
+    assert missing_bits["solver_name"] == "CRYPTOMINISAT_EXT"
+    assert missing_bits["components_values"][cipher_output_id] == {"value": "0x1234abcd"}
+    assert missing_bits["status"] == "SATISFIABLE"

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
@@ -1,4 +1,6 @@
+import math
 import numpy as np
+
 from claasp.utils.utils import get_k_th_bit
 from claasp.components.modadd_component import MODADD
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
@@ -11,10 +13,10 @@ def count_sequences_of_ones(data, full_window_size):
     for entry in data:
         for key, binary_str in entry.items():
             binary_str = binary_str[2:]  # Remove the '0b' prefix
-            sequences = binary_str.split('0')
+            sequences = binary_str.split("0")
             for seq in sequences:
                 if len(seq) >= full_window_size:
-                    count += (len(seq) - full_window_size + 1)  # Count overlapping sequences
+                    count += len(seq) - full_window_size + 1  # Count overlapping sequences
     return count
 
 
@@ -26,7 +28,7 @@ def binary_list_to_int(binary_list):
 
 
 def extract_bits_from_hex(hex_value, bit_positions):
-    hex_value = int(f'0x{hex_value}', 16)
+    hex_value = int(f"{hex_value}", 16)
     bin_values = []
 
     last_bit_position = bit_positions[-1]
@@ -46,14 +48,14 @@ def compute_modadd_xor(modadd_objects, component_values):
         input_bit_positions = modadd.input_bit_positions
 
         # Get the output value of the MODADD component
-        output_value = component_values[modadd_id]['value']
+        output_value = component_values[modadd_id]["value"]
 
         # Initialize the XOR result with the output value
-        xor_result = int(f'0x{output_value}', 16)
+        xor_result = int(f"{output_value}", 16)
 
         # XOR all input values based on bit positions
         for input_id, bit_positions in zip(input_id_links, input_bit_positions):
-            input_value = component_values[input_id]['value']
+            input_value = component_values[input_id]["value"]
 
             extracted_bits_number = extract_bits_from_hex(input_value, bit_positions)
             xor_result ^= extracted_bits_number
@@ -65,19 +67,18 @@ def compute_modadd_xor(modadd_objects, component_values):
 speck_5rounds = SpeckBlockCipher(number_of_rounds=5)
 speck_4rounds = SpeckBlockCipher(number_of_rounds=4)
 
+
 def test_find_all_xor_differential_trails_with_fixed_weight():
     sat = SatXorDifferentialModel(speck_5rounds)
     sat.set_window_size_weight_pr_vars(1)
 
-    assert int(sat.find_all_xor_differential_trails_with_fixed_weight(
-        9)[0]['total_weight']) == int(9.0)
+    assert int(sat.find_all_xor_differential_trails_with_fixed_weight(9)[0]["total_weight"]) == int(9.0)
 
 
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
     trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10)
-
 
     assert len(trails) == 28
 
@@ -86,25 +87,30 @@ def test_find_lowest_weight_xor_differential_trail():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
     trail = sat.find_lowest_weight_xor_differential_trail()
-    print(trail)
-    assert int(trail['total_weight']) == int(9.0)
+
+    assert int(trail["total_weight"]) == int(9.0)
 
 
 def test_find_one_xor_differential_trail():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=integer_to_bit_list(0, 32, 'big'))
+    plaintext = set_fixed_variables(
+        component_id="plaintext",
+        constraint_type="not_equal",
+        bit_positions=range(32),
+        bit_values=integer_to_bit_list(0, 32, "big"),
+    )
     trail = sat.find_one_xor_differential_trail(fixed_values=[plaintext])
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r5'
-    assert trail['model_type'] == 'xor_differential'
-    assert trail['solver_name'] == 'CRYPTOMINISAT_EXT'
-    assert trail['status'] == 'SATISFIABLE'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r5"
+    assert trail["model_type"] == "xor_differential"
+    assert trail["solver_name"] == "CRYPTOMINISAT_EXT"
+    assert trail["status"] == "SATISFIABLE"
 
     trail = sat.find_one_xor_differential_trail(fixed_values=[plaintext], solver_name="KISSAT_EXT")
-    assert trail['solver_name'] == 'KISSAT_EXT'
-    assert trail['status'] == 'SATISFIABLE'
+
+    assert trail["solver_name"] == "KISSAT_EXT"
+    assert trail["status"] == "SATISFIABLE"
 
 
 def test_find_one_xor_differential_trail_with_fixed_weight():
@@ -113,17 +119,16 @@ def test_find_one_xor_differential_trail_with_fixed_weight():
     sat.set_window_size_heuristic_by_round([0, 0, 0])
     result = sat.find_one_xor_differential_trail_with_fixed_weight(3)
 
-    assert int(result['total_weight']) == int(3.0)
+    assert int(result["total_weight"]) == int(3.0)
 
 
 def test_find_one_xor_differential_trail_with_fixed_weight_with_at_least_one_full_2_window():
     speck = SpeckBlockCipher(number_of_rounds=9)
     sat = SatXorDifferentialModel(speck)
-    sat.set_window_size_heuristic_by_round(
-        [2 for _ in range(9)], number_of_full_windows=1
-    )
+    sat.set_window_size_heuristic_by_round([2 for _ in range(9)], number_of_full_windows=1)
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name="CADICAL_EXT")
-    assert int(result['total_weight']) == int(30.0)
+
+    assert int(result["total_weight"]) == int(30.0)
 
 
 def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_three_full_2_window():
@@ -138,9 +143,10 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_thre
     speck_components = speck.get_all_components()
     modadd_objects = list(filter(lambda obj: isinstance(obj, MODADD), speck_components))
 
-    carry_list = compute_modadd_xor(modadd_objects, result['components_values'])
+    carry_list = compute_modadd_xor(modadd_objects, result["components_values"])
     computed_number_of_full_windows = count_sequences_of_ones(carry_list, window_size)
-    assert int(result['total_weight']) == int(30.0)
+
+    assert int(result["total_weight"]) == int(30.0)
     assert computed_number_of_full_windows == number_of_full_windows
 
 
@@ -151,29 +157,26 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_one_
     window_size = 3
     probability_weight = 34
     sat.set_window_size_heuristic_by_round(
-        [window_size for _ in range(10)], number_of_full_windows=number_of_full_windows, full_window_operator='exactly'
+        [window_size for _ in range(10)], number_of_full_windows=number_of_full_windows, full_window_operator="exactly"
     )
 
     plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='equal',
+        component_id="plaintext",
+        constraint_type="equal",
         bit_positions=range(32),
-        bit_values=[1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0])
-    key = set_fixed_variables(
-        component_id='key',
-        constraint_type='equal',
-        bit_positions=range(64),
-        bit_values=(0,) * 64)
-    sat.build_xor_differential_trail_model(34, fixed_variables=[plaintext, key])
-    result = sat._solve_with_external_sat_solver(
-        "xor_differential", "PARKISSAT_EXT", ["-c=6"]
+        bit_values=[1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
     )
+    key = set_fixed_variables(
+        component_id="key", constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    sat.build_xor_differential_trail_model(34, fixed_variables=[plaintext, key])
+    result = sat._solve_with_external_sat_solver("xor_differential", "PARKISSAT_EXT", ["-c=6"])
     speck_components = speck.get_all_components()
     modadd_objects = list(filter(lambda obj: isinstance(obj, MODADD), speck_components))
-    carry_list = compute_modadd_xor(modadd_objects, result['components_values'])
+    carry_list = compute_modadd_xor(modadd_objects, result["components_values"])
     computed_number_of_full_windows = count_sequences_of_ones(carry_list, window_size)
 
-    assert int(result['total_weight']) == int(probability_weight)
+    assert int(result["total_weight"]) == int(probability_weight)
     assert computed_number_of_full_windows == number_of_full_windows
 
 
@@ -181,34 +184,29 @@ def test_find_one_xor_differential_trail_with_fixed_weight_9_rounds():
     speck = SpeckBlockCipher(number_of_rounds=9)
     sat = SatXorDifferentialModel(speck)
 
-    sat.set_window_size_heuristic_by_round(
-        [2 for _ in range(9)]
-    )
+    sat.set_window_size_heuristic_by_round([2 for _ in range(9)])
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name="CADICAL_EXT")
-    assert int(result['total_weight']) == int(30.0)
+
+    assert int(result["total_weight"]) == int(30.0)
 
 
 def test_find_one_xor_differential_trail_with_fixed_weight_with_at_least_one_full_window_parallel():
     speck = SpeckBlockCipher(number_of_rounds=10)
     sat = SatXorDifferentialModel(speck)
-    sat.set_window_size_heuristic_by_round(
-        [3 for _ in range(10)], number_of_full_windows=1
-    )
+    sat.set_window_size_heuristic_by_round([3 for _ in range(10)], number_of_full_windows=1)
     plaintext = set_fixed_variables(
-        component_id='plaintext',
-        constraint_type='not_equal',
+        component_id="plaintext",
+        constraint_type="not_equal",
         bit_positions=range(32),
-        bit_values=integer_to_bit_list(0, 32, 'big'))
-    key = set_fixed_variables(
-        component_id='key',
-        constraint_type='equal',
-        bit_positions=range(64),
-        bit_values=(0,) * 64)
-    sat.build_xor_differential_trail_model(34, fixed_variables=[plaintext, key])
-    result = sat._solve_with_external_sat_solver(
-        "xor_differential", "PARKISSAT_EXT", ["-c=10"]
+        bit_values=integer_to_bit_list(0, 32, "big"),
     )
-    assert int(result['total_weight']) == int(34.0)
+    key = set_fixed_variables(
+        component_id="key", constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    sat.build_xor_differential_trail_model(34, fixed_variables=[plaintext, key])
+    result = sat._solve_with_external_sat_solver("xor_differential", "PARKISSAT_EXT", ["-c=10"])
+
+    assert int(result["total_weight"]) == int(34.0)
 
 
 def test_find_one_xor_differential_trail_with_fixed_weight_and_window_heuristic_per_component():
@@ -220,7 +218,8 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_window_heuristic_
     sat = SatXorDifferentialModel(speck)
     sat.set_window_size_heuristic_by_component_id(dict_of_window_heuristic_per_component)
     result = sat.find_one_xor_differential_trail_with_fixed_weight(3)
-    assert int(result['total_weight']) == int(3.0)
+
+    assert int(result["total_weight"]) == int(3.0)
 
 
 def test_build_xor_differential_trail_model_fixed_weight_and_parkissat():
@@ -228,15 +227,16 @@ def test_build_xor_differential_trail_model_fixed_weight_and_parkissat():
     speck = SpeckBlockCipher(number_of_rounds=3)
     sat = SatXorDifferentialModel(speck)
     sat.build_xor_differential_trail_model(3)
-    result = sat._solve_with_external_sat_solver("xor_differential", "PARKISSAT_EXT", [f'-c={number_of_cores}'])
+    result = sat._solve_with_external_sat_solver("xor_differential", "PARKISSAT_EXT", [f"-c={number_of_cores}"])
 
-    assert int(result['total_weight']) == int(3.0)
+    assert int(result["total_weight"]) == int(3.0)
 
 
 def repeat_input_difference(input_difference_, number_of_samples_, number_of_bytes_):
-    bytes_array = input_difference_.to_bytes(number_of_bytes_, 'big')
+    bytes_array = input_difference_.to_bytes(number_of_bytes_, "big")
     np_array = np.array(list(bytes_array), dtype=np.uint8)
     column_array = np_array.reshape(-1, 1)
+
     return np.tile(column_array, (1, number_of_samples_))
 
 
@@ -245,7 +245,7 @@ def test_differential_in_related_key_scenario_speck3264():
     number_of_samples = 2**20
     input_difference = 0x00402000
     output_difference = 0x0
-    key_difference = 0x000afa3d0030a000
+    key_difference = 0x000AFA3D0030A000
     input_difference_data = repeat_input_difference(input_difference, number_of_samples, 4)
     output_difference_data = repeat_input_difference(output_difference, number_of_samples, 4)
     key_difference_data = repeat_input_difference(key_difference, number_of_samples, 8)
@@ -256,15 +256,15 @@ def test_differential_in_related_key_scenario_speck3264():
     ciphertext2 = speck_5rounds.evaluate_vectorized([plaintext_data2, key_data ^ key_difference_data])
     rows_all_true = np.all((ciphertext1[0] ^ ciphertext2[0] == output_difference_data.T), axis=1)
     total = np.count_nonzero(rows_all_true)
-    import math
-    total_prob_weight = math.log(total/number_of_samples, 2)
+    total_prob_weight = math.log(total / number_of_samples, 2)
+
     assert 21 > abs(total_prob_weight) > 12
 
 
 def test_differential_in_single_key_scenario_speck3264():
     rng = np.random.default_rng(seed=3)
     number_of_samples = 2**9
-    input_difference = 0x02110a04
+    input_difference = 0x02110A04
     output_difference = 0x81008102
     input_difference_data = repeat_input_difference(input_difference, number_of_samples, 4)
     output_difference_data = repeat_input_difference(output_difference, number_of_samples, 4)
@@ -275,6 +275,6 @@ def test_differential_in_single_key_scenario_speck3264():
     ciphertext2 = speck_4rounds.evaluate_vectorized([plaintext_data2, key_data])
     rows_all_true = np.all((ciphertext1[0] ^ ciphertext2[0] == output_difference_data.T), axis=1)
     total = np.count_nonzero(rows_all_true)
-    import math
-    total_prob_weight = math.log(total/number_of_samples, 2)
+    total_prob_weight = math.log(total / number_of_samples, 2)
+
     assert 19 > abs(total_prob_weight) > 6

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_linear_model_test.py
@@ -1,6 +1,6 @@
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 from claasp.cipher_modules.models.sat.sat_models.sat_xor_linear_model import SatXorLinearModel
+from claasp.cipher_modules.models.utils import set_fixed_variables
 
 
 def test_branch_xor_linear_constraints():
@@ -9,17 +9,18 @@ def test_branch_xor_linear_constraints():
 
     constraints = SatXorLinearModel.branch_xor_linear_constraints(sat.bit_bindings)
 
-    assert constraints[0] == '-plaintext_0_o rot_0_0_0_i'
-    assert constraints[1] == 'plaintext_0_o -rot_0_0_0_i'
-    assert constraints[2] == '-plaintext_1_o rot_0_0_1_i'
-    assert constraints[-3] == 'xor_2_10_14_o -cipher_output_2_12_30_i'
-    assert constraints[-2] == '-xor_2_10_15_o cipher_output_2_12_31_i'
-    assert constraints[-1] == 'xor_2_10_15_o -cipher_output_2_12_31_i'
+    assert constraints[0] == "-plaintext_0_o rot_0_0_0_i"
+    assert constraints[1] == "plaintext_0_o -rot_0_0_0_i"
+    assert constraints[2] == "-plaintext_1_o rot_0_0_1_i"
+    assert constraints[-3] == "xor_2_10_14_o -cipher_output_2_12_30_i"
+    assert constraints[-2] == "-xor_2_10_15_o cipher_output_2_12_31_i"
+    assert constraints[-1] == "xor_2_10_15_o -cipher_output_2_12_31_i"
+
 
 def test_find_all_xor_linear_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=4)
     sat = SatXorLinearModel(speck)
-    key = set_fixed_variables('key', 'not_equal', list(range(16)), [0] * 16)
+    key = set_fixed_variables("key", "not_equal", list(range(16)), [0] * 16)
     trails = sat.find_all_xor_linear_trails_with_weight_at_most(0, 3, fixed_values=[key])
 
     assert len(trails) == 73
@@ -30,7 +31,7 @@ def test_find_lowest_weight_xor_linear_trail():
     sat = SatXorLinearModel(speck)
     trail = sat.find_lowest_weight_xor_linear_trail()
 
-    assert trail['total_weight'] == 3.0
+    assert trail["total_weight"] == 3.0
 
 
 def test_find_one_xor_linear_trail():
@@ -38,10 +39,10 @@ def test_find_one_xor_linear_trail():
     sat = SatXorLinearModel(speck)
     trail = sat.find_one_xor_linear_trail()
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r4'
-    assert trail['model_type'] == 'xor_linear'
-    assert trail['solver_name'] == 'CRYPTOMINISAT_EXT'
-    assert trail['status'] == 'SATISFIABLE'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r4"
+    assert trail["model_type"] == "xor_linear"
+    assert trail["solver_name"] == "CRYPTOMINISAT_EXT"
+    assert trail["status"] == "SATISFIABLE"
 
 
 def test_find_one_xor_linear_trail_with_fixed_weight():
@@ -49,21 +50,30 @@ def test_find_one_xor_linear_trail_with_fixed_weight():
     sat = SatXorLinearModel(speck)
     result = sat.find_one_xor_linear_trail_with_fixed_weight(7)
 
-    assert result['total_weight'] == 7.0
+    assert result["total_weight"] == 7.0
 
 
 def test_fix_variables_value_xor_linear_constraints():
-    speck = SpeckBlockCipher(number_of_rounds=3)
-    sat = SatXorLinearModel(speck)
-    fixed_variables = [{'component_id': 'plaintext',
-                        'constraint_type': 'equal',
-                        'bit_positions': [0, 1, 2, 3],
-                        'bit_values': [1, 0, 1, 1]},
-                       {'component_id': 'ciphertext',
-                        'constraint_type': 'not_equal',
-                        'bit_positions': [0, 1, 2, 3],
-                        'bit_values': [1, 1, 1, 0]}]
+    fixed_variables = [
+        {
+            "component_id": "plaintext",
+            "constraint_type": "equal",
+            "bit_positions": [0, 1, 2, 3],
+            "bit_values": [1, 0, 1, 1],
+        },
+        {
+            "component_id": "ciphertext",
+            "constraint_type": "not_equal",
+            "bit_positions": [0, 1, 2, 3],
+            "bit_values": [1, 1, 1, 0],
+        },
+    ]
     constraints = SatXorLinearModel.fix_variables_value_xor_linear_constraints(fixed_variables)
 
-    assert constraints == ['plaintext_0_o', '-plaintext_1_o', 'plaintext_2_o', 'plaintext_3_o',
-                           '-ciphertext_0_o -ciphertext_1_o -ciphertext_2_o ciphertext_3_o']
+    assert constraints == [
+        "plaintext_0_o",
+        "-plaintext_1_o",
+        "plaintext_2_o",
+        "plaintext_3_o",
+        "-ciphertext_0_o -ciphertext_1_o -ciphertext_2_o ciphertext_3_o",
+    ]

--- a/tests/unit/components/fsr_component_test.py
+++ b/tests/unit/components/fsr_component_test.py
@@ -5,22 +5,23 @@ from claasp.ciphers.stream_ciphers.snow3g_stream_cipher import Snow3GStreamCiphe
 
 
 def test_fsr_algebraic_polynomials():
-
     a51 = A51StreamCipher()
     fsr_component = a51.get_component_from_id("fsr_1_0")
     algebraic = AlgebraicModel(a51)
     A = fsr_component.algebraic_polynomials(algebraic)
-    assert str(A[0]) == 'fsr_1_0_x1*fsr_1_0_x30*fsr_1_0_x53 + fsr_1_0_x1*fsr_1_0_x10*fsr_1_0_x53 + fsr_1_0_x1*fsr_1_0_x10*fsr_1_0_x30 + fsr_1_0_x0*fsr_1_0_x30*fsr_1_0_x53 + fsr_1_0_x0*fsr_1_0_x10*fsr_1_0_x53 + fsr_1_0_x0*fsr_1_0_x10*fsr_1_0_x30 + fsr_1_0_x1*fsr_1_0_x10 + fsr_1_0_x0*fsr_1_0_x10 + fsr_1_0_y0 + fsr_1_0_x1'
+    assert (
+        str(A[0])
+        == "fsr_1_0_x1*fsr_1_0_x30*fsr_1_0_x53 + fsr_1_0_x1*fsr_1_0_x10*fsr_1_0_x53 + fsr_1_0_x1*fsr_1_0_x10*fsr_1_0_x30 + fsr_1_0_x0*fsr_1_0_x30*fsr_1_0_x53 + fsr_1_0_x0*fsr_1_0_x10*fsr_1_0_x53 + fsr_1_0_x0*fsr_1_0_x10*fsr_1_0_x30 + fsr_1_0_x1*fsr_1_0_x10 + fsr_1_0_x0*fsr_1_0_x10 + fsr_1_0_y0 + fsr_1_0_x1"
+    )
 
     trivium = TriviumStreamCipher(number_of_initialization_clocks=1, keystream_bit_len=1)
     fsr_component = trivium.get_component_from_id("fsr_0_2")
     algebraic = AlgebraicModel(trivium)
     T = fsr_component.algebraic_polynomials(algebraic)
-    assert str(T[92])=='fsr_0_2_x178*fsr_0_2_x179 + fsr_0_2_y92 + fsr_0_2_x222 + fsr_0_2_x177 + fsr_0_2_x24'
-
+    assert str(T[92]) == "fsr_0_2_x178*fsr_0_2_x179 + fsr_0_2_y92 + fsr_0_2_x222 + fsr_0_2_x177 + fsr_0_2_x24"
 
     snow = Snow3GStreamCipher(number_of_initialization_clocks=1, keystream_word_size=1)
     fsr_component = snow.get_component_from_id("fsr_0_714")
     algebraic = AlgebraicModel(snow)
     S = fsr_component.algebraic_polynomials(algebraic)
-    assert str(S[480]) == 'fsr_0_714_y480 + fsr_0_714_x352 + fsr_0_714_x64 + fsr_0_714_x0'
+    assert str(S[480]) == "fsr_0_714_y480 + fsr_0_714_x352 + fsr_0_714_x64 + fsr_0_714_x0"


### PR DESCRIPTION
The new hex value representation includes the `'0x'`
Some SAT tests where failing due to this.