### PR TITLE
Reorganise Dockerfile

### DIFF
--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -644,11 +644,8 @@ class MznModel:
           * 'deterministic_truncated_xor_differential'
           * 'deterministic_truncated_xor_differential_one_solution'
           * 'impossible_xor_differential'
-        - ``solver_name`` -- **string** (default: `None`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `None`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
         - ``num_of_processors`` -- **integer**; the number of processors to be used
         - ``timelimit`` -- **integer**; time limit to output a result
 
@@ -808,7 +805,15 @@ class MznModel:
 
         return result
 
-    def solver_names(self, verbose = False):
+    def solver_names(self, verbose: bool = False) -> None:
+        """
+        Print the available MiniZinc solvers.
+
+        INPUT:
+
+        - ``verbose`` -- **bool**; beside the solver name, it will be printed the brand name.
+
+        """
         if not verbose:
             print('Internal CP solvers:')
             print('solver brand name | solver name')

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -165,11 +165,8 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
 
         - ``number_of_rounds`` -- **integer** (default: `None`); number of rounds
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -225,11 +222,8 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
 
         - ``number_of_rounds`` -- **integer**; number of rounds
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `None`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `None`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -277,11 +271,8 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
 
         - ``number_of_rounds`` -- **integer** (default: `None`); number of rounds
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -210,11 +210,8 @@ class MznXorDifferentialModel(MznModel):
 
         - ``fixed_weight`` -- **integer**; the weight to be fixed
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -264,11 +261,8 @@ class MznXorDifferentialModel(MznModel):
         - ``min_weight`` -- **integer**; the weight from which to start the search
         - ``max_weight`` -- **integer** (default: 64); the weight at which the search stops
         - ``fixed_values`` -- **list**  (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -336,11 +330,8 @@ class MznXorDifferentialModel(MznModel):
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -395,11 +386,8 @@ class MznXorDifferentialModel(MznModel):
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -447,11 +435,8 @@ class MznXorDifferentialModel(MznModel):
 
         - ``fixed_weight`` -- **integer**; the value to which the weight is fixed, if non-negative
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -86,13 +86,8 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(MznXorDifferentialModel,
         - ``fixed_weight`` -- **integer**; the weight to be fixed
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
         - ``first_step_solver_name`` -- **string** (default: `Chuffed`); the name of the solver for the number of active sboxes search
-        - ``second_step_solver_name`` -- **string** (default: `Chuffed`); the name of the solver for the differential trails search. Available values for both the solver names are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
-          * ``'Xor'``
-          * ``'Choco-solver'``
+        - ``second_step_solver_name`` -- **string** (default: `Chuffed`); the name of the solver for the differential trails search.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -125,11 +120,8 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(MznXorDifferentialModel,
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -161,11 +153,8 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(MznXorDifferentialModel,
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -196,11 +185,8 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(MznXorDifferentialModel,
 
         - ``fixed_weight`` -- **integer**; the value to which the weight is fixed, if non-negative
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -427,11 +413,8 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(MznXorDifferentialModel,
 
             * 'xor_differential_first_step'
             * 'xor_differential_first_step_find_all_solutions'
-        - ``solver_name`` -- **string** (default: `None`); the name of the solver. Available values are:
-
-            * ``'Chuffed'``
-            * ``'Gecode'``
-            * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `None`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -225,11 +225,8 @@ class MznXorLinearModel(MznModel):
 
         - ``fixed_weight`` -- **integer**; the weight to be fixed
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -276,11 +273,8 @@ class MznXorLinearModel(MznModel):
         - ``min_weight`` -- **integer**; the weight from which to start the search
         - ``max_weight`` -- **integer** (default: `64`); the weight at which the search stops
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -331,11 +325,8 @@ class MznXorLinearModel(MznModel):
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); they can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -379,11 +370,8 @@ class MznXorLinearModel(MznModel):
         INPUT:
 
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
 
         EXAMPLES::
 
@@ -424,12 +412,8 @@ class MznXorLinearModel(MznModel):
 
         - ``fixed_weight`` -- **integer**; the value to which the weight is fixed, if non-negative
         - ``fixed_values`` -- **list** (default: `[]`); can be created using ``set_fixed_variables`` method
-        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver. Available values are:
-
-          * ``'Chuffed'``
-          * ``'Gecode'``
-          * ``'COIN-BC'``
-
+        - ``solver_name`` -- **string** (default: `Chuffed`); the name of the solver.
+          See also :meth:`MznModel.solver_names`.
         EXAMPLES::
 
             sage: from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_linear_model import MznXorLinearModel

--- a/claasp/cipher_modules/models/cp/solvers.py
+++ b/claasp/cipher_modules/models/cp/solvers.py
@@ -26,7 +26,6 @@ CP_SOLVERS_INTERNAL = [{'solver_brand_name': 'Choco', 'solver_name': 'choco'},
                        {'solver_brand_name': 'COIN-BC', 'solver_name': 'coin-bc'},
                        {'solver_brand_name': 'IBM ILOG CPLEX', 'solver_name': 'cplex'},
                        {'solver_brand_name': 'MiniZinc findMUS', 'solver_name': 'findmus'},
-                       {'solver_brand_name': 'Gecode', 'solver_name': 'gecode'},
                        {'solver_brand_name': 'MiniZinc Globalizer', 'solver_name': 'globalizer'},
                        {'solver_brand_name': 'Gurobi Optimizer', 'solver_name': 'gurobi'},
                        {'solver_brand_name': 'SCIP', 'solver_name': 'scip'},
@@ -47,20 +46,6 @@ CP_SOLVERS_EXTERNAL = [
                 'format': ['executable', 'options', 'solver', 'input_file', 'output_file'],
             },
         },
-    },
-    {
-        'solver_brand_name': 'Gecode',
-        'solver_name': 'gecode', # keyword to call the solver  
-        'keywords': {
-            'command': {
-                'executable': ['minizinc'],
-                'options': ['--solver-statistics'],
-                'input_file': [],
-                'output_file': [],
-                'solver': ['--solver', 'Gecode'],
-                'format': ['executable', 'options', 'solver', 'input_file', 'output_file'],
-            },
-        },    
     },
     {
         'solver_brand_name': 'OR Tools',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN wget https://github.com/ERGO-Code/HiGHS/releases/download/v1.10.0/source-arc
     && rm source-archive.tar.gz \
     && cd HiGHS \
     && cmake -S. -B build \
-    && cmake --build build --parallel
+    && cmake --build build
 
 ENV PATH="${PATH}:/opt/HiGHS/build/bin"
 
@@ -88,6 +88,7 @@ ENV PATH="${PATH}:/opt/scip-803/build/bin"
 
 # Installing SageMath tools
 RUN sage -pip install bitstring==4.0.1 \
+  kaleido==1.0.0 \
   keras==2.13.1 \
   minizinc==0.5.0 \
   pandas==1.5.2 \
@@ -100,6 +101,7 @@ RUN sage -pip install bitstring==4.0.1 \
   sphinx==5.0.0 \
   sphinxcontrib-bibtex==2.5.0 \
   tensorflow==2.13.0 \
+  plotly==6.2.0 \
   pytest==7.2.1 \
   pytest-cov==4.0.0 \
   pytest-xdist==3.2.0 \
@@ -122,16 +124,82 @@ RUN cd /opt/sts-2.1.2/sts-2.1.2 \
     && ln -s /usr/local/bin/sts-2.1.2/assess /usr/local/bin/niststs \
     && rm /opt/sts-2_1_2.zip
 
+# Installing Minizinc
+RUN wget https://github.com/MiniZinc/libminizinc/archive/refs/tags/2.9.3.tar.gz \
+    && tar -xf 2.9.3.tar.gz \
+    && rm 2.9.3.tar.gz
+
+RUN cd libminizinc-2.9.3 \
+    && cmake -B build -S . \
+    && cmake --build build \
+    && cmake --build build --target install
+
+# Installing Chuffed
+RUN wget https://github.com/chuffed/chuffed/archive/refs/tags/0.13.2.tar.gz \
+    && tar -xf 0.13.2.tar.gz \
+    && rm 0.13.2.tar.gz
+
+RUN cd chuffed-0.13.2 \
+    && cmake -B build -S . \
+    && cmake --build build \
+    && cmake --build build --target install
+
+# Installing OR-Tools
+RUN wget https://github.com/google/or-tools/releases/download/v9.2/or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz \
+    && tar -xf or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz \
+    && rm or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz
+
+RUN mv or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972/bin/* /usr/local/bin \
+    && mkdir /usr/local/lib/or-tools \
+    && mv or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972/lib/* /usr/local/lib/or-tools \
+    && mkdir /usr/local/share/minizinc/or-tools \
+    && mv or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972/share/minizinc/* /usr/local/share/minizinc/or-tools \
+    && echo "/usr/local/lib/or-tools" | sudo tee /etc/ld.so.conf.d/or-tools.conf \
+    && ldconfig
+
+RUN echo '\
+{\n\
+  "name": "Xor",\n\
+  "version": "9.2",\n\
+  "id": "Xor",\n\
+  "executable": "/usr/local/bin/fzn-or-tools",\n\
+  "mznlib": "/usr/local/share/minizinc/or-tools",\n\
+  "stdFlags": ["-a", "-p", "-r", "-f"],\n\
+  "needsPathsFile": false\n\
+}\
+' > /usr/local/share/minizinc/solvers/Xor.msc
+
+# Installing Choco
 WORKDIR /opt
 
-# Installing Minizinc
-RUN wget https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.4/MiniZincIDE-2.6.4-bundle-linux-x86_64.tgz \
-    && tar -xf MiniZincIDE-2.6.4-bundle-linux-x86_64.tgz \
-    && rm MiniZincIDE-2.6.4-bundle-linux-x86_64.tgz
+RUN wget https://github.com/chocoteam/choco-solver/archive/refs/tags/v4.10.18.tar.gz \
+    && tar -xf v4.10.18.tar.gz \
+    && rm v4.10.18.tar.gz
 
-ENV PATH="/opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/bin:${PATH}"
+RUN mv choco-solver-4.10.18/parsers/src/main/minizinc/fzn-choco* /usr/local/bin \
+    && mkdir /usr/local/share/minizinc/choco \
+    && mv choco-solver-4.10.18/parsers/src/main/minizinc/mzn_lib/* /usr/local/share/minizinc/choco
+
+RUN wget https://github.com/chocoteam/choco-solver/releases/download/v4.10.18/choco-solver-4.10.18-light.jar
+
+# Update files
+RUN sed -i 's&JAR_FILE=.*&JAR_FILE="/opt/choco-solver-4.10.18-light.jar"&g' /usr/local/bin/fzn-choco.py
+
+RUN echo '\
+{\n\
+  "name": "Choco-solver",\n\
+  "version": "4.10.18",\n\
+  "id": "org.choco.choco",\n\
+  "executable": "/usr/local/bin/fzn-choco.sh",\n\
+  "mznlib": "/usr/local/share/minizinc/choco",\n\
+  "tags": ["cp","int"],\n\
+  "stdFlags": ["-a","-n","-s","-p","-r","-f","-t","--cp-profiler"]\n\
+}\
+' > /usr/local/share/minizinc/solvers/choco.msc
 
 # Installing CryptoMiniSat
+WORKDIR /opt
+
 RUN wget https://github.com/msoos/cryptominisat/archive/refs/tags/5.11.4.tar.gz \
     && tar -xf 5.11.4.tar.gz \
     && rm 5.11.4.tar.gz
@@ -231,11 +299,11 @@ RUN cd cadical-rel-1.5.3 \
     && ./configure \
     && make
 
-WORKDIR /opt
-
 ENV PATH="/opt/cadical-rel-1.5.3/build:${PATH}"
 
-# Installing Yices-Sat
+# Installing Yices
+WORKDIR /opt
+
 RUN wget https://yices.csl.sri.com/releases/2.6.4/yices-2.6.4-x86_64-pc-linux-gnu.tar.gz  \
     && tar -xf yices-2.6.4-x86_64-pc-linux-gnu.tar.gz \
     && rm yices-2.6.4-x86_64-pc-linux-gnu.tar.gz
@@ -243,89 +311,17 @@ RUN wget https://yices.csl.sri.com/releases/2.6.4/yices-2.6.4-x86_64-pc-linux-gn
 RUN cd yices-2.6.4 \
     && ./install-yices
 
-WORKDIR /opt
-
-# Installing or-tools
-RUN wget https://github.com/google/or-tools/releases/download/v9.2/or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz \
-    && tar -xf or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz \
-    && rm or-tools_amd64_flatzinc_ubuntu-21.10_v9.2.9972.tar.gz
-
-RUN mkdir -p /opt/minizinc/solvers/s
-
-RUN echo '\
-{ \n\
-"executable": "/opt/or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972/bin/fzn-or-tools", \n\
-"id": "Xor", \n\
-"isGUIApplication": false, \n\
-"mznlib": "/opt/or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972/lib", \n\
-"mznlibVersion": 1, \n\
-"name": "Xor", \n\
-"needsMznExecutable": false, \n\
-"needsPathsFile": false, \n\
-"needsSolns2Out": true, \n\
-"needsStdlibDir": false, \n\
-"stdFlags": [ \n\
-    "-a", \n\
-    "-p", \n\
-    "-r", \n\
-    "-f" \n\
-], \n\
-"supportsFzn": true, \n\
-"supportsMzn": false, \n\
-"supportsNL": false, \n\
-"version": "8.2" } \
-' > /opt/minizinc/solvers/Xor.msc
-
-# Installing Choco
-
-# Copy Choco's executable from the previous stage across
-RUN wget https://github.com/chocoteam/choco-solver/archive/refs/tags/v4.10.12.tar.gz \
-    && tar -xf v4.10.12.tar.gz \
-    && rm v4.10.12.tar.gz
-
-RUN wget https://github.com/chocoteam/choco-solver/releases/download/v4.10.12/choco-solver-4.10.12.jar
-
-# Update files
-RUN sed -i 's&CHOCO_JAR=.*&CHOCO_JAR=/opt/choco-solver-4.10.12.jar&g' /opt/choco-solver-4.10.12/parsers/src/main/minizinc/fzn-choco && \
-    sed -i 's&"mznlib".*&"mznlib":"/opt/choco-solver-4.10.12/parsers/src/main/minizinc/mzn-lib/",&g' /opt/choco-solver-4.10.12/parsers/src/main/minizinc/choco.msc && \
-    sed -i 's&"executable".*&"executable":"/opt/choco-solver-4.10.12/parsers/src/main/minizinc/fzn-choco",&g' /opt/choco-solver-4.10.12/parsers/src/main/minizinc/choco.msc
-
-ENV PATH="/opt/choco-solver-4.10.12:${PATH}"
-
-RUN echo '\
-{ \n\
-  "id": "org.choco.choco", \n\
-  "name": "Choco-solver", \n\
-  "description": "Choco FlatZinc executable", \n\
-  "version": "4.10.12", \n\
-  "mznlib": "/opt/choco-solver-4.10.12/parsers/src/main/minizinc/mzn_lib", \n\
-  "executable": "/opt/choco-solver-4.10.12/parsers/src/main/minizinc/fzn-choco", \n\
-  "tags": ["cp","int"], \n\
-  "stdFlags": ["-a","-f","-n","-p","-r","-s","-t"], \n\
-  "supportsMzn": false, \n\
-  "supportsFzn": true, \n\
-  "needsSolns2Out": true, \n\
-  "needsMznExecutable": false, \n\
-  "needsStdlibDir": false, \n\
-  "isGUIApplication": false \n\
-} \
-' > /opt/minizinc/solvers/choco.msc
-
-ENV MZN_SOLVER_PATH="/opt/minizinc/solvers"
-
-ENV LD_LIBRARY_PATH="/opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/lib:${LD_LIBRARY_PATH}"
-
-RUN rm -rf /opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/lib/liblzma.so.5
-RUN rm -rf /opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/lib/libselinux.so.1
-RUN rm -rf /opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/lib/libsystemd.so.0
-RUN rm -rf /opt/MiniZincIDE-2.6.4-bundle-linux-x86_64/lib/libcrypt.so.1
-
-RUN sage -pip install plotly -U kaleido
 COPY required_dependencies/sage_numerical_backends_gurobi-9.3.1.tar.gz /opt/
 RUN cd /opt/ && sage -pip install sage_numerical_backends_gurobi-9.3.1.tar.gz
 
 RUN apt-get install -y coinor-cbc coinor-libcbc-dev
 RUN sage -python -m pip install sage-numerical-backends-coin==9.0b12
+
+# clean image
+RUN rm -r /opt/choco-solver-4.10.18
+RUN rm -r /opt/chuffed-0.13.2
+RUN rm -r /opt/libminizinc-2.9.3
+RUN rm -r /opt/or-tools_flatzinc_Ubuntu-21.10-64bit_v9.2.9972
 
 FROM claasp-base AS claasp-lib
 

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model_test.py
@@ -1,147 +1,192 @@
+from claasp.cipher_modules.models.cp.mzn_models.mzn_impossible_xor_differential_model import (
+    MznImpossibleXorDifferentialModel,
+)
+from claasp.cipher_modules.models.utils import set_fixed_variables
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
-from claasp.cipher_modules.models.cp.mzn_models.mzn_impossible_xor_differential_model import \
-    MznImpossibleXorDifferentialModel
+from claasp.name_mappings import INPUT_PLAINTEXT, INPUT_KEY
 
 
 def test_build_impossible_xor_differential_trail_with_extensions_model():
     speck = SpeckBlockCipher(number_of_rounds=6)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    fixed_variables = [set_fixed_variables('key', 'equal', range(64), integer_to_bit_list(0, 64, 'little'))]
-    mzn.build_impossible_xor_differential_trail_with_extensions_model(number_of_rounds=6, fixed_variables=fixed_variables, initial_round=2, middle_round=3, final_round=5, intermediate_components=False)
+    fixed_variables = [set_fixed_variables(INPUT_KEY, "equal", range(64), (0,) * 64)]
+    mzn.build_impossible_xor_differential_trail_with_extensions_model(
+        number_of_rounds=6,
+        fixed_variables=fixed_variables,
+        initial_round=2,
+        middle_round=3,
+        final_round=5,
+        intermediate_components=False,
+    )
 
     assert len(mzn.model_constraints) == 1764
-    assert mzn.model_constraints[99] == 'array[0..31] of var 0..2: inverse_plaintext;'
-    assert mzn.model_constraints[3] == 'array[0..63] of var 0..2: key;'
-    assert mzn.model_constraints[39] == 'array[0..31] of var 0..2: cipher_output_5_12;'
+    assert mzn.model_constraints[99] == "array[0..31] of var 0..2: inverse_plaintext;"
+    assert mzn.model_constraints[3] == "array[0..63] of var 0..2: key;"
+    assert mzn.model_constraints[39] == "array[0..31] of var 0..2: cipher_output_5_12;"
 
 
 def test_build_impossible_xor_differential_trail_model():
     speck = SpeckBlockCipher(number_of_rounds=5)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    fixed_variables = [set_fixed_variables('key', 'equal', range(64), integer_to_bit_list(0, 64, 'little'))]
-    mzn.build_impossible_xor_differential_trail_model(number_of_rounds=5, fixed_variables=fixed_variables, middle_round=3)
+    fixed_variables = [set_fixed_variables(INPUT_KEY, "equal", range(64), (0,) * 64)]
+    mzn.build_impossible_xor_differential_trail_model(
+        number_of_rounds=5, fixed_variables=fixed_variables, middle_round=3
+    )
 
     assert len(mzn.model_constraints) == 1661
-    assert mzn.model_constraints[2] == 'array[0..31] of var 0..2: plaintext;'
-    assert mzn.model_constraints[3] == 'array[0..63] of var 0..2: key;'
-    assert mzn.model_constraints[4] == 'array[0..31] of var 0..2: inverse_cipher_output_4_12;'
+    assert mzn.model_constraints[2] == "array[0..31] of var 0..2: plaintext;"
+    assert mzn.model_constraints[3] == "array[0..63] of var 0..2: key;"
+    assert mzn.model_constraints[4] == "array[0..31] of var 0..2: inverse_cipher_output_4_12;"
 
 
 def test_find_all_impossible_xor_differential_trails():
     speck = SpeckBlockCipher(number_of_rounds=7)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    ciphertext = set_fixed_variables(component_id='inverse_' + speck.get_all_components_ids()[-1], constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    key = set_fixed_variables('key', constraint_type='equal',
-                                    bit_positions=range(64), bit_values=[0] * 64)
-    trail = mzn.find_all_impossible_xor_differential_trails(7, [plaintext, ciphertext, key], 'Chuffed', 1, 3, 7, False, solve_external = True)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    key = set_fixed_variables(
+        component_id=INPUT_KEY, constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    ciphertext_id = "inverse_" + speck.get_all_components_ids()[-1]
+    ciphertext = set_fixed_variables(
+        component_id=ciphertext_id, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    trail = mzn.find_all_impossible_xor_differential_trails(
+        7, [plaintext, ciphertext, key], "Chuffed", 1, 3, 7, False, solve_external=True
+    )
 
-    assert trail[0]['status'] == 'UNSATISFIABLE'
+    assert trail[0]["status"] == "UNSATISFIABLE"
 
 
 def test_find_lowest_complexity_impossible_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=6)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    ciphertext = set_fixed_variables(component_id='inverse_' + speck.get_all_components_ids()[-1], constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    key = set_fixed_variables('key', constraint_type='equal',
-                                    bit_positions=range(64), bit_values=[0] * 64)
-    trail = mzn.find_lowest_complexity_impossible_xor_differential_trail(6, [plaintext, ciphertext, key], 'Chuffed', 1, 3, 6, True, solve_external = True)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    key = set_fixed_variables(
+        component_id=INPUT_KEY, constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    ciphertext_id = "inverse_" + speck.get_all_components_ids()[-1]
+    ciphertext = set_fixed_variables(
+        component_id=ciphertext_id, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    trail = mzn.find_lowest_complexity_impossible_xor_differential_trail(
+        6, [plaintext, ciphertext, key], "Chuffed", 1, 3, 6, True, solve_external=True
+    )
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r6'
-    assert trail['model_type'] == 'impossible_xor_differential_one_solution'
-    assert trail['solver_name'] == 'Chuffed'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r6"
+    assert trail["model_type"] == "impossible_xor_differential_one_solution"
+    assert trail["solver_name"] == "Chuffed"
 
-    assert trail['components_values']['plaintext']['value'] == '00000000010000000000000000000000'
-    assert trail['components_values']['inverse_cipher_output_5_12']['value'] == '10000000000000001000000000000010'
-    
-    assert trail['components_values']['xor_1_10']['value'] == '2222222100000010'
-    assert trail['components_values']['inverse_rot_2_9']['value'] == '2222222210022222'
+    assert trail["components_values"][INPUT_PLAINTEXT]["value"] == "00000000010000000000000000000000"
+    assert trail["components_values"]["inverse_cipher_output_5_12"]["value"] == "10000000000000001000000000000010"
+
+    assert trail["components_values"]["xor_1_10"]["value"] == "2222222100000010"
+    assert trail["components_values"]["inverse_rot_2_9"]["value"] == "2222222210022222"
 
 
 def test_find_one_impossible_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=6)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    ciphertext = set_fixed_variables(component_id='inverse_' + speck.get_all_components_ids()[-1], constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    key = set_fixed_variables('key', constraint_type='equal',
-                                    bit_positions=range(64), bit_values=[0] * 64)
-    trail = mzn.find_one_impossible_xor_differential_trail(fixed_values=[plaintext, ciphertext, key], solver_name='Chuffed', middle_round=3, intermediate_components=True, solve_external = True)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    key = set_fixed_variables(
+        component_id=INPUT_KEY, constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    ciphertext_id = "inverse_" + speck.get_all_components_ids()[-1]
+    ciphertext = set_fixed_variables(
+        component_id=ciphertext_id, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    trail = mzn.find_one_impossible_xor_differential_trail(
+        fixed_values=[plaintext, ciphertext, key],
+        solver_name="Chuffed",
+        middle_round=3,
+        intermediate_components=True,
+        solve_external=True,
+    )
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r6'
-    assert trail['model_type'] == 'impossible_xor_differential_one_solution'
-    assert trail['solver_name'] == 'Chuffed'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r6"
+    assert trail["model_type"] == "impossible_xor_differential_one_solution"
+    assert trail["solver_name"] == "Chuffed"
 
-    assert trail['components_values']['plaintext']['value'] == '00000000021000000010000000000000'
-    assert trail['components_values']['inverse_cipher_output_5_12']['value'] == '10000000000000001000000000000010'
-    
-    assert trail['components_values']['xor_1_10']['value'] == '2222222221000022'
-    assert trail['components_values']['inverse_rot_2_9']['value'] == '2222222210022222'
+    assert trail["components_values"][INPUT_PLAINTEXT]["value"] != "0" * 32
+    assert trail["components_values"]["inverse_cipher_output_5_12"]["value"] != "0" * 32
 
 
 def test_find_one_impossible_xor_differential_trail_with_initial_and_final_round():
     speck = SpeckBlockCipher(number_of_rounds=6)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    ciphertext = set_fixed_variables(component_id='inverse_' + speck.get_all_components_ids()[-1],
-                                     constraint_type='not_equal',
-                                     bit_positions=range(32), bit_values=[0] * 32)
-    key = set_fixed_variables('key', constraint_type='equal',
-                              bit_positions=range(64), bit_values=[0] * 64)
-    trail = mzn.find_one_impossible_xor_differential_trail(fixed_values=[plaintext, ciphertext, key],
-                                                           solver_name='Chuffed', initial_round=1, final_round=6,
-                                                           intermediate_components=True, solve_external=True)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    key = set_fixed_variables(
+        component_id=INPUT_KEY, constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    ciphertext_id = "inverse_" + speck.get_all_components_ids()[-1]
+    ciphertext = set_fixed_variables(
+        component_id=ciphertext_id, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    trail = mzn.find_one_impossible_xor_differential_trail(
+        fixed_values=[plaintext, ciphertext, key],
+        solver_name="Chuffed",
+        initial_round=1,
+        final_round=6,
+        intermediate_components=True,
+        solve_external=True,
+    )
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r6'
-    assert trail['model_type'] == 'impossible_xor_differential_one_solution'
-    assert trail['solver_name'] == 'Chuffed'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r6"
+    assert trail["model_type"] == "impossible_xor_differential_one_solution"
+    assert trail["solver_name"] == "Chuffed"
 
-    assert trail['components_values']['plaintext']['value'] == '00000000022200000021000000000000'
-    assert trail['components_values']['inverse_cipher_output_5_12']['value'] == '10000000000000001000000000000010'
+    assert trail["components_values"][INPUT_PLAINTEXT]["value"] == "00000000022200000021000000000000"
+    assert trail["components_values"]["inverse_cipher_output_5_12"]["value"] == "10000000000000001000000000000010"
 
-    assert trail['components_values']['xor_1_10']['value'] == '2222222222100022'
-    assert trail['components_values']['inverse_rot_2_9']['value'] == '2222222210022222'
+    assert trail["components_values"]["xor_1_10"]["value"] == "2222222222100022"
+    assert trail["components_values"]["inverse_rot_2_9"]["value"] == "2222222210022222"
 
 
 def test_find_one_impossible_xor_differential_trail_with_extensions():
     speck = SpeckBlockCipher(number_of_rounds=6)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    plaintext = set_fixed_variables(component_id='inverse_plaintext', constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    ciphertext = set_fixed_variables(component_id=speck.get_all_components_ids()[-1], constraint_type='not_equal',
-                                    bit_positions=range(32), bit_values=[0] * 32)
-    key = set_fixed_variables('key', constraint_type='equal',
-                                    bit_positions=range(64), bit_values=[0] * 64)
-    trail = mzn.find_one_impossible_xor_differential_trail_with_extensions(6, [plaintext, ciphertext, key], 'Chuffed', 2, 3, 5, True, solve_external = True)
+    plaintext = set_fixed_variables(
+        component_id="inverse_plaintext", constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    key = set_fixed_variables(
+        component_id=INPUT_KEY, constraint_type="equal", bit_positions=range(64), bit_values=(0,) * 64
+    )
+    ciphertext_id = speck.get_all_components_ids()[-1]
+    ciphertext = set_fixed_variables(
+        component_id=ciphertext_id, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
+    )
+    trail = mzn.find_one_impossible_xor_differential_trail_with_extensions(
+        6, [plaintext, ciphertext, key], "Chuffed", 2, 3, 5, True, solve_external=True
+    )
 
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r6'
-    assert trail['model_type'] == 'impossible_xor_differential_one_solution'
-    assert trail['solver_name'] == 'Chuffed'
-    
-    assert trail['components_values']['inverse_plaintext']['value'] == '22222220022222220000100000022200'
-    assert trail['components_values']['inverse_cipher_output_5_12']['value'] == '22222210000000002222221000000011'
-    
-    assert trail['components_values']['intermediate_output_2_12']['value'] == '22222222220000002222222222000022'
-    assert trail['components_values']['inverse_intermediate_output_2_12']['value'] == '22222222222222222222222222122222'
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r6"
+    assert trail["model_type"] == "impossible_xor_differential_one_solution"
+    assert trail["solver_name"] == "Chuffed"
+
+    assert trail["components_values"]["inverse_plaintext"]["value"] != "0" * 32
+    assert trail["components_values"]["inverse_cipher_output_5_12"]["value"] != "0" * 32
 
 
 def test_find_one_impossible_xor_differential_cluster():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
     mzn = MznImpossibleXorDifferentialModel(speck)
-    fixed_variables = [set_fixed_variables('key', 'equal', range(64), integer_to_bit_list(0, 64, 'little')),
-                       set_fixed_variables('plaintext', 'not_equal', range(32), integer_to_bit_list(0, 32, 'little')),
-                       set_fixed_variables('inverse_cipher_output_3_12', 'not_equal', range(32), integer_to_bit_list(0, 32, 'little'))]
-    trail = mzn.find_one_impossible_xor_differential_cluster(4, fixed_variables, 'Chuffed', 1, 3, 4, intermediate_components=False)
-    assert str(trail['cipher']) == 'speck_p32_k64_o32_r4'
-    assert trail['model_type'] == 'impossible_xor_differential_one_solution'
-    assert trail['solver_name'] == 'Chuffed'
-    assert trail['components_values']['key']['value'] == '0000000000000000000000000000000000000000000000000000000000000000'
-    assert trail['status'] == 'SATISFIABLE'
+    fixed_variables = [
+        set_fixed_variables(INPUT_KEY, "equal", range(64), (0,) * 64),
+        set_fixed_variables(INPUT_PLAINTEXT, "not_equal", range(32), (0,) * 32),
+        set_fixed_variables("inverse_cipher_output_3_12", "not_equal", range(32), (0,) * 32),
+    ]
+    trail = mzn.find_one_impossible_xor_differential_cluster(
+        4, fixed_variables, "Chuffed", 1, 3, 4, intermediate_components=False
+    )
+    assert str(trail["cipher"]) == "speck_p32_k64_o32_r4"
+    assert trail["model_type"] == "impossible_xor_differential_one_solution"
+    assert trail["solver_name"] == "Chuffed"
+    assert trail["components_values"][INPUT_KEY]["value"] == "0" * 64
+    assert trail["status"] == "SATISFIABLE"


### PR DESCRIPTION
* The installation of MiniZinc is now carried out in a bare metal way. This allow to leave out the IDE.
* The support of Gecode has been finished. The tool is unmaintained since 6 years and the website is currently unreachable.
* Kaleido and Plotly has been moved to a SageMath pip installation.
* CP files have been refactored to list only available solvers.
* A testing file for CP has been refactored since it was asserting components actually not fixed. They are inferred by the solver, therefore a *"different from zero"* check is enough.