### PR TITLE
Refactor SAT creation of vars

### DIFF
--- a/claasp/component.py
+++ b/claasp/component.py
@@ -143,11 +143,11 @@ class Component:
         for link, positions in zip(input_id_link, input_bit_positions):
             input_bit_ids.extend([f'{link}_{j}{suffix}' for j in positions])
 
-        return self.input_bit_size, input_bit_ids
+        return input_bit_ids
 
     def _generate_input_double_ids(self):
-        _, in_ids_0 = self._generate_input_ids(suffix='_0')
-        _, in_ids_1 = self._generate_input_ids(suffix='_1')
+        in_ids_0 = self._generate_input_ids(suffix='_0')
+        in_ids_1 = self._generate_input_ids(suffix='_1')
 
         return in_ids_0, in_ids_1
 

--- a/claasp/components/and_component.py
+++ b/claasp/components/and_component.py
@@ -365,7 +365,7 @@ class AND(MultiInputNonlinearLogicalOperator):
               '-and_0_8_11 key_23',
               'and_0_8_11 -xor_0_7_11 -key_23'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -402,7 +402,7 @@ class AND(MultiInputNonlinearLogicalOperator):
               '(assert (= and_0_8_10 (and xor_0_7_10 key_22)))',
               '(assert (= and_0_8_11 (and xor_0_7_11 key_23)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -479,7 +479,7 @@ class CipherOutput(Component):
               'cipher_output_2_12_31 -xor_2_10_15',
               'xor_2_10_15 -cipher_output_2_12_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -623,7 +623,7 @@ class CipherOutput(Component):
               '(assert (= cipher_output_2_12_30 xor_2_10_14))',
               '(assert (= cipher_output_2_12_31 xor_2_10_15))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):

--- a/claasp/components/linear_layer_component.py
+++ b/claasp/components/linear_layer_component.py
@@ -124,13 +124,13 @@ class LinearLayer(Component):
               'x -linear_layer_0_6_22 sbox_0_0_2 sbox_0_2_2 sbox_0_3_2 sbox_0_4_3 sbox_0_5_0 sbox_0_5_1 sbox_0_5_3',
               'x -linear_layer_0_6_23 sbox_0_0_0 sbox_0_0_1 sbox_0_0_2 sbox_0_0_3 sbox_0_1_3 sbox_0_2_1 sbox_0_3_1 sbox_0_3_2 sbox_0_3_3 sbox_0_4_1 sbox_0_4_2 sbox_0_4_3 sbox_0_5_1 sbox_0_5_2 sbox_0_5_3'])
         """
-        input_bit_len, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         matrix = self.description
         constraints = []
         for i in range(output_bit_len):
             operands = [f'x -{output_bit_ids[i]}']
-            operands.extend(input_bit_ids[j] for j in range(input_bit_len) if matrix[j][i])
+            operands.extend(input_bit_id for j, input_bit_id in enumerate(input_bit_ids) if matrix[j][i])
             constraints.append(' '.join(operands))
 
         return output_bit_ids, constraints
@@ -725,12 +725,12 @@ class LinearLayer(Component):
             sage: constraints[-1]
             'linear_layer_0_6_23 -sbox_0_0_0 -sbox_0_0_1 -sbox_0_0_2 -sbox_0_0_3 -sbox_0_1_3 -sbox_0_2_1 -sbox_0_3_1 -sbox_0_3_2 -sbox_0_3_3 -sbox_0_4_1 -sbox_0_4_2 -sbox_0_4_3 -sbox_0_5_1 -sbox_0_5_2 -sbox_0_5_3'
         """
-        input_bit_len, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         matrix = self.description
         constraints = []
         for i in range(output_bit_len):
-            operands = [input_bit_ids[j] for j in range(input_bit_len) if matrix[j][i]]
+            operands = [input_bit_id for j, input_bit_id in enumerate(input_bit_ids) if matrix[j][i]]
             constraints.extend(sat_utils.cnf_xor(output_bit_ids[i], operands))
 
         return output_bit_ids, constraints
@@ -863,7 +863,7 @@ class LinearLayer(Component):
             sage: constraints[-1]
             '(assert (= linear_layer_0_6_23 (xor sbox_0_0_0 sbox_0_0_1 sbox_0_0_2 sbox_0_0_3 sbox_0_1_3 sbox_0_2_1 sbox_0_3_1 sbox_0_3_2 sbox_0_3_3 sbox_0_4_1 sbox_0_4_2 sbox_0_4_3 sbox_0_5_1 sbox_0_5_2 sbox_0_5_3)))'
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         matrix = self.description
         constraints = []

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -209,7 +209,7 @@ class MODADD(Modular):
               'x -modadd_0_1_14 rot_0_0_14 plaintext_30 carry_modadd_0_1_14',
               'x -modadd_0_1_15 rot_0_0_15 plaintext_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         carry_bit_ids = [f'carry_{output_bit_ids[i]}' for i in range(output_bit_len - 1)]
         constraints = []

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -339,7 +339,7 @@ class MODADD(Modular):
               'modadd_0_1_15 rot_0_0_15 -plaintext_31',
               '-modadd_0_1_15 -rot_0_0_15 -plaintext_31'])
         """
-        _, input_ids = self._generate_input_ids()
+        input_ids = self._generate_input_ids()
         output_len, output_ids = self._generate_output_ids()
         num_of_addenda = self.description[1]
         # reformat of the in_ids
@@ -384,7 +384,7 @@ class MODADD(Modular):
               '(assert (= modadd_0_1_30 (xor shift_0_0_30 key_30 carry_0_modadd_0_1_30)))',
               '(assert (= modadd_0_1_31 (xor shift_0_0_31 key_31)))'])
         """
-        _, input_ids = self._generate_input_ids()
+        input_ids = self._generate_input_ids()
         output_len, output_ids = self._generate_output_ids()
         num_of_addenda = self.description[1]
         # reformat of the in_ids

--- a/claasp/components/modsub_component.py
+++ b/claasp/components/modsub_component.py
@@ -255,7 +255,7 @@ class MODSUB(Modular):
               'modsub_0_7_31 modadd_0_4_31 -temp_input_plaintext_63',
               '-modsub_0_7_31 -modadd_0_4_31 -temp_input_plaintext_63'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         temp_carry_bit_ids = [f'temp_carry_{input_bit_ids[output_bit_len + i]}' for i in range(output_bit_len - 1)]
         temp_input_bit_ids = [f'temp_input_{input_bit_ids[output_bit_len + i]}' for i in range(output_bit_len)]
@@ -327,7 +327,7 @@ class MODSUB(Modular):
               '(assert (= modsub_0_7_30 (xor modadd_0_4_30 temp_input_plaintext_62 carry_modsub_0_7_30)))',
               '(assert (= modsub_0_7_31 (xor modadd_0_4_31 temp_input_plaintext_63)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         temp_carry_bit_ids = [f'temp_carry_{input_bit_ids[output_bit_len + i]}' for i in range(output_bit_len - 1)]
         temp_input_bit_ids = [f'temp_input_{input_bit_ids[output_bit_len + i]}' for i in range(output_bit_len)]

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -983,7 +983,7 @@ class Modular(Component):
                 new_constraints = generate_window_size_clauses(first_addend, second_addend, result, aux_var)
                 constraints_.extend(new_constraints)
 
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         dummy_bit_ids = [f'dummy_{output_bit_ids[i]}' for i in range(output_bit_len - 1)]
         hw_bit_ids = [f'hw_{output_bit_ids[i]}' for i in range(output_bit_len)]
@@ -1286,7 +1286,7 @@ class Modular(Component):
               '(assert (or hw_modadd_0_1_30 (not (xor shift_0_0_30 key_30 modadd_0_1_30 key_31))))',
               '(assert (not (xor modadd_0_1_31 shift_0_0_31 key_31)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         hw_bit_ids = [f'hw_{output_bit_ids[i]}' for i in range(output_bit_len)]
         constraints = []

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -474,7 +474,7 @@ class MultiInputNonlinearLogicalOperator(Component):
               '-xor_0_7_11 hw_and_0_8_11',
               '-key_23 hw_and_0_8_11'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         hw_bit_ids = [f'hw_{output_bit_ids[i]}' for i in range(output_bit_len)]
         constraints = []
@@ -555,7 +555,7 @@ class MultiInputNonlinearLogicalOperator(Component):
               '(assert (or (and (not xor_0_7_10) (not key_22) (not and_0_8_10) (not hw_and_0_8_10)) (and xor_0_7_10 hw_and_0_8_10) (and key_22 hw_and_0_8_10)))',
               '(assert (or (and (not xor_0_7_11) (not key_23) (not and_0_8_11) (not hw_and_0_8_11)) (and xor_0_7_11 hw_and_0_8_11) (and key_23 hw_and_0_8_11)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         hw_bit_ids = [f'hw_{output_bit_ids[i]}' for i in range(output_bit_len)]
         constraints = []

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -541,7 +541,7 @@ class NOT(Component):
               'not_0_8_31 xor_0_6_31',
               '-not_0_8_31 -xor_0_6_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -626,7 +626,7 @@ class NOT(Component):
               'not_0_8_31 -xor_0_6_31',
               'xor_0_6_31 -not_0_8_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -707,7 +707,7 @@ class NOT(Component):
               '(assert (distinct not_0_5_62 xor_0_2_62))',
               '(assert (distinct not_0_5_63 xor_0_2_63))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -744,7 +744,7 @@ class NOT(Component):
               '(assert (= not_0_5_62 xor_0_2_62))',
               '(assert (= not_0_5_63 xor_0_2_63))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):

--- a/claasp/components/or_component.py
+++ b/claasp/components/or_component.py
@@ -278,7 +278,7 @@ class OR(MultiInputNonlinearLogicalOperator):
               'or_0_4_31 -xor_0_1_31',
               '-or_0_4_31 xor_0_3_31 xor_0_1_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -315,7 +315,7 @@ class OR(MultiInputNonlinearLogicalOperator):
               '(assert (= or_0_4_30 (or xor_0_3_30 xor_0_1_30)))',
               '(assert (= or_0_4_31 (or xor_0_3_31 xor_0_1_31)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -636,7 +636,7 @@ class Rotate(Component):
               'rot_1_1_15 -key_40',
               'key_40 -rot_1_1_15'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         rotation = self.description[1]
         input_bit_ids_rotated = input_bit_ids[-rotation:] + input_bit_ids[:-rotation]
@@ -801,7 +801,7 @@ class Rotate(Component):
               '(assert (= rot_0_0_14 plaintext_7))',
               '(assert (= rot_0_0_15 plaintext_8))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         rotation = self.description[1]
         input_bit_ids_rotated = input_bit_ids[-rotation:] + input_bit_ids[:-rotation]

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -695,7 +695,7 @@ class SHIFT(Component):
               '-shift_0_0_30',
               '-shift_0_0_31'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         shift_amount = self.description[1]
         constraints = []
@@ -883,7 +883,7 @@ class SHIFT(Component):
               '(assert (not shift_0_0_30))',
               '(assert (not shift_0_0_31))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         shift_amount = self.description[1]
         constraints = []

--- a/claasp/components/variable_shift_component.py
+++ b/claasp/components/variable_shift_component.py
@@ -229,7 +229,7 @@ class VariableShift(Component):
               '-var_shift_0_2_31 -key_91',
               'var_shift_0_2_31 -state_3_var_shift_0_2_31 key_91'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         input_ids = input_bit_ids[:output_bit_len]
         shift_ids = input_bit_ids[output_bit_len:]
@@ -285,7 +285,7 @@ class VariableShift(Component):
               '(assert (ite key_91 (not var_shift_0_2_30) (= var_shift_0_2_30 state_3_var_shift_0_2_30)))',
               '(assert (ite key_91 (not var_shift_0_2_31) (= var_shift_0_2_31 state_3_var_shift_0_2_31)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         input_ids = input_bit_ids[:output_bit_len]
         shift_ids = input_bit_ids[output_bit_len:]

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -216,7 +216,7 @@ class XOR(Component):
               'x -xor_0_2_14 modadd_0_1_14 key_62',
               'x -xor_0_2_15 modadd_0_1_15 key_63'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -1128,7 +1128,7 @@ class XOR(Component):
               'xor_0_2_15 modadd_0_1_15 -key_63',
               '-xor_0_2_15 -modadd_0_1_15 -key_63'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):
@@ -1284,7 +1284,7 @@ class XOR(Component):
               '(assert (= xor_0_2_14 (xor modadd_0_1_14 key_62)))',
               '(assert (= xor_0_2_15 (xor modadd_0_1_15 key_63)))'])
         """
-        _, input_bit_ids = self._generate_input_ids()
+        input_bit_ids = self._generate_input_ids()
         output_bit_len, output_bit_ids = self._generate_output_ids()
         constraints = []
         for i in range(output_bit_len):


### PR DESCRIPTION
Creating input variables for SAT solvers was kept in old style since the first porting.
This PR reduces the load of the return in the function related to input variables creation improving the clarity.