### PR TITLE
Moved call to sort_cipher() inside ChachaStreamCipher init

### DIFF
--- a/claasp/ciphers/stream_ciphers/chacha_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/chacha_stream_cipher.py
@@ -124,3 +124,5 @@ class ChachaStreamCipher(ChachaPermutation):
             component = self.component_from(last_round, component_number)
             if component.type == "cipher_output":
                 component.set_input_id_links(lst_ids)
+
+        self.sort_cipher()

--- a/tests/unit/ciphers/stream_ciphers/chacha_stream_cipher_test.py
+++ b/tests/unit/ciphers/stream_ciphers/chacha_stream_cipher_test.py
@@ -15,7 +15,6 @@ def test_chacha_stream_cipher():
     assert chacha.component_from(3, 0).id == 'modadd_3_0'
 
     cipher = ChachaStreamCipher(number_of_rounds=40)
-    cipher.sort_cipher()
     plaintext = 0x61707865_3320646e_79622d32_6b206574_03020100_07060504_0b0a0908_0f0e0d0c_13121110_17161514_1b1a1918_1f1e1d1c_00000001_09000000_4a000000_00000000
     key = 0x00010203_04050607_08090a0b_0c0d0e0f_10111213_14151617_18191a1b_1c1d1e1f
     nonce = 0x00000000_00000009_0000004a_00000000


### PR DESCRIPTION
This PR fixes an issue with `ChachaStreamCipher` that forced a user to explicitly call `sort_cipher()` after cipher instance. The method is now called at the end of the init of the class.