### PR TITLE
FEATURE/Add: solver_names() method tests for SAT, SMT, MILP and CP mo…

### DIFF
--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -808,23 +808,46 @@ class MznModel:
 
         return result
 
-    def solver_names(self, verbose = False):
-        if not verbose:
-            print('Internal CP solvers:')
-            print('solver brand name | solver name')
-            for i in range(len(CP_SOLVERS_INTERNAL)):
-                print(f'{CP_SOLVERS_INTERNAL[i]["solver_brand_name"]} | {CP_SOLVERS_INTERNAL[i]["solver_name"]}')
-            print('\n')
-            print('External CP solvers:')
-            print('solver brand name | solver name')
-            for i in range(len(CP_SOLVERS_EXTERNAL)):
-                print(f'{CP_SOLVERS_EXTERNAL[i]["solver_brand_name"]} | {CP_SOLVERS_EXTERNAL[i]["solver_name"]}')
-        else:
-            print('Internal CP solvers:')
-            print(CP_SOLVERS_INTERNAL)
-            print('\n')
-            print('External CP solvers:')
-            print(CP_SOLVERS_EXTERNAL)
+    def solver_names(self, verbose=False):
+        """
+        Return a list of available CP solvers.
+
+        INPUT:
+
+        - ``verbose`` -- **boolean** (default: `False`); if True, include additional solver information
+
+        OUTPUT:
+
+        A list of dictionaries containing solver information. Each dictionary contains:
+        - ``solver_brand_name``: The full name of the solver
+        - ``solver_name``: The identifier used to call the solver
+        - ``keywords``: (only if verbose=True) Additional configuration details
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher()
+            sage: mzn = MznModel(speck)
+            sage: solvers = mzn.solver_names()
+            sage: len(solvers) > 0
+            True
+            sage: 'solver_name' in solvers[0]
+            True
+            sage: 'solver_brand_name' in solvers[0]
+            True
+        """
+        solver_names = []
+
+        keys = ['solver_brand_name', 'solver_name']
+        for solver in CP_SOLVERS_INTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        if verbose:
+            keys = ['solver_brand_name', 'solver_name', 'keywords']
+
+        for solver in CP_SOLVERS_EXTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        return solver_names
 
     def weight_constraints(self, weight):
         """

--- a/claasp/cipher_modules/models/sat/sat_model.py
+++ b/claasp/cipher_modules/models/sat/sat_model.py
@@ -403,6 +403,47 @@ class SatModel:
                           for i in range(component.output_bit_size)])
         return weight
 
+    def solver_names(self, verbose=False):
+        """
+        Return a list of available SAT solvers.
+
+        INPUT:
+
+        - ``verbose`` -- **boolean** (default: `False`); if True, include additional solver information
+
+        OUTPUT:
+
+        A list of dictionaries containing solver information. Each dictionary contains:
+        - ``solver_brand_name``: The full name of the solver
+        - ``solver_name``: The identifier used to call the solver
+        - ``keywords``: (only if verbose=True) Additional configuration details
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.sat.sat_model import SatModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher()
+            sage: sat = SatModel(speck)
+            sage: solvers = sat.solver_names()
+            sage: len(solvers) > 0
+            True
+            sage: 'solver_name' in solvers[0]
+            True
+            sage: 'solver_brand_name' in solvers[0]
+            True
+        """
+        solver_names = []
+
+        keys = ['solver_brand_name', 'solver_name']
+        for solver in solvers.SAT_SOLVERS_INTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        if verbose:
+            keys = ['solver_brand_name', 'solver_name', 'keywords']
+
+        for solver in solvers.SAT_SOLVERS_EXTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        return solver_names
+
     def solve(self, model_type, solver_name=solvers.SOLVER_DEFAULT, options=None):
         """
         Return the solution of the model using the ``solver_name`` SAT solver.

--- a/claasp/cipher_modules/models/smt/smt_model.py
+++ b/claasp/cipher_modules/models/smt/smt_model.py
@@ -366,6 +366,47 @@ class SmtModel:
                 literals.append(f'{component_id}_{position}{out_suffix}')
         constraints.append(utils.smt_assert(utils.smt_or(literals)))
 
+    def solver_names(self, verbose=False):
+        """
+        Return a list of available SMT solvers.
+
+        INPUT:
+
+        - ``verbose`` -- **boolean** (default: `False`); if True, include additional solver information
+
+        OUTPUT:
+
+        A list of dictionaries containing solver information. Each dictionary contains:
+        - ``solver_brand_name``: The full name of the solver
+        - ``solver_name``: The identifier used to call the solver
+        - ``keywords``: (only if verbose=True) Additional configuration details
+
+        EXAMPLES::
+
+            sage: from claasp.cipher_modules.models.smt.smt_model import SmtModel
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: speck = SpeckBlockCipher()
+            sage: smt = SmtModel(speck)
+            sage: solvers = smt.solver_names()
+            sage: len(solvers) > 0
+            True
+            sage: 'solver_name' in solvers[0]
+            True
+            sage: 'solver_brand_name' in solvers[0]
+            True
+        """
+        solver_names = []
+
+        keys = ['solver_brand_name', 'solver_name']
+        for solver in solvers.SMT_SOLVERS_INTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        if verbose:
+            keys = ['solver_brand_name', 'solver_name', 'keywords']
+
+        for solver in solvers.SMT_SOLVERS_EXTERNAL:
+            solver_names.append({key: solver[key] for key in keys})
+        return solver_names
+
     def solve(self, model_type, solver_name=solvers.SOLVER_DEFAULT):
         """
         Return the solution of the model using the ``solver_name`` SMT solver.

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -12,6 +12,26 @@ from claasp.cipher_modules.models.cp.mzn_models.mzn_deterministic_truncated_xor_
     import MznDeterministicTruncatedXorDifferentialModelARXOptimized
 
 
+def test_solver_names():
+    speck = SpeckBlockCipher(number_of_rounds=3)
+    mzn = MznModel(speck)
+    solver_names = mzn.solver_names()
+    assert isinstance(solver_names, list)
+    assert len(solver_names) > 0
+    # Check that each entry has the required keys
+    for solver in solver_names:
+        assert 'solver_brand_name' in solver
+        assert 'solver_name' in solver
+        assert 'keywords' not in solver  # verbose=False by default
+    
+    # Test verbose mode
+    verbose_solver_names = mzn.solver_names(verbose=True)
+    assert isinstance(verbose_solver_names, list)
+    # External solvers should have keywords when verbose=True
+    external_solvers = [s for s in verbose_solver_names if 'keywords' in s]
+    assert len(external_solvers) > 0
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning:")
 def test_build_mix_column_truncated_table():
     aes = AESBlockCipher(number_of_rounds=3)

--- a/tests/unit/cipher_modules/models/milp/milp_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_model_test.py
@@ -9,6 +9,26 @@ from claasp.cipher_modules.models.milp.milp_model import get_independent_input_o
     get_input_output_variables
 
 
+def test_solver_names():
+    speck = SpeckBlockCipher(number_of_rounds=3)
+    milp = MilpModel(speck)
+    solver_names = milp.solver_names()
+    assert isinstance(solver_names, list)
+    assert len(solver_names) > 0
+    # Check that each entry has the required keys
+    for solver in solver_names:
+        assert 'solver_brand_name' in solver
+        assert 'solver_name' in solver
+        assert 'keywords' not in solver  # verbose=False by default
+    
+    # Test verbose mode
+    verbose_solver_names = milp.solver_names(verbose=True)
+    assert isinstance(verbose_solver_names, list)
+    # External solvers should have keywords when verbose=True
+    external_solvers = [s for s in verbose_solver_names if 'keywords' in s]
+    assert len(external_solvers) > 0
+
+
 def test_get_independent_input_output_variables():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     component = speck.get_component_from_id("xor_1_10")

--- a/tests/unit/cipher_modules/models/sat/sat_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_model_test.py
@@ -30,6 +30,26 @@ def test_solve():
     assert eval(solution["components_values"]["cipher_output_31_13"]["value"]) >= 0
 
 
+def test_solver_names():
+    speck = SpeckBlockCipher(number_of_rounds=3)
+    sat = SatModel(speck)
+    solver_names = sat.solver_names()
+    assert isinstance(solver_names, list)
+    assert len(solver_names) > 0
+    # Check that each entry has the required keys
+    for solver in solver_names:
+        assert 'solver_brand_name' in solver
+        assert 'solver_name' in solver
+        assert 'keywords' not in solver  # verbose=False by default
+    
+    # Test verbose mode
+    verbose_solver_names = sat.solver_names(verbose=True)
+    assert isinstance(verbose_solver_names, list)
+    # External solvers should have keywords when verbose=True
+    external_solvers = [s for s in verbose_solver_names if 'keywords' in s]
+    assert len(external_solvers) > 0
+
+
 def test_fix_variables_value_constraints():
     fixed_variables = [
         {

--- a/tests/unit/cipher_modules/models/smt/smt_model_test.py
+++ b/tests/unit/cipher_modules/models/smt/smt_model_test.py
@@ -5,6 +5,26 @@ from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 
 
+def test_solver_names():
+    speck = SpeckBlockCipher(number_of_rounds=3)
+    smt = SmtModel(speck)
+    solver_names = smt.solver_names()
+    assert isinstance(solver_names, list)
+    assert len(solver_names) > 0
+    # Check that each entry has the required keys
+    for solver in solver_names:
+        assert 'solver_brand_name' in solver
+        assert 'solver_name' in solver
+        assert 'keywords' not in solver  # verbose=False by default
+    
+    # Test verbose mode
+    verbose_solver_names = smt.solver_names(verbose=True)
+    assert isinstance(verbose_solver_names, list)
+    # All SMT solvers are external, so they should have keywords when verbose=True
+    for solver in verbose_solver_names:
+        assert 'keywords' in solver
+
+
 def test_fix_variables_value_constraints():
     speck = SpeckBlockCipher(number_of_rounds=3)
     smt = SmtModel(speck)


### PR DESCRIPTION
…dels

- Add test_solver_names() to sat_model_test.py
- Add test_solver_names() to smt_model_test.py
- Add test_solver_names() to milp_model_test.py
- Add test_solver_names() to mzn_model_test.py
- Update CP model solver_names() to return list instead of printing
- All tests validate solver list structure and verbose mode