### PR TITLE
Build image during push/pr and fix Glucose arm issue

### DIFF
--- a/.github/workflows/build-claasp-base-image.yaml
+++ b/.github/workflows/build-claasp-base-image.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+      - develop
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   build-image:
@@ -16,6 +20,19 @@ jobs:
       with:
         persist-credentials: false
         fetch-depth: 0
+
+    - name: Compute image tag
+      id: tag
+      shell: bash
+      run: |
+        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+          echo "tag=develop" >> "$GITHUB_OUTPUT"
+        else
+          SHA="${{ github.event.pull_request.head.sha }}"
+          echo "tag=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -34,7 +51,7 @@ jobs:
         file: ./docker/Dockerfile
         push: true
         platforms: linux/amd64
-        tags: tiicrc/claasp-base:latest
+        tags: tiicrc/claasp-base:${{ steps.tag.outputs.tag }}
         target: claasp-base
         cache-from: type=gha,scope=claasp-base
         cache-to: type=gha,scope=claasp-base,mode=max
@@ -47,7 +64,7 @@ jobs:
         file: ./docker/Dockerfile
         push: true
         platforms: linux/arm64
-        tags: tiicrc/claasp-m1-base:latest
+        tags: tiicrc/claasp-m1-base:${{ steps.tag.outputs.tag }}
         target: claasp-base
         cache-from: type=gha,scope=claasp-base-m1
         cache-to: type=gha,scope=claasp-base-m1,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -258,21 +258,19 @@ WORKDIR /opt
 ENV PATH="/opt/ParKissat-RS-master/:${PATH}"
 
 # Installing Glucose
-RUN wget https://www.labri.fr/perso/lsimon/downloads/softwares/glucose-syrup-4.1.tgz || \
-    wget https://fosszone.csd.auth.gr/sagemath/spkg/upstream/glucose/glucose-syrup-4.1.tgz
+RUN git clone https://github.com/audemard/glucose.git glucose-syrup \
+    && cd glucose-syrup \
+    && git checkout 674dbba75b47864a332ba797bec80dcaca0a4857
 
-RUN tar -xf glucose-syrup-4.1.tgz \
-    && rm glucose-syrup-4.1.tgz
-
-RUN cd glucose-syrup-4.1/simp \
+RUN cd glucose-syrup/simp \
     && make
 
-RUN cd glucose-syrup-4.1/parallel \
+RUN cd glucose-syrup/parallel \
     && make
 
 WORKDIR /opt
 
-ENV PATH="/opt/glucose-syrup-4.1/simp:/opt/glucose-syrup-4.1/parallel:${PATH}"
+ENV PATH="/opt/glucose-syrup/simp:/opt/glucose-syrup/parallel:${PATH}"
 
 # Installing MathSat
 RUN wget https://mathsat.fbk.eu/release/mathsat-5.6.11-linux-x86_64.tar.gz \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,13 +50,14 @@ RUN set -eux; \
         wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_armlinux64.tar.gz; \
         tar -xzf gurobi10.0.0_armlinux64.tar.gz; \
         rm gurobi10.0.0_armlinux64.tar.gz; \
+        export GUROBI_HOME="/opt/gurobi1000/armlinux64"; \
     else \
         wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz; \
         tar -xzf gurobi10.0.0_linux64.tar.gz; \
         rm gurobi10.0.0_linux64.tar.gz; \
+        export GUROBI_HOME="/opt/gurobi1000/linux64"; \
     fi
 
-ENV GUROBI_HOME="/opt/gurobi1000/linux64"
 ENV PATH="${PATH}:${GUROBI_HOME}/bin"
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,16 +50,17 @@ RUN set -eux; \
         wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_armlinux64.tar.gz; \
         tar -xzf gurobi10.0.0_armlinux64.tar.gz; \
         rm gurobi10.0.0_armlinux64.tar.gz; \
-        export GUROBI_HOME="/opt/gurobi1000/armlinux64"; \
+        ln -sfn /opt/gurobi1000/armlinux64 /opt/gurobi; \
     else \
         wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz; \
         tar -xzf gurobi10.0.0_linux64.tar.gz; \
         rm gurobi10.0.0_linux64.tar.gz; \
-        export GUROBI_HOME="/opt/gurobi1000/linux64"; \
+        ln -sfn /opt/gurobi1000/linux64 /opt/gurobi; \
     fi
 
-ENV PATH="${PATH}:${GUROBI_HOME}/bin"
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib"
+ENV GUROBI_HOME=/opt/gurobi
+ENV PATH="/opt/gurobi/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/gurobi/lib:${LD_LIBRARY_PATH}"
 
 WORKDIR /opt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04 AS claasp-base
 ARG DEBIAN_FRONTEND=noninteractive
 ARG COPY_CLAASP_LIBRARY=false
 ARG INSTALL_CLAASP_LIBRARY=false
+ARG TARGETARCH
 
 # Install dependencies with apt-get
 RUN apt-get -q update
@@ -43,9 +44,17 @@ COPY docker/sitecustomize.py /usr/lib/python3.10/sitecustomize.py
 
 WORKDIR /opt
 
-RUN wget https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz \
-    && tar -xf gurobi10.0.0_linux64.tar.gz \
-    && rm gurobi10.0.0_linux64.tar.gz
+RUN set -eux; \
+    cd /opt; \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_armlinux64.tar.gz; \
+        tar -xzf gurobi10.0.0_armlinux64.tar.gz; \
+        rm gurobi10.0.0_armlinux64.tar.gz; \
+    else \
+        wget -q https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz; \
+        tar -xzf gurobi10.0.0_linux64.tar.gz; \
+        rm gurobi10.0.0_linux64.tar.gz; \
+    fi
 
 ENV GUROBI_HOME="/opt/gurobi1000/linux64"
 ENV PATH="${PATH}:${GUROBI_HOME}/bin"


### PR DESCRIPTION
This PR enables image builds both on pushes to the develop branch and on pull requests targeting develop. The image tag is generated automatically based on the new if / elseif / else logic introduced in the CI configuration. This allows us to detect build issues early (across both amd64 and arm64 architectures) without having to wait for the merge from develop into main.

Besides that this PR solves the following issue: Glucose uses the macro _FPU_EXTENDED/_FPU_DOUBLE unconditionally on Linux, which fails on arm64 because those x87 macros are only available on x86/x86_64. Newer version of Glucose in commit 674dbba75b47864a332ba797bec80dcaca0a4857 fix this problem.