### PR TITLE
FIX/Refactor: Standardize MiniZinc variable and constraint handling

### DIFF
--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -1045,22 +1045,23 @@ class MznModel:
     @property
     def model_constraints(self):
         """
-        Return the model specified by ``model_type``.
+        Return the constraints of the model.
 
-        INPUT:
-
-        - ``model_type`` -- **string**; the model to retrieve
+        This property provides access to only the constraints, excluding variable declarations.
+        Use together with `model_variables` to get the complete model.
 
         EXAMPLES::
 
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
-            sage: speck = SpeckBlockCipher(number_of_rounds=4)
-            sage: cp = MznModel(speck)
-            sage: cp.model_constraints()
-            Traceback (most recent call last):
-            ...
-            ValueError: No model generated
+            sage: from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model import MznXorDifferentialModel
+            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: mzn = MznXorDifferentialModel(speck)
+            sage: mzn.build_xor_differential_trail_model()
+            sage: constraints = mzn.model_constraints
+            sage: len(constraints) > 0
+            True
+            sage: 'constraint rot_0_0[2] = plaintext[11];' == constraints[29]
+            True
         """
         if not self._model_constraints:
             raise ValueError("No model generated")
@@ -1069,22 +1070,23 @@ class MznModel:
     @property
     def model_variables(self):
         """
-        Return the variables of the model specified by ``model_type``.
+        Return the variable declarations of the model.
 
-        INPUT:
-
-        - ``model_type`` -- **string**; the model to retrieve
+        This property provides access to only the variable declarations, excluding constraints.
+        Use together with `model_constraints` to get the complete model.
 
         EXAMPLES::
 
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-            sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
-            sage: speck = SpeckBlockCipher(number_of_rounds=4)
-            sage: cp = MznModel(speck)
-            sage: cp.model_variables()
-            Traceback (most recent call last):
-            ...
-            ValueError: No model generated
+            sage: from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model import MznXorDifferentialModel
+            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: mzn = MznXorDifferentialModel(speck)
+            sage: mzn.build_xor_differential_trail_model()
+            sage: variables = mzn.model_variables
+            sage: len(variables) > 0
+            True
+            sage: 'array[0..15] of var 0..1: pre_modadd_0_1_0;' == variables[0]
+            True
         """
         if not self._variables_list:
             raise ValueError("No model generated")

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -758,9 +758,8 @@ class MznModel:
             "impossible_xor_differential",
         ):
             truncated = True
-            mzn_model = self._model_constraints
-        else:
-            mzn_model = self._variables_list + self._model_constraints
+        
+        mzn_model = self._variables_list + self._model_constraints
 
         solutions = []
         if solve_external:
@@ -1066,3 +1065,27 @@ class MznModel:
         if not self._model_constraints:
             raise ValueError("No model generated")
         return self._model_constraints
+
+    @property
+    def model_variables(self):
+        """
+        Return the variables of the model specified by ``model_type``.
+
+        INPUT:
+
+        - ``model_type`` -- **string**; the model to retrieve
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
+            sage: speck = SpeckBlockCipher(number_of_rounds=4)
+            sage: cp = MznModel(speck)
+            sage: cp.model_variables()
+            Traceback (most recent call last):
+            ...
+            ValueError: No model generated
+        """
+        if not self._variables_list:
+            raise ValueError("No model generated")
+        return self._variables_list

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -758,10 +758,14 @@ class MznModel:
             "impossible_xor_differential",
         ):
             truncated = True
+            mzn_model = self._model_constraints
+        else:
+            mzn_model = self._variables_list + self._model_constraints
+
         solutions = []
         if solve_external:
             command = self.get_command_for_solver_process(model_type, solver_name, processes_, timeout_in_seconds_)
-            model = "\n".join(self._model_constraints) + "\n"
+            model = "\n".join(mzn_model)
             start = time.time()
             solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
             end = time.time()
@@ -769,8 +773,7 @@ class MznModel:
             if solver_process.returncode >= 0:
                 solver_output = solver_process.stdout.splitlines()
         else:
-            constraints = self._model_constraints
-            mzn_model_string = "\n".join(constraints)
+            mzn_model_string = "\n".join(mzn_model)
             solver_name_mzn = Solver.lookup(solver_name)
             bit_mzn_model = Model()
             bit_mzn_model.add_string(mzn_model_string)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -82,7 +82,7 @@ class MznCipherModel(MznModel):
         self._model_constraints.extend(self.final_constraints())
 
         if not second:
-            self._model_constraints = self._model_prefix + self._variables_list + self._model_constraints
+            self._model_constraints = self._model_prefix + self._model_constraints
 
     def find_missing_bits(self, fixed_values=[], solver_name=SOLVER_DEFAULT, solver_external=True):
         self.build_cipher_model(fixed_variables=fixed_values)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -130,7 +130,7 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
                 self.final_wordwise_deterministic_truncated_xor_differential_constraints(minimize)
             )
 
-        self._model_constraints = self._model_prefix + self._variables_list + deterministic_truncated_xor_differential
+        self._model_constraints = self._model_prefix + deterministic_truncated_xor_differential
 
     def final_deterministic_truncated_xor_differential_constraints(self, minimize=False):
         """

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -163,7 +163,7 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
                 probabilistic=probabilistic,
             )
         )
-        set_of_constraints = self._variables_list + deterministic_truncated_xor_differential
+        set_of_constraints = deterministic_truncated_xor_differential
 
         self._model_constraints = self._model_prefix + self.clean_constraints(
             set_of_constraints, initial_round, middle_round, final_round
@@ -836,7 +836,7 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
         if final_round is None:
             final_round = self._cipher.number_of_rounds
         command = self.get_command_for_solver_process(model_type, solver_name, processes_, timeout_in_seconds_)
-        model = "\n".join(self._model_constraints) + "\n"
+        model = "\n".join(self._variables_list + self._model_constraints) + "\n"
         solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
         if solver_process.returncode >= 0:
             solutions = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
@@ -191,13 +191,18 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
                 number_of_rounds, initial_round, middle_round, final_round, intermediate_components
             )
         )
-        set_of_constraints = self._variables_list + deterministic_truncated_xor_differential
+        set_of_constraints = deterministic_truncated_xor_differential
 
+        cleaned_variables = []
+        for variable in self._variables_list:
+            if variable not in cleaned_variables:
+                cleaned_variables.append(variable)
+        self._variables_list = cleaned_variables
+        
         cleaned_constraints = []
         for constraint in self._model_prefix + set_of_constraints:
             if constraint not in cleaned_constraints:
                 cleaned_constraints.append(constraint)
-
         self._model_constraints = cleaned_constraints
 
     def build_impossible_xor_differential_trail_model(
@@ -280,7 +285,7 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
                 number_of_rounds, initial_round, middle_round, final_round, intermediate_components, fully_automatic
             )
         )
-        set_of_constraints = self._variables_list + deterministic_truncated_xor_differential
+        set_of_constraints = deterministic_truncated_xor_differential
 
         self._model_constraints = self._model_prefix + self.clean_constraints(
             set_of_constraints, initial_round, middle_round, final_round, fully_automatic
@@ -1409,7 +1414,7 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
             number_of_rounds = self._cipher.number_of_rounds
             final_round = self._cipher.number_of_rounds
         command = self.get_command_for_solver_process(model_type, solver_name, processes_, timeout_in_seconds_)
-        model = "\n".join(self._model_constraints) + "\n"
+        model = "\n".join(self._variables_list + self._model_constraints) + "\n"
         start = time.time()
         solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
         end = time.time()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -138,7 +138,7 @@ class MznXorDifferentialModel(MznModel):
         self._model_prefix.extend(variables)
         self._variables_list.extend(constraints)
         self._model_constraints.extend(self.final_xor_differential_constraints(weight, milp_modadd))
-        self._model_constraints = self._model_prefix + self._variables_list + self._model_constraints
+        self._model_constraints = self._model_prefix + self._model_constraints
 
     def build_xor_differential_trail_model_template(self, weight, fixed_variables, milp_modadd=False):
         variables = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -78,7 +78,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
         self._model_prefix.extend(variables)
         self._variables_list.append(constraints)
         self._model_constraints.extend(self.final_xor_differential_constraints(weight))
-        self._model_constraints = self._model_prefix + self._variables_list + self._model_constraints
+        self._model_constraints = self._model_prefix + self._model_constraints
 
     def find_all_xor_differential_trails_with_fixed_weight(
         self,
@@ -483,7 +483,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             for key in command_options["format"]:
                 command.extend(command_options[key])
 
-            model = table_of_solutions + "\n" + "\n".join(self._model_constraints) + "\n"
+            model =  table_of_solutions + "\n".join(self._variables_list) + "\n".join(self._model_constraints) + "\n"
             solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
             if solver_process.returncode < 0:
                 raise ValueError("something went wrong with solver subprocess... sorry!")

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -542,6 +542,7 @@ class MznXorLinearModel(MznModel):
         end = tm.time()
         build_time = end - start
         if solve_with_API:
+            # TODO: Add the logic of parse_output when using the solve_with_API parameter, since the asserts of the tests fail when active
             solution = self.solve_for_ARX(
                 solver_name=solver_name, timeout_in_seconds_=timelimit, processes_=num_of_processors
             )

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -181,7 +181,7 @@ class MznXorLinearModel(MznModel):
         self._model_prefix.extend(variables)
         self._variables_list.extend(constraints)
         self._model_constraints.extend(self.final_xor_linear_constraints(weight))
-        self._model_constraints = self._model_prefix + self._variables_list + self._model_constraints
+        self._model_constraints = self._model_prefix + self._model_constraints
 
     def final_xor_linear_constraints(self, weight):
         """

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -273,7 +273,7 @@ def test_build_generic_cp_model_from_dictionary_xor_linear():
     model._model_prefix.extend(variables)
     model._variables_list.extend(constraints)
     model._model_constraints.extend(model.final_xor_linear_constraints(weight))
-    model._model_constraints = model._model_prefix + model._variables_list + model._model_constraints
+    model._model_constraints = model._model_prefix + model._model_constraints
 
     result = model.solve(model_type="xor_linear_one_solution", solver_name="cp-sat")
     

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_test.py
@@ -13,7 +13,7 @@ def test_build_deterministic_truncated_xor_differential_trail_model():
     fixed_variables = [set_fixed_variables(INPUT_KEY, "equal", range(64), (0,) * 64)]
     mzn.build_deterministic_truncated_xor_differential_trail_model(fixed_variables)
 
-    assert len(mzn.model_constraints) == 438
+    assert len(mzn.model_constraints)+len(mzn.model_variables) == 438
     assert mzn.model_constraints[2] == "array[0..31] of var 0..2: plaintext;"
     assert mzn.model_constraints[3] == "array[0..63] of var 0..2: key;"
     assert mzn.model_constraints[4] == "array[0..15] of var 0..2: rot_0_0;"

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model_test.py
@@ -15,7 +15,7 @@ def test_build_impossible_xor_differential_trail_model():
         number_of_rounds=4, fixed_variables=fixed_variables, middle_round=3
     )
 
-    assert len(mzn.model_constraints) == 2442
+    assert len(mzn.model_constraints) + len(mzn.model_variables) == 2442
     assert mzn.model_constraints[2] == "set of int: ext_domain = 0..2 union { i | i in 10..800 where (i mod 10 = 0)};"
     assert mzn.model_constraints[3] == "array[0..63] of var ext_domain: plaintext;"
     assert mzn.model_constraints[4] == "array[0..79] of var ext_domain: key;"

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model_test.py
@@ -21,7 +21,7 @@ def test_build_impossible_xor_differential_trail_with_extensions_model():
         intermediate_components=False,
     )
 
-    assert len(mzn.model_constraints) == 1764
+    assert len(mzn.model_constraints) + len(mzn.model_variables) == 1764
     assert mzn.model_constraints[99] == "array[0..31] of var 0..2: inverse_plaintext;"
     assert mzn.model_constraints[3] == "array[0..63] of var 0..2: key;"
     assert mzn.model_constraints[39] == "array[0..31] of var 0..2: cipher_output_5_12;"
@@ -35,7 +35,7 @@ def test_build_impossible_xor_differential_trail_model():
         number_of_rounds=5, fixed_variables=fixed_variables, middle_round=3
     )
 
-    assert len(mzn.model_constraints) == 1661
+    assert len(mzn.model_constraints) + len(mzn.model_variables) == 1661
     assert mzn.model_constraints[2] == "array[0..31] of var 0..2: plaintext;"
     assert mzn.model_constraints[3] == "array[0..63] of var 0..2: key;"
     assert mzn.model_constraints[4] == "array[0..31] of var 0..2: inverse_cipher_output_4_12;"

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_wordwise_deterministic_truncated_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_wordwise_deterministic_truncated_xor_differential_model_test.py
@@ -12,7 +12,7 @@ def test_find_one_wordwise_deterministic_truncated_xor_differential_trail():
     fixed_variables = [set_fixed_variables("key_value", "equal", range(16), (0,) * 16)]
     mzn.build_deterministic_truncated_xor_differential_trail_model(fixed_variables, wordwise=True)
 
-    assert len(mzn.model_constraints) == 1361
+    assert len(mzn.model_constraints) + len(mzn.model_variables) == 1361
     assert mzn.model_constraints[2] == "array[0..15] of var 0..3: key_active;"
     assert mzn.model_constraints[3] == "array[0..15] of var -2..255: key_value;"
     assert mzn.model_constraints[4] == "array[0..15] of var 0..3: plaintext_active;"

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model_test.py
@@ -98,6 +98,12 @@ def test_find_one_xor_linear_trail_with_fixed_weight():
     assert trail["model_type"] == "xor_linear_one_solution"
     assert trail["total_weight"] == "3.0"
 
+def test_find_one_xor_linear_trail_with_fixed_weight_solve_with_api():
+    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)
+    mzn = MznXorLinearModel(speck)
+    trail = mzn.find_one_xor_linear_trail_with_fixed_weight(3, solve_external=False, solve_with_API=True)
+
+    assert isinstance(trail.statistics, dict)
 
 def test_fix_variables_value_xor_linear_constraints():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=4)


### PR DESCRIPTION
## Problem Description

This PR fixes the `MiniZincError: type error: identifier already defined` error that happened when using the generic solver API (`solve_with_API=True`).

### Source of the Error

The problem was found in functions that use the `solve_with_API` parameter. When this parameter is set to `True`, the code calls `solve_for_ARX()` instead of the standard `solve()` method.

**Key difference between the methods:**

* **`solve_for_ARX()`**: Designed to return the native MiniZinc object. It builds the model by explicitly joining `_model_constraints` + `_variables_list`:
```python
constraints = self._model_constraints
variables = self._variables_list
mzn_model_string = "\n".join(constraints) + "\n".join(variables)
```

* **`solve()`**: Parses the solver output. Previously used only `_model_constraints`, but models were inconsistent in whether `_variables_list` was included inside `_model_constraints`.

### Root Cause

The duplicate identifiers were caused by an **inconsistency in how model parts were structured** across different model classes:

* **Some Models** (xor_differential, xor_linear): Included `_variables_list` **inside** `_model_constraints` during build
* **Other Models** (truncated, impossible): Kept them separate or partially separate
* **Result**: When `solve_for_ARX()` added `_variables_list` again, declarations were duplicated for some models

## Implemented Solution

### 1. Standardized Model Construction Pattern

We **homologated all models** to use a consistent pattern where `_variables_list` and `_model_constraints` remain **completely separate** throughout the build process:

**All Models Now Follow:**
```python
# During build - keep separate
self._variables_list.extend(variables)
self._model_constraints = self._model_prefix + deterministic_truncated_xor_differential

# NOT included anymore:
# self._model_constraints = self._model_prefix + self._variables_list + constraints
```

### 2. Updated solve() Methods

**Main solve() method in mzn_model.py** now consistently concatenates both parts:
```python
# Removed conditional logic - now uniform for all model types
mzn_model = self._variables_list + self._model_constraints
```

**Custom solve() methods** in specialized models also updated:
- `mzn_impossible_xor_differential_model.py::solve()`:
```python
# Before:
model = "\n".join(self._model_constraints) + "\n"

# Now:
model = "\n".join(self._variables_list + self._model_constraints) + "\n"
```

- `mzn_hybrid_impossible_xor_differential_model.py::solve()`:
```python
# Before:
model = "\n".join(self._model_constraints) + "\n"

# Now:
model = "\n".join(self._variables_list + self._model_constraints) + "\n"
```

### 3. Updated Public API Properties in mzn_model.py

To maintain backward compatibility while exposing the new structure:

```python
@property
def model_constraints(self):
    """Returns only the constraints (without variables)"""
    return self._model_constraints

@property  
def model_variables(self):
    """Returns only the variable declarations"""
    return self._variables_list
```

Tests now use: `len(mzn.model_constraints) + len(mzn.model_variables)`


## Pending TODO

There is a TODO in `mzn_xor_linear_model.py`:

```python
# TODO: Add the logic of parse_output when using the solve_with_API parameter, 
# since the asserts of the tests fail when active
```

**Context:** Currently, when `solve_with_API=True`, the `solve_for_ARX()` method returns the native MiniZinc object without parsing it. However, `solve()` uses `_parse_solver_output()` to convert the output into a standard dictionary.

**Impact:** Current tests using `solve_with_API=True` only check the basic structure (`isinstance(trail.statistics, dict)`), but they do not check the full content (component values, `total_weight`, etc.) like the tests with `solve_with_API=False` do.