### PR TITLE
Decouple CP model from component constraint generators using context/state/result pattern

### DIFF
--- a/claasp/cipher_modules/models/cp/cp_build_context.py
+++ b/claasp/cipher_modules/models/cp/cp_build_context.py
@@ -14,6 +14,9 @@ class CpBuildContext:
     data_type: str = "bool"
     true_value: str = "true"
     false_value: str = "false"
+    input_postfix: str = "x"
+    output_postfix: str = "y"
+    sat_or_milp: str = "sat"
     float_and_lat_values: tuple = ()
     bit_bindings_for_intermediate_output: dict = field(default_factory=dict)
 
@@ -25,6 +28,9 @@ class CpBuildContext:
             data_type=model.data_type,
             true_value=model.true_value,
             false_value=model.false_value,
+            input_postfix=getattr(model, 'input_postfix', 'x'),
+            output_postfix=getattr(model, 'output_postfix', 'y'),
+            sat_or_milp=getattr(model, 'sat_or_milp', 'sat'),
             float_and_lat_values=tuple(getattr(model, '_float_and_lat_values', [])),
             bit_bindings_for_intermediate_output=getattr(model, 'bit_bindings_for_intermediate_output', {}),
         )

--- a/claasp/cipher_modules/models/cp/cp_build_context.py
+++ b/claasp/cipher_modules/models/cp/cp_build_context.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CpBuildContext:
+    """Read-only configuration snapshot taken from ``MznModel`` at build time.
+
+    Generators receive this instead of the full model so they never
+    depend on mutable solver state.
+    """
+
+    cipher: object = None
+    word_size: int = 0
+    data_type: str = "bool"
+    true_value: str = "true"
+    false_value: str = "false"
+    float_and_lat_values: tuple = ()
+    bit_bindings_for_intermediate_output: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_model(cls, model):
+        return cls(
+            cipher=model._cipher,
+            word_size=getattr(model, 'word_size', 0),
+            data_type=model.data_type,
+            true_value=model.true_value,
+            false_value=model.false_value,
+            float_and_lat_values=tuple(getattr(model, '_float_and_lat_values', [])),
+            bit_bindings_for_intermediate_output=getattr(model, 'bit_bindings_for_intermediate_output', {}),
+        )

--- a/claasp/cipher_modules/models/cp/cp_build_state.py
+++ b/claasp/cipher_modules/models/cp/cp_build_state.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CpBuildState:
+    """Mutable accumulator for state that CP constraint generators read and write.
+
+    Passed through the builder loop so generators never touch the model directly.
+    """
+
+    next_probability_index: int = 0
+    shift_declaration_cache: list = field(default_factory=list)
+    component_probability_map: dict = field(default_factory=dict)
+    sbox_table_cache: list = field(default_factory=list)
+
+    @classmethod
+    def from_model(cls, model):
+        return cls(
+            next_probability_index=model.component_probability_index,
+            shift_declaration_cache=list(model.modadd_two_term_shift_cache),
+            component_probability_map=dict(model.component_and_probability),
+            sbox_table_cache=list(model.sbox_table_cache),
+        )
+
+    def apply_to_model(self, model):
+        model.component_probability_index = self.next_probability_index
+        model.modadd_two_term_shift_cache = self.shift_declaration_cache
+        model.component_and_probability = self.component_probability_map
+        model.sbox_table_cache = self.sbox_table_cache
+
+    def allocate_probability_index(self):
+        idx = self.next_probability_index
+        self.next_probability_index += 1
+        return idx

--- a/claasp/cipher_modules/models/cp/cp_build_state.py
+++ b/claasp/cipher_modules/models/cp/cp_build_state.py
@@ -12,6 +12,8 @@ class CpBuildState:
     shift_declaration_cache: list = field(default_factory=list)
     component_probability_map: dict = field(default_factory=dict)
     sbox_table_cache: list = field(default_factory=list)
+    intermediate_constraints_array: list = field(default_factory=list)
+    mzn_output_directives: list = field(default_factory=list)
 
     @classmethod
     def from_model(cls, model):
@@ -20,6 +22,8 @@ class CpBuildState:
             shift_declaration_cache=list(model.modadd_two_term_shift_cache),
             component_probability_map=dict(model.component_and_probability),
             sbox_table_cache=list(model.sbox_table_cache),
+            intermediate_constraints_array=list(getattr(model, 'intermediate_constraints_array', [])),
+            mzn_output_directives=list(getattr(model, 'mzn_output_directives', [])),
         )
 
     def apply_to_model(self, model):
@@ -27,6 +31,8 @@ class CpBuildState:
         model.modadd_two_term_shift_cache = self.shift_declaration_cache
         model.component_and_probability = self.component_probability_map
         model.sbox_table_cache = self.sbox_table_cache
+        model.intermediate_constraints_array = self.intermediate_constraints_array
+        model.mzn_output_directives = self.mzn_output_directives
 
     def allocate_probability_index(self):
         idx = self.next_probability_index

--- a/claasp/cipher_modules/models/cp/cp_component_build_result.py
+++ b/claasp/cipher_modules/models/cp/cp_component_build_result.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CpComponentBuildResult:
+    """Value returned by decoupled CP constraint generators.
+
+    Bundles the declarations, constraints and optional metadata produced
+    by a single component generator call so the caller never needs to
+    inspect positional-tuple semantics.
+    """
+
+    declarations: list = field(default_factory=list)
+    constraints: list = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -93,9 +93,9 @@ class MznModel:
                     break
         self._float_and_lat_values = []
         self._probability = False
-        self.sbox_mant = []
-        self.mix_column_mant = []
-        self.modadd_twoterms_mant = []
+        self.sbox_table_cache = []
+        self.mix_column_declaration_cache = []
+        self.modadd_two_term_shift_cache = []
         self.input_sbox = []
         self.table_of_solutions_length = 0
         self.list_of_xor_components = []

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -85,7 +85,7 @@ class MznModel:
     def initialise_model(self):
         self._variables_list = []
         self._model_constraints = []
-        self.c = 0
+        self.component_probability_index = 0
         if self._cipher.is_spn():
             for component in self._cipher.get_all_components():
                 if SBOX in component.type:

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -46,6 +46,8 @@ from claasp.name_mappings import (
     XOR_DIFFERENTIAL_LINEAR_OPTIMAL_SOLUTION,
 )
 
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.utils import write_model_to_file, convert_solver_solution_to_dictionary
 
 SOLVE_SATISFY = "solve satisfy;"
@@ -181,7 +183,9 @@ class MznModel:
         components_values[f"solution{solution_number}"][f"{component}"] = component_solution
 
     def build_generic_cp_model_from_dictionary(self, component_and_model_types, fixed_variables=None):
-        variables = []
+        context = CpBuildContext.from_model(self)
+        state = CpBuildState.from_model(self)
+
         self._variables_list = []
         self._model_constraints = []
         component_types = [CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER, MIX_COLUMN, SBOX, WORD_OPERATION]
@@ -196,21 +200,11 @@ class MznModel:
                 print(f'{component.id} not yet implemented')
             else:
                 cp_generic_propagation_constraints = getattr(component, model_type)
-                try:
-                    result = cp_generic_propagation_constraints()
-                except TypeError:
-                    result = cp_generic_propagation_constraints(self)
+                result = cp_generic_propagation_constraints(context, state)
 
-                if len(result) == 2:
-                    variables, constraints = result
-                    metadata = {}
-                elif len(result) == 3:
-                    variables, constraints, metadata = result
-                else:
-                    raise ValueError("Unexpected return value from component generator")
-
-                self._model_constraints.extend(constraints)
-                self._variables_list.extend(variables)
+                self._variables_list.extend(result.declarations)
+                self._model_constraints.extend(result.constraints)
+                metadata = result.metadata
 
                 if metadata:
                     probability_var = metadata.get("probability_var")
@@ -221,6 +215,9 @@ class MznModel:
                             round_index = self._cipher.get_round_from_component_id(component.id)
                             if round_index < len(self.probability_modadd_vars_per_round):
                                 self.probability_modadd_vars_per_round[round_index].append(probability_var)
+
+        # Apply accumulated state back to model
+        state.apply_to_model(self)
 
     def build_mix_column_truncated_table(self, component):
         """

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -56,7 +56,7 @@ class MznCipherModel(MznModel):
         """
         self.initialise_model()
         self._model_prefix.extend(self.input_constraints())
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         variables = []
         self._variables_list = []
         constraints = self.fix_variables_value_constraints(fixed_variables)
@@ -74,7 +74,7 @@ class MznCipherModel(MznModel):
                 if component.type != SBOX:
                     variables, constraints = component.cp_constraints()
                 else:
-                    variables, constraints = component.cp_constraints(self.sbox_mant)
+                    variables, constraints = component.cp_constraints(self.sbox_table_cache)
 
             self._model_constraints.extend(constraints)
             self._variables_list.extend(variables)
@@ -138,7 +138,7 @@ class MznCipherModel(MznModel):
               ...
              'array[0..31] of var 0..1: cipher_output_3_12;']
         """
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         cp_declarations = [
             f"array[0..{bit_size - 1}] of var 0..1: {input_};"
             for input_, bit_size in zip(self._cipher.inputs, self._cipher.inputs_bit_size)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -70,14 +70,14 @@ class MznCipherModel(MznModel):
                 WORD_OPERATION == component.type and operation not in operation_types
             ):
                 print(f"{component.id} not yet implemented")
+                continue
+            if component.type != SBOX:
+                    result = component.cp_constraints()
             else:
-                if component.type != SBOX:
-                    variables, constraints = component.cp_constraints()
-                else:
-                    variables, constraints = component.cp_constraints(self.sbox_table_cache)
+                    result = component.cp_constraints(self.sbox_table_cache)
 
-            self._model_constraints.extend(constraints)
-            self._variables_list.extend(variables)
+            self._model_constraints.extend(result.constraints)
+            self._variables_list.extend(result.declarations)
 
         self._model_constraints.extend(self.final_constraints())
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -57,7 +57,6 @@ class MznCipherModel(MznModel):
         self.initialise_model()
         self._model_prefix.extend(self.input_constraints())
         self.sbox_table_cache = []
-        variables = []
         self._variables_list = []
         constraints = self.fix_variables_value_constraints(fixed_variables)
         component_types = (CIPHER_OUTPUT, CONSTANT, INTERMEDIATE_OUTPUT, LINEAR_LAYER, MIX_COLUMN, SBOX, WORD_OPERATION)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
@@ -47,7 +47,6 @@ class MznCipherModelARXOptimized(MznModel):
             ...
         """
         self._variables_list = []
-        variables = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)
         self._model_constraints = constraints
         component_types = [CIPHER_OUTPUT, INTERMEDIATE_OUTPUT, WORD_OPERATION]

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
@@ -59,8 +59,8 @@ class MznCipherModelARXOptimized(MznModel):
                 WORD_OPERATION == component.type and operation not in operation_types
             ):
                 print(f"{component.id} not yet implemented")
-            else:
-                variables, constraints = component.minizinc_constraints(self)
+                continue
+            result = component.minizinc_constraints(self)
 
-            self._model_constraints.extend(constraints)
-            self._variables_list.extend(variables)
+            self._model_constraints.extend(result.constraints)
+            self._variables_list.extend(result.declarations)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
@@ -15,7 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ****************************************************************************
 
-
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.name_mappings import CIPHER_OUTPUT, INTERMEDIATE_OUTPUT, WORD_OPERATION
 
@@ -49,6 +50,8 @@ class MznCipherModelARXOptimized(MznModel):
         self._variables_list = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)
         self._model_constraints = constraints
+        context = CpBuildContext.from_model(self)
+        state = CpBuildState.from_model(self)
         component_types = [CIPHER_OUTPUT, INTERMEDIATE_OUTPUT, WORD_OPERATION]
         operation_types = ["ROTATE", "SHIFT", "XOR"]
 
@@ -59,7 +62,9 @@ class MznCipherModelARXOptimized(MznModel):
             ):
                 print(f"{component.id} not yet implemented")
                 continue
-            result = component.minizinc_constraints(self)
+            result = component.minizinc_constraints(context, state)
 
             self._model_constraints.extend(result.constraints)
             self._variables_list.extend(result.declarations)
+
+        state.apply_to_model(self)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -492,10 +492,10 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
     def propagate_deterministically(self, component, wordwise=False, inverse=False):
         if not wordwise:
             if component.type == SBOX:
-                variables, constraints, sbox_mant = (
-                    component.cp_deterministic_truncated_xor_differential_trail_constraints(self.sbox_mant, inverse)
+                variables, constraints, sbox_table_cache = (
+                    component.cp_deterministic_truncated_xor_differential_trail_constraints(self.sbox_table_cache, inverse)
                 )
-                self.sbox_mant = sbox_mant
+                self.sbox_table_cache = sbox_table_cache
             else:
                 variables, constraints = component.cp_deterministic_truncated_xor_differential_trail_constraints()
         else:

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -17,6 +17,8 @@
 
 from minizinc import Status
 
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import MznModel, SOLVE_SATISFY
 from claasp.cipher_modules.models.cp.solvers import SOLVER_DEFAULT
 from claasp.cipher_modules.models.utils import (
@@ -497,6 +499,9 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
             else:
                 result = component.cp_deterministic_truncated_xor_differential_trail_constraints()
         else:
-            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
+            context = CpBuildContext.from_model(self)
+            state = CpBuildState.from_model(self)
+            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(context, state)
+            state.apply_to_model(self)
 
         return result.declarations, result.constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -492,13 +492,11 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
     def propagate_deterministically(self, component, wordwise=False, inverse=False):
         if not wordwise:
             if component.type == SBOX:
-                variables, constraints, sbox_table_cache = (
-                    component.cp_deterministic_truncated_xor_differential_trail_constraints(self.sbox_table_cache, inverse)
-                )
-                self.sbox_table_cache = sbox_table_cache
+                result = component.cp_deterministic_truncated_xor_differential_trail_constraints(self.sbox_table_cache, inverse)
+                self.sbox_table_cache = result.metadata
             else:
-                variables, constraints = component.cp_deterministic_truncated_xor_differential_trail_constraints()
+                result = component.cp_deterministic_truncated_xor_differential_trail_constraints()
         else:
-            variables, constraints = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
+            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
 
-        return variables, constraints
+        return result.declarations, result.constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
@@ -57,11 +57,12 @@ class MznDeterministicTruncatedXorDifferentialModelARXOptimized(MznModel):
             operation_types = ["ROTATE", "SHIFT"]
 
             if component.type in component_types and (component.type != WORD_OPERATION or operation in operation_types):
-                variables, constraints = component.minizinc_deterministic_truncated_xor_differential_trail_constraints(
+                result = component.minizinc_deterministic_truncated_xor_differential_trail_constraints(
                     self
                 )
             else:
                 print(f"{component.id} not yet implemented")
+                continue
 
-            self._variables_list.extend(variables)
-            self._model_constraints.extend(constraints)
+            self._variables_list.extend(result.declarations)
+            self._model_constraints.extend(result.constraints)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
@@ -46,7 +46,6 @@ class MznDeterministicTruncatedXorDifferentialModelARXOptimized(MznModel):
             sage: minizinc.build_deterministic_truncated_xor_differential_trail_model()
             ...
         """
-        variables = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)
         self._variables_list = []
         self._model_constraints = constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -723,12 +723,12 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
                 if key_schedule and probabilistic:
                     variables, constraints = component.cp_xor_differential_propagation_constraints(self, inverse)
                 else:
-                    variables, constraints, sbox_mant = (
+                    variables, constraints, sbox_table_cache = (
                         component.cp_hybrid_deterministic_truncated_xor_differential_constraints(
-                            self.sbox_mant, inverse, self.sboxes_component_number_list
+                            self.sbox_table_cache, inverse, self.sboxes_component_number_list
                         )
                     )
-                    self.sbox_mant = sbox_mant
+                    self.sbox_table_cache = sbox_table_cache
                     self.sbox_size = component.output_bit_size
             elif component.description[0] == "XOR":
                 variables, constraints = component.cp_hybrid_deterministic_truncated_xor_differential_constraints()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -37,6 +37,7 @@ import subprocess
 from sage.combinat.permutation import Permutation
 from sage.crypto.sbox import SBox
 
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import SOLVE_SATISFY, MznModel
 from claasp.cipher_modules.models.cp.mzn_models.mzn_impossible_xor_differential_model import (
     MznImpossibleXorDifferentialModel,
@@ -721,23 +722,23 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
         if not wordwise:
             if component.type == SBOX:
                 if key_schedule and probabilistic:
-                    variables, constraints = component.cp_xor_differential_propagation_constraints(self, inverse)
+                    state = CpBuildState.from_model(self)
+                    result = component.cp_xor_differential_propagation_constraints(None, state, inverse)
+                    state.apply_to_model(self)
                 else:
-                    variables, constraints, sbox_table_cache = (
-                        component.cp_hybrid_deterministic_truncated_xor_differential_constraints(
-                            self.sbox_table_cache, inverse, self.sboxes_component_number_list
-                        )
+                    result = component.cp_hybrid_deterministic_truncated_xor_differential_constraints(
+                        self.sbox_table_cache, inverse, self.sboxes_component_number_list
                     )
-                    self.sbox_table_cache = sbox_table_cache
+                    self.sbox_table_cache = result.metadata
                     self.sbox_size = component.output_bit_size
             elif component.description[0] == "XOR":
-                variables, constraints = component.cp_hybrid_deterministic_truncated_xor_differential_constraints()
+                result = component.cp_hybrid_deterministic_truncated_xor_differential_constraints()
             else:
-                variables, constraints = component.cp_deterministic_truncated_xor_differential_trail_constraints()
+                result = component.cp_deterministic_truncated_xor_differential_trail_constraints()
         else:
-            variables, constraints = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
+            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
 
-        return variables, constraints
+        return result.declarations, result.constraints
 
     def format_component_value(self, component_id, string):
         if f"{component_id}_i" in string:

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -37,6 +37,7 @@ import subprocess
 from sage.combinat.permutation import Permutation
 from sage.crypto.sbox import SBox
 
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
 from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import SOLVE_SATISFY, MznModel
 from claasp.cipher_modules.models.cp.mzn_models.mzn_impossible_xor_differential_model import (
@@ -736,7 +737,10 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
             else:
                 result = component.cp_deterministic_truncated_xor_differential_trail_constraints()
         else:
-            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(self)
+            context = CpBuildContext.from_model(self)
+            state = CpBuildState.from_model(self)
+            result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(context, state)
+            state.apply_to_model(self)
 
         return result.declarations, result.constraints
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -20,6 +20,7 @@ import math
 import time as tm
 from sage.crypto.sbox import SBox
 
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import MznModel, SOLVE_SATISFY
 from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (
@@ -150,19 +151,24 @@ class MznXorDifferentialModel(MznModel):
         operation_types = ("AND", "MODADD", "MODSUB", "NOT", "OR", "ROTATE", "SHIFT", "XOR")
         self._model_constraints = constraints
 
+        state = CpBuildState.from_model(self)
+
         for component in self._cipher.get_all_components():
             operation = component.description[0]
             if component.type not in component_types or (
                 WORD_OPERATION == component.type and operation not in operation_types
             ):
                 print(f"{component.id} not yet implemented")
+                continue
             elif operation in ("MODADD", "MODSUB") and milp_modadd:
-                variables, constraints = component.cp_xor_differential_propagation_constraints_arx_optimized(self)
+                result = component.cp_xor_differential_propagation_constraints_arx_optimized(self)
             else:
-                variables, constraints = component.cp_xor_differential_propagation_constraints(self)
+                result = component.cp_xor_differential_propagation_constraints(None, state)
 
-            self._variables_list.extend(variables)
-            self._model_constraints.extend(constraints)
+            self._variables_list.extend(result.declarations)
+            self._model_constraints.extend(result.constraints)
+
+        state.apply_to_model(self)
 
         if weight != -1:
             variables, constraints = self.weight_constraints(weight)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -128,7 +128,7 @@ class MznXorDifferentialModel(MznModel):
             sage: cp.build_xor_differential_trail_model()
         """
         self.initialise_model()
-        self.c = 0
+        self.component_probability_index = 0
         self.sbox_mant = []
         self.input_sbox = []
         self.component_and_probability = {}

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -129,7 +129,7 @@ class MznXorDifferentialModel(MznModel):
         """
         self.initialise_model()
         self.component_probability_index = 0
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         self.input_sbox = []
         self.component_and_probability = {}
         self.table_of_solutions_length = 0
@@ -636,7 +636,7 @@ class MznXorDifferentialModel(MznModel):
             f"array[0..{bit_size - 1}] of var 0..1: {input_};"
             for input_, bit_size in zip(self._cipher.inputs, self._cipher.inputs_bit_size)
         ]
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         prob_count = 0
         valid_probabilities = {0}
         and_already_added = []
@@ -676,7 +676,7 @@ class MznXorDifferentialModel(MznModel):
         description = component.description
         sbox = SBox(description)
         sbox_already_in = False
-        for mant in self.sbox_mant:
+        for mant in self.sbox_table_cache:
             if description == mant[0]:
                 sbox_already_in = True
         if not sbox_already_in:
@@ -687,4 +687,4 @@ class MznXorDifferentialModel(MznModel):
                 valid_probabilities.update(
                     {round(100 * math.log2(2**input_size / occurrence)) for occurrence in set_of_occurrences}
                 )
-            self.sbox_mant.append((description, output_id_link))
+            self.sbox_table_cache.append((description, output_id_link))

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
@@ -184,15 +184,14 @@ class MznXorDifferentialModelARXOptimized(MznModel):
                 WORD_OPERATION == component.type and operation not in operation_types
             ):
                 print(f"{component.id} not yet implemented")
-            else:
-                variables, constraints = component.minizinc_xor_differential_propagation_constraints(self)
+                continue
+            result = component.minizinc_xor_differential_propagation_constraints(self)
 
-            self._variables_list.extend(variables)
-            self._model_constraints.extend(constraints)
+            self._variables_list.extend(result.declarations)
+            self._model_constraints.extend(result.constraints)
 
         if weight != -1:
-            variables, constraints = self.weight_constraints(weight)
-            self._variables_list.extend(variables)
+            constraints = self.weight_constraints(weight)
             self._model_constraints.extend(constraints)
 
         self.init_constraints()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
@@ -171,7 +171,6 @@ class MznXorDifferentialModelARXOptimized(MznModel):
             sage: minizinc = MznXorDifferentialModelARXOptimized(speck)
             sage: minizinc.build_xor_differential_trail_model()
         """
-        variables = []
         self._variables_list = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)
         component_types = [CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, WORD_OPERATION]

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -132,7 +132,7 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
         self.sbox_mant = []
         self.input_sbox = []
         self._variables_list = []
-        self.c = 0
+        self.component_probability_index = 0
         self.table_of_solutions_length = 0
         constraints = self.fix_variables_value_constraints(fixed_variables, "first_step")
         self._first_step = constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -146,12 +146,13 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
                 component.type == WORD_OPERATION and operation not in operation_types
             ):
                 print(f"{component.id} not yet implemented")
+                continue
             elif component.type == WORD_OPERATION and operation == "XOR":
-                variables, constraints = component.cp_transform_xor_components_for_first_step(self)
+                result = component.cp_transform_xor_components_for_first_step(self)
             else:
-                variables, constraints = component.cp_xor_differential_propagation_first_step_constraints(self)
-            self._variables_list.extend(variables)
-            self._first_step.extend(constraints)
+                result = component.cp_xor_differential_propagation_first_step_constraints(self)
+            self._variables_list.extend(result.declarations)
+            self._first_step.extend(result.constraints)
 
         self.add_additional_xor_constraints(nmax, repetition)
         for i, component in enumerate(self.list_of_xor_components):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -128,8 +128,8 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
         variables = []
         self.list_of_xor_all_inputs = []
         self.list_of_xor_components = []
-        self.mix_column_mant = []
-        self.sbox_mant = []
+        self.mix_column_declaration_cache = []
+        self.sbox_table_cache = []
         self.input_sbox = []
         self._variables_list = []
         self.component_probability_index = 0

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -71,7 +71,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             sage: cp.build_xor_differential_trail_second_step_model(-1, fixed_variables)
         """
         self.component_probability_index = 0
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         self.component_and_probability = {}
         self.build_xor_differential_trail_model_template(weight, fixed_variables)
         variables, constraints = self.input_xor_differential_constraints()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -70,7 +70,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             ....: integer_to_bit_list(0, 128, 'little'))]
             sage: cp.build_xor_differential_trail_second_step_model(-1, fixed_variables)
         """
-        self.c = 0
+        self.component_probability_index = 0
         self.sbox_mant = []
         self.component_and_probability = {}
         self.build_xor_differential_trail_model_template(weight, fixed_variables)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -21,6 +21,8 @@ import time as tm
 
 from sage.crypto.sbox import SBox
 
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import MznModel, SOLVE_SATISFY, CONSTRAINT_TYPE_ERROR
 from claasp.cipher_modules.models.utils import get_bit_bindings, get_single_key_scenario_format_for_fixed_values
 from claasp.name_mappings import (
@@ -149,6 +151,9 @@ class MznXorLinearModel(MznModel):
         constraints = self.fix_variables_value_xor_linear_constraints(fixed_variables)
         self._model_constraints = constraints
 
+        state = CpBuildState.from_model(self)
+        context = CpBuildContext.from_model(self)
+
         for component in self._cipher.get_all_components():
             component_types = [
                 CONSTANT,
@@ -162,12 +167,17 @@ class MznXorLinearModel(MznModel):
             operation = component.description[0]
             operation_types = ["AND", "MODADD", "NOT", "ROTATE", "SHIFT", "XOR", "OR", "MODSUB"]
             if component.type in component_types and (component.type != WORD_OPERATION or operation in operation_types):
-                variables, constraints = component.cp_xor_linear_mask_propagation_constraints(self)
+                result = component.cp_xor_linear_mask_propagation_constraints(context, state)
+                variables = result.declarations
+                constraints = result.constraints
             else:
                 print(f"{component.id} not yet implemented")
+                continue
 
             self._variables_list.extend(variables)
             self._model_constraints.extend(constraints)
+
+        state.apply_to_model(self)
 
         constraints = self.branch_xor_linear_constraints()
         self._model_constraints.extend(constraints)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -133,7 +133,7 @@ class MznXorLinearModel(MznModel):
         """
         self.initialise_model()
         self.sbox_mant = []
-        self.c = 0
+        self.component_probability_index = 0
         self._variables_list = []
         self.component_and_probability = {}
         self._variables_list = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -132,7 +132,7 @@ class MznXorLinearModel(MznModel):
             sage: cp.build_xor_linear_trail_model(-1, fixed_variables)
         """
         self.initialise_model()
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         self.component_probability_index = 0
         self._variables_list = []
         self.component_and_probability = {}
@@ -669,7 +669,7 @@ class MznXorLinearModel(MznModel):
               'var int: weight = sum(p);'],
              [])
         """
-        self.sbox_mant = []
+        self.sbox_table_cache = []
         cp_constraints = []
         and_already_added = []
         cipher_inputs = self._cipher.inputs
@@ -728,8 +728,8 @@ class MznXorLinearModel(MznModel):
         description = component.description
         sbox = SBox(description)
         already_in = False
-        for i in range(len(self.sbox_mant)):
-            if description == self.sbox_mant[i][0]:
+        for i in range(len(self.sbox_table_cache)):
+            if description == self.sbox_table_cache[i][0]:
                 already_in = True
         if not already_in:
             sbox_lat = sbox.linear_approximation_table()
@@ -742,7 +742,7 @@ class MznXorLinearModel(MznModel):
                         for occurence in set_of_occurrences
                     }
                 )
-            self.sbox_mant.append((description, output_id_link))
+            self.sbox_table_cache.append((description, output_id_link))
 
     def weight_xor_linear_constraints(self, weight):
         """

--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -1273,8 +1273,8 @@ def differential_truncated_checker_permutation_input_and_output_truncated(
 
 def truncated_differential_linear_checker_permutation(
     cipher,
-    input_trunc_diff,      
-    output_mask, 
+    input_trunc_diff,
+    output_mask,
     number_of_samples,
     state_size,
     seed=None,

--- a/claasp/components/and_component.py
+++ b/claasp/components/and_component.py
@@ -19,6 +19,7 @@
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.milp.utils import utils as milp_utils
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
 
 
@@ -209,15 +210,16 @@ class AND(MultiInputNonlinearLogicalOperator):
             cp_constraint = f"constraint {self.id}[{i}] = {operation};"
             cp_constraints.append(cp_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists declarations and constraints for the probability of AND component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
@@ -225,13 +227,14 @@ class AND(MultiInputNonlinearLogicalOperator):
             sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
             sage: cipher = AndCipher(word_bit_size=12, number_of_inputs=2)
             sage: cp = MznModel(cipher)
+            sage: from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
+            sage: context = CpBuildContext.from_model(cp)
+            sage: state = CpBuildState.from_model(cp)
             sage: and_component = cipher.get_component_from_id('and_0_0')
-            sage: and_component.cp_xor_linear_mask_propagation_constraints(cp)
-            (['array[0..23] of var 0..1:and_0_0_i;',
-              'array[0..11] of var 0..1:and_0_0_o;'],
-             ['constraint table([and_0_0_i[0]]++[and_0_0_i[12]]++[and_0_0_o[0]]++[p[0]],and2inputs_LAT);',
-               ...
-              'constraint table([and_0_0_i[11]]++[and_0_0_i[23]]++[and_0_0_o[11]]++[p[11]],and2inputs_LAT);'])
+            sage: result = and_component.cp_xor_linear_mask_propagation_constraints(context, state)
+            sage: result.declarations[0]
+            'array[0..23] of var 0..1:and_0_0_i;'
         """
         output_id_link = self.id
         cp_declarations = []
@@ -240,32 +243,32 @@ class AND(MultiInputNonlinearLogicalOperator):
         input_len = self.input_bit_size // num_add
         cp_declarations.append(f"array[0..{self.input_bit_size - 1}] of var 0..1:{output_id_link}_i;")
         cp_declarations.append(f"array[0..{self.output_bit_size - 1}] of var 0..1:{output_id_link}_o;")
-        model.component_and_probability[output_id_link] = 0
+        state.component_probability_map[output_id_link] = 0
         component_probability_indices = []
         for i in range(self.output_bit_size):
             new_constraint = "constraint table("
             for j in range(num_add):
                 new_constraint = new_constraint + f"[{output_id_link}_i[{i + input_len * j}]]++"
-            if model.float_and_lat_values:
+            if context.float_and_lat_values:
                 cp_declarations.append(f"var :p_{output_id_link}_{i};")
                 new_constraint = (
                     new_constraint + f"[{output_id_link}_o[{i}]]++[p_{output_id_link}_{i}],and{num_add}inputs_LAT);"
                 )
                 cp_constraints.append(new_constraint)
-                for k in range(len(model.float_and_lat_values)):
-                    rounded_float = round(float(model.float_and_lat_values[k]), 2)
+                for k in range(len(context.float_and_lat_values)):
+                    rounded_float = round(float(context.float_and_lat_values[k]), 2)
                     cp_constraints.append(
-                        f"constraint if p_{output_id_link}_{i} == {1000 + k} then p[{model.component_probability_index}]={rounded_float} else "
-                        f"p[{model.component_probability_index}]=p_{output_id_link}_{i} endif;"
+                        f"constraint if p_{output_id_link}_{i} == {1000 + k} then p[{state.next_probability_index}]={rounded_float} else "
+                        f"p[{state.next_probability_index}]=p_{output_id_link}_{i} endif;"
                     )
             else:
-                new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++[p[{model.component_probability_index}]],and{num_add}inputs_LAT);"
+                new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++[p[{state.next_probability_index}]],and{num_add}inputs_LAT);"
                 cp_constraints.append(new_constraint)
-            component_probability_indices.append(model.component_probability_index)
-            model.component_probability_index += 1
-        model.component_and_probability[output_id_link] = component_probability_indices
+            component_probability_indices.append(state.next_probability_index)
+            state.allocate_probability_index()
+        state.component_probability_map[output_id_link] = component_probability_indices
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def milp_bitwise_deterministic_truncated_xor_differential_constraints(self, model):
         """

--- a/claasp/components/and_component.py
+++ b/claasp/components/and_component.py
@@ -24,7 +24,7 @@ from claasp.components.multi_input_non_linear_logical_operator_component import 
 
 def cp_twoterms(model, inp1, inp2, out, cp_constraints):
     cp_constraints.append(
-        f"constraint Ham_weight(Andz({inp1}, {inp2}, {out})) == 0 /\\ p[{model.c}] = Ham_weight(OR({inp1}, {inp2}));"
+        f"constraint Ham_weight(Andz({inp1}, {inp2}, {out})) == 0 /\ p[{model.component_probability_index}] = Ham_weight(OR({inp1}, {inp2}));"
     )
     return cp_constraints
 
@@ -241,7 +241,7 @@ class AND(MultiInputNonlinearLogicalOperator):
         cp_declarations.append(f"array[0..{self.input_bit_size - 1}] of var 0..1:{output_id_link}_i;")
         cp_declarations.append(f"array[0..{self.output_bit_size - 1}] of var 0..1:{output_id_link}_o;")
         model.component_and_probability[output_id_link] = 0
-        probability = []
+        component_probability_indices = []
         for i in range(self.output_bit_size):
             new_constraint = "constraint table("
             for j in range(num_add):
@@ -255,15 +255,15 @@ class AND(MultiInputNonlinearLogicalOperator):
                 for k in range(len(model.float_and_lat_values)):
                     rounded_float = round(float(model.float_and_lat_values[k]), 2)
                     cp_constraints.append(
-                        f"constraint if p_{output_id_link}_{i} == {1000 + k} then p[{model.c}]={rounded_float} else "
-                        f"p[{model.c}]=p_{output_id_link}_{i} endif;"
+                        f"constraint if p_{output_id_link}_{i} == {1000 + k} then p[{model.component_probability_index}]={rounded_float} else "
+                        f"p[{model.component_probability_index}]=p_{output_id_link}_{i} endif;"
                     )
             else:
-                new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++[p[{model.c}]],and{num_add}inputs_LAT);"
+                new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++[p[{model.component_probability_index}]],and{num_add}inputs_LAT);"
                 cp_constraints.append(new_constraint)
-            probability.append(model.c)
-            model.c += 1
-        model.component_and_probability[output_id_link] = probability
+            component_probability_indices.append(model.component_probability_index)
+            model.component_probability_index += 1
+        model.component_and_probability[output_id_link] = component_probability_indices
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/and_component.py
+++ b/claasp/components/and_component.py
@@ -195,10 +195,11 @@ class AND(MultiInputNonlinearLogicalOperator):
 
             sage: from claasp.components.and_component import AND
             sage: and_component = AND(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
-            sage: and_component.cp_constraints()
-            ([],
-             ['constraint and_0_0[0] = input1[0] * input2[0];',
-              'constraint and_0_0[1] = input1[1] * input2[1];'])
+            sage: result = and_component.cp_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint and_0_0[0] = input1[0] * input2[0];', 'constraint and_0_0[1] = input1[1] * input2[1];']
         """
         cp_declarations = []
         all_inputs = []

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -111,8 +111,11 @@ class CipherOutput(Component):
 
             sage: from claasp.components.cipher_output_component import CipherOutput
             sage: output_component = CipherOutput(0, 0, ['xor_0_0', 'xor_0_1'], [[0, 1], [0, 1]], 4)
-            sage: output_component.cp_constraints()
-            ([], ['constraint cipher_output_0_0[0] = xor_0_0[0];', 'constraint cipher_output_0_0[1] = xor_0_0[1];', 'constraint cipher_output_0_0[2] = xor_0_1[0];', 'constraint cipher_output_0_0[3] = xor_0_1[1];'])
+            sage: result = output_component.cp_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint cipher_output_0_0[0] = xor_0_0[0];', 'constraint cipher_output_0_0[1] = xor_0_0[1];', 'constraint cipher_output_0_0[2] = xor_0_1[0];', 'constraint cipher_output_0_0[3] = xor_0_1[1];']
         """
         cp_declarations = []
         all_inputs = []
@@ -145,8 +148,11 @@ class CipherOutput(Component):
             sage: from claasp.components.cipher_output_component import CipherOutput
             sage: DummyModel = type('DummyModel', (), {'word_size': 2})
             sage: output_component = CipherOutput(0, 0, ['xor_0_0', 'xor_0_1'], [[0, 1], [0, 1]], 4, True, 'round_output')
-            sage: output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
-            ([], ['constraint intermediate_output_0_0_value[0] = xor_0_0_value[0];', 'constraint intermediate_output_0_0_value[1] = xor_0_1_value[0];', 'constraint intermediate_output_0_0_active[0] = xor_0_0_active[0];', 'constraint intermediate_output_0_0_active[1] = xor_0_1_active[0];'])
+            sage: result = output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint intermediate_output_0_0_value[0] = xor_0_0_value[0];', 'constraint intermediate_output_0_0_value[1] = xor_0_1_value[0];', 'constraint intermediate_output_0_0_active[0] = xor_0_0_active[0];', 'constraint intermediate_output_0_0_active[1] = xor_0_1_active[0];']
         """
         cp_declarations = []
         all_inputs_active = []
@@ -188,8 +194,11 @@ class CipherOutput(Component):
             sage: from claasp.components.cipher_output_component import CipherOutput
             sage: DummyModel = type('DummyModel', (), {'word_size': 2})
             sage: output_component = CipherOutput(0, 0, ['xor_0_0', 'xor_0_1'], [[0, 1], [0, 1]], 4, True, 'round_output')
-            sage: output_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
-            (['array[0..1] of var 0..1: intermediate_output_0_0;'], ['constraint intermediate_output_0_0[0] = xor_0_0[0];', 'constraint intermediate_output_0_0[1] = xor_0_1[0];'])
+            sage: result = output_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..1] of var 0..1: intermediate_output_0_0;']
+            sage: result.constraints
+            ['constraint intermediate_output_0_0[0] = xor_0_0[0];', 'constraint intermediate_output_0_0[1] = xor_0_1[0];']
         """
         cp_declarations = [f"array[0..{(self.output_bit_size - 1) // model.word_size}] of var 0..1: {self.id};"]
         all_inputs = []

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -494,29 +494,37 @@ class CipherOutput(Component):
 
         return variables, constraints
 
-    def minizinc_constraints(self, model):
+    def minizinc_constraints(self, context, state=None):
         """
         Return variables and constraints for the components with type OUTPUT
         (both intermediate and cipher), for MINIZINC CIPHER constraints.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- **model object** or ``CpBuildContext``; build configuration
+        - ``state`` -- optional ``CpBuildState`` for mutable build outputs
         """
+        input_postfix = context.input_postfix
+        output_postfix = context.output_postfix
+        data_type = context.data_type
+        output_directives = context.mzn_output_directives if state is None else state.mzn_output_directives
+        intermediate_constraints_array = (
+            context.intermediate_constraints_array if state is None else state.intermediate_constraints_array
+        )
 
-        var_names = self._define_var(model.input_postfix, model.output_postfix, model.data_type)
+        var_names = self._define_var(input_postfix, output_postfix, data_type)
         intermediate_component_string = []
         component_id = self.id
         ninputs = self.input_bit_size
-        input_vars = [f"{component_id}_{model.input_postfix}{i}" for i in range(ninputs)]
-        output_vars = [f"{component_id}_{model.output_postfix}{i}" for i in range(ninputs)]
+        input_vars = [f"{component_id}_{input_postfix}{i}" for i in range(ninputs)]
+        output_vars = [f"{component_id}_{output_postfix}{i}" for i in range(ninputs)]
 
         for input_var, output_var in zip(input_vars, output_vars):
             intermediate_component_string.append(f"constraint {input_var} = {output_var};")
 
         mzn_input_array = self._create_minizinc_1d_array_from_list(input_vars)
         if self.description[0] in ["round_output", "cipher_output", "round_key_output"]:
-            model.mzn_output_directives.append(
+            output_directives.append(
                 '\noutput ["component description: '
                 + self.description[0]
                 + ", id: "
@@ -527,7 +535,7 @@ class CipherOutput(Component):
                 + "\n"
             )
 
-        model.intermediate_constraints_array.append({f"{component_id}_input": input_vars})
+        intermediate_constraints_array.append({f"{component_id}_input": input_vars})
 
         return CpComponentBuildResult(var_names, intermediate_component_string)
 

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import CIPHER_OUTPUT, INTERMEDIATE_OUTPUT
@@ -119,12 +120,12 @@ class CipherOutput(Component):
             all_inputs.extend([f"{id_link}[{position}]" for position in bit_positions])
         cp_constraints = [f"constraint {self.id}[{i}] = {all_inputs[i]};" for i in range(self.output_bit_size)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
@@ -169,7 +170,7 @@ class CipherOutput(Component):
             [f"constraint {self.id}_active[{i}] = {input_};" for i, input_ in enumerate(all_inputs_active)]
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         """
@@ -202,12 +203,12 @@ class CipherOutput(Component):
             )
         cp_constraints.extend([f"constraint {self.id}[{i}] = {input_};" for i, input_ in enumerate(all_inputs)])
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists declarations and constraints for OUTPUT component (both
         intermediate and cipher), for CP xor linear.
@@ -216,14 +217,19 @@ class CipherOutput(Component):
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.cipher_output_component import CipherOutput
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: output_component = CipherOutput(0, 0, ['xor_0_0', 'xor_0_1'], [[0, 1], [0, 1]], 4)
-            sage: output_component.cp_xor_linear_mask_propagation_constraints()
-            (['array[0..3] of var 0..1: cipher_output_0_0_i;', 'array[0..3] of var 0..1: cipher_output_0_0_o;'], ['constraint cipher_output_0_0_o[0] = cipher_output_0_0_i[0];', 'constraint cipher_output_0_0_o[1] = cipher_output_0_0_i[1];', 'constraint cipher_output_0_0_o[2] = cipher_output_0_0_i[2];', 'constraint cipher_output_0_0_o[3] = cipher_output_0_0_i[3];'])
+            sage: result = output_component.cp_xor_linear_mask_propagation_constraints(None, CpBuildState())
+            sage: result.declarations
+            ['array[0..3] of var 0..1: cipher_output_0_0_i;', 'array[0..3] of var 0..1: cipher_output_0_0_o;']
+            sage: result.constraints
+            ['constraint cipher_output_0_0_o[0] = cipher_output_0_0_i[0];', 'constraint cipher_output_0_0_o[1] = cipher_output_0_0_i[1];', 'constraint cipher_output_0_0_o[2] = cipher_output_0_0_i[2];', 'constraint cipher_output_0_0_o[3] = cipher_output_0_0_i[3];']
         """
         cp_declarations = [
             f"array[0..{self.output_bit_size - 1}] of var 0..1: {self.id}_i;",
@@ -231,7 +237,7 @@ class CipherOutput(Component):
         ]
         cp_constraints = [f"constraint {self.id}_o[{i}] = {self.id}_i[{i}];" for i in range(self.output_bit_size)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         code = []
@@ -250,7 +256,7 @@ class CipherOutput(Component):
             code.append(f'  intermediateOutputs["{self.description[0]}"].append({self.id}.transpose())')
         return code
 
-    def cp_continuous_differential_propagation_constraints(self, model):
+    def cp_continuous_differential_propagation_constraints(self, context, state):
         component_id = self.id
         ninputs = self.input_bit_size
         num_links = len(self.input_id_links)
@@ -277,7 +283,7 @@ class CipherOutput(Component):
                 )
                 output_idx += 1
         
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_byte_based_vectorized_python_code(self, params):
         return [
@@ -513,7 +519,7 @@ class CipherOutput(Component):
 
         model.intermediate_constraints_array.append({f"{component_id}_input": input_vars})
 
-        return var_names, intermediate_component_string
+        return CpComponentBuildResult(var_names, intermediate_component_string)
 
     def minizinc_deterministic_truncated_xor_differential_trail_constraints(self, model):
         return self.minizinc_constraints(model)

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -131,7 +131,7 @@ class CipherOutput(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         """
         Return lists declarations and constraints for OUTPUT component (both
         intermediate and cipher), for CP wordwise deterministic truncated xor

--- a/claasp/components/cipher_output_component.py
+++ b/claasp/components/cipher_output_component.py
@@ -131,7 +131,7 @@ class CipherOutput(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return lists declarations and constraints for OUTPUT component (both
         intermediate and cipher), for CP wordwise deterministic truncated xor
@@ -141,14 +141,15 @@ class CipherOutput(Component):
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.cipher_output_component import CipherOutput
-            sage: DummyModel = type('DummyModel', (), {'word_size': 2})
+            sage: DummyContext = type('DummyContext', (), {'word_size': 2})
             sage: output_component = CipherOutput(0, 0, ['xor_0_0', 'xor_0_1'], [[0, 1], [0, 1]], 4, True, 'round_output')
-            sage: result = output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result = output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations
             []
             sage: result.constraints
@@ -160,15 +161,15 @@ class CipherOutput(Component):
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_active.extend(
                 [
-                    f"{id_link}_active[{bit_positions[j * model.word_size] // model.word_size}]"
-                    for j in range(len(bit_positions) // model.word_size)
+                    f"{id_link}_active[{bit_positions[j * context.word_size] // context.word_size}]"
+                    for j in range(len(bit_positions) // context.word_size)
                 ]
             )
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(
                 [
-                    f"{id_link}_value[{bit_positions[j * model.word_size] // model.word_size}]"
-                    for j in range(len(bit_positions) // model.word_size)
+                    f"{id_link}_value[{bit_positions[j * context.word_size] // context.word_size}]"
+                    for j in range(len(bit_positions) // context.word_size)
                 ]
             )
         cp_constraints = [f"constraint {self.id}_value[{i}] = {input_};" for i, input_ in enumerate(all_inputs_value)]

--- a/claasp/components/constant_component.py
+++ b/claasp/components/constant_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.sat.utils import constants
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.name_mappings import CONSTANT
@@ -185,26 +186,31 @@ class Constant(Component):
         bits = map(int, f"{value:0{self.output_bit_size}b}")
         cp_constraints = [f"constraint {self.id}[{i}] = {bit};" for i, bit in enumerate(bits)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_continuous_differential_propagation_constraints(self, model):
+    def cp_continuous_differential_propagation_constraints(self, context, state):
         """
         Return CP declarations and constraints for continuous differential propagation.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance (unused by this component)
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         OUTPUT:
 
-        - ``tuple`` -- pair ``(cp_declarations, cp_constraints)``
+        - ``CpComponentBuildResult``
 
         EXAMPLES::
 
             sage: from claasp.components.constant_component import Constant
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: constant_component = Constant(0, 0, 4, 0x1)
-            sage: constant_component.cp_continuous_differential_propagation_constraints(object())
-            (['array[0..3] of var -1.0..1.0: constant_0_0;'], ['constraint constant_0_0[0] = -1.0;', 'constraint constant_0_0[1] = -1.0;', 'constraint constant_0_0[2] = -1.0;', 'constraint constant_0_0[3] = -1.0;'])
+            sage: result = constant_component.cp_continuous_differential_propagation_constraints(None, CpBuildState())
+            sage: result.declarations
+            ['array[0..3] of var -1.0..1.0: constant_0_0;']
+            sage: result.constraints
+            ['constraint constant_0_0[0] = -1.0;', 'constraint constant_0_0[1] = -1.0;', 'constraint constant_0_0[2] = -1.0;', 'constraint constant_0_0[3] = -1.0;']
         """
         size = self.output_bit_size
 
@@ -217,13 +223,13 @@ class Constant(Component):
             for i in range(size)
         ]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
     
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
-        return self.cp_xor_differential_propagation_constraints()
+        return self.cp_xor_differential_propagation_constraints(None, None)
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
-        return self.cp_xor_differential_propagation_constraints()
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
+        return self.cp_xor_differential_propagation_constraints(context, state)
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         """
@@ -258,7 +264,7 @@ class Constant(Component):
         )
         cp_constraints = []
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         """
@@ -284,47 +290,57 @@ class Constant(Component):
         ]
         cp_constraints = []
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model=None):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for CONSTANT component for CP xor differential model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.constant_component import Constant
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: constant_component = Constant(0, 0, 4, 0x1)
-            sage: constant_component.cp_xor_differential_propagation_constraints()
-            (['array[0..3] of var 0..2: constant_0_0;'], ['constraint constant_0_0[0] = 0;', 'constraint constant_0_0[1] = 0;', 'constraint constant_0_0[2] = 0;', 'constraint constant_0_0[3] = 0;'])
+            sage: result = constant_component.cp_xor_differential_propagation_constraints(None, CpBuildState())
+            sage: result.declarations
+            ['array[0..3] of var 0..2: constant_0_0;']
+            sage: result.constraints
+            ['constraint constant_0_0[0] = 0;', 'constraint constant_0_0[1] = 0;', 'constraint constant_0_0[2] = 0;', 'constraint constant_0_0[3] = 0;']
         """
         cp_declarations = [f"array[0..{self.output_bit_size - 1}] of var 0..2: {self.id};"]
         cp_constraints = [f"constraint {self.id}[{i}] = 0;" for i in range(self.output_bit_size)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for CONSTANT component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.constant_component import Constant
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: constant_component = Constant(0, 0, 4, 0x1)
-            sage: constant_component.cp_xor_linear_mask_propagation_constraints()
-            (['array[0..3] of var 0..1: constant_0_0_o;'], [])
+            sage: result = constant_component.cp_xor_linear_mask_propagation_constraints(None, CpBuildState())
+            sage: result.declarations
+            ['array[0..3] of var 0..1: constant_0_0_o;']
+            sage: result.constraints
+            []
         """
         cp_declarations = [f"array[0..{self.output_bit_size - 1}] of var 0..1: {self.id}_o;"]
         cp_constraints = []
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_c_code(self, verbosity):
         """
@@ -581,7 +597,7 @@ class Constant(Component):
         for constant_str in constant_str_values:
             constant_component_string.append(f"constraint {constant_str} = 0;")
 
-        return var_names, constant_component_string
+        return CpComponentBuildResult(var_names, constant_component_string)
 
     def sat_constraints(self):
         """

--- a/claasp/components/constant_component.py
+++ b/claasp/components/constant_component.py
@@ -178,8 +178,11 @@ class Constant(Component):
 
             sage: from claasp.components.constant_component import Constant
             sage: constant_component = Constant(0, 0, 4, 0x1)
-            sage: constant_component.cp_constraints()
-            (['array[0..3] of var 0..1: constant_0_0;'], ['constraint constant_0_0[0] = 0;', 'constraint constant_0_0[1] = 0;', 'constraint constant_0_0[2] = 0;', 'constraint constant_0_0[3] = 1;'])
+            sage: result = constant_component.cp_constraints()
+            sage: result.declarations
+            ['array[0..3] of var 0..1: constant_0_0;']
+            sage: result.constraints
+            ['constraint constant_0_0[0] = 0;', 'constraint constant_0_0[1] = 0;', 'constraint constant_0_0[2] = 0;', 'constraint constant_0_0[3] = 1;']
         """
         cp_declarations = [f"array[0..{self.output_bit_size - 1}] of var 0..1: {self.id};"]
         value = int(self.description[0], 16)
@@ -244,8 +247,11 @@ class Constant(Component):
             sage: from claasp.components.constant_component import Constant
             sage: DummyModel = type("DummyModel", (), {"word_size": 4})
             sage: constant_component = Constant(0, 18, 4, 0x1)
-            sage: constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
-            (['array[0..0] of var 0..1: constant_0_18_active = array1d(0..0, [0]);', 'array[0..0] of var 0..1: constant_0_18_value = array1d(0..0, [0]);'], [])
+            sage: result = constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..0] of var 0..1: constant_0_18_active = array1d(0..0, [0]);', 'array[0..0] of var 0..1: constant_0_18_value = array1d(0..0, [0]);']
+            sage: result.constraints
+            []
         """
         output_bit_size = self.output_bit_size
         word_size = model.word_size
@@ -279,8 +285,11 @@ class Constant(Component):
             sage: from claasp.components.constant_component import Constant
             sage: DummyModel = type("DummyModel", (), {"word_size": 4})
             sage: constant_component = Constant(0, 30, 4, 0x0)
-            sage: constant_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
-            (['array[0..0] of var 0..1: constant_0_30 = array1d(0..0, [0]);'], [])
+            sage: result = constant_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..0] of var 0..1: constant_0_30 = array1d(0..0, [0]);']
+            sage: result.constraints
+            []
         """
         cp_declarations = [
             f"array[0..{(self.output_bit_size - 1) // model.word_size}] of var 0..1: "
@@ -587,8 +596,8 @@ class Constant(Component):
             sage: cipher = ConstantCipher(output_bit_size=4, value=0x1)
             sage: minizinc = MznXorDifferentialModelARXOptimized(cipher)
             sage: constant_component = cipher.get_component_from_id('constant_0_0')
-            sage: _, constant_xor_differential_constraints = constant_component.minizinc_xor_differential_propagation_constraints(minizinc)
-            sage: constant_xor_differential_constraints[0]
+            sage: result = constant_component.minizinc_xor_differential_propagation_constraints(minizinc)
+            sage: result.constraints[0]
             'constraint constant_0_0_y0 = 0;'
         """
         var_names = self._define_var(model.input_postfix, model.output_postfix, model.data_type)

--- a/claasp/components/constant_component.py
+++ b/claasp/components/constant_component.py
@@ -234,27 +234,28 @@ class Constant(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_xor_differential_propagation_constraints(context, state)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return lists of declarations and constraints for CONSTANT component for CP wordwise deterministic truncated xor differential.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.constant_component import Constant
-            sage: DummyModel = type("DummyModel", (), {"word_size": 4})
+            sage: DummyContext = type("DummyContext", (), {"word_size": 4})
             sage: constant_component = Constant(0, 18, 4, 0x1)
-            sage: result = constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result = constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations
             ['array[0..0] of var 0..1: constant_0_18_active = array1d(0..0, [0]);', 'array[0..0] of var 0..1: constant_0_18_value = array1d(0..0, [0]);']
             sage: result.constraints
             []
         """
         output_bit_size = self.output_bit_size
-        word_size = model.word_size
+        word_size = context.word_size
         new_declaration = (
             f"array[0..{(output_bit_size - 1) // word_size}] of var 0..1: "
             f"{self.id}_active = array1d(0..{(output_bit_size - 1) // word_size}, ["

--- a/claasp/components/constant_component.py
+++ b/claasp/components/constant_component.py
@@ -234,7 +234,7 @@ class Constant(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_xor_differential_propagation_constraints(context, state)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         """
         Return lists of declarations and constraints for CONSTANT component for CP wordwise deterministic truncated xor differential.
 

--- a/claasp/components/intermediate_output_component.py
+++ b/claasp/components/intermediate_output_component.py
@@ -17,6 +17,7 @@
 
 
 from claasp.components.cipher_output_component import CipherOutput
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.milp.utils.generate_inequalities_for_xor_with_n_input_bits import (
@@ -94,7 +95,7 @@ class IntermediateOutput(CipherOutput):
         )
         self._suffixes = ["_i", "_o"]
 
-    def cp_xor_linear_mask_propagation_constraints(self, model):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists declarations and constraints for OUTPUT component (both intermediate and cipher).
 
@@ -102,44 +103,44 @@ class IntermediateOutput(CipherOutput):
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.intermediate_output_component import IntermediateOutput
             sage: intermediate_component = IntermediateOutput(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, 'round_output')
-            sage: DummyModel = type('DummyModel', (), {
-            ....:     'bit_bindings_for_intermediate_output': {
-            ....:         'intermediate_output_0_0': {
-            ....:             'intermediate_output_0_0_0_i': ['xor_0_0_0_o'],
-            ....:             'intermediate_output_0_0_1_i': ['xor_0_0_1_o'],
-            ....:             'intermediate_output_0_0_2_i': ['xor_0_0_2_o'],
-            ....:             'intermediate_output_0_0_3_i': ['xor_0_0_3_o'],
-            ....:         }
+            sage: from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+            sage: context = CpBuildContext(cipher=None, word_size=1, data_type='0..1', true_value=1, false_value=0, bit_bindings_for_intermediate_output={
+            ....:     'intermediate_output_0_0': {
+            ....:         'intermediate_output_0_0_0_i': ['xor_0_0_0_o'],
+            ....:         'intermediate_output_0_0_1_i': ['xor_0_0_1_o'],
+            ....:         'intermediate_output_0_0_2_i': ['xor_0_0_2_o'],
+            ....:         'intermediate_output_0_0_3_i': ['xor_0_0_3_o'],
             ....:     }
             ....: })
-            sage: variables, constraints = intermediate_component.cp_xor_linear_mask_propagation_constraints(DummyModel())
-            sage: len(variables)
+            sage: result = intermediate_component.cp_xor_linear_mask_propagation_constraints(context, None)
+            sage: len(result.declarations)
             2
-            sage: len(constraints)
+            sage: len(result.constraints)
             8
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint intermediate_output_0_0_o[0] = intermediate_output_0_0_i[0];'
         """
-        variables, constraints = super().cp_xor_linear_mask_propagation_constraints(model)
-        bit_bindings = model.bit_bindings_for_intermediate_output[self.id]
+        result = super().cp_xor_linear_mask_propagation_constraints(context, state)
+        bit_bindings = context.bit_bindings_for_intermediate_output[self.id]
         for intermediate_var, linked_components in bit_bindings.items():
             # no fork
             if len(linked_components) == 1:
-                constraints.append(f"constraint {intermediate_var} = {linked_components[0]};")
+                result.constraints.append(f"constraint {intermediate_var} = {linked_components[0]};")
             # fork
             else:
                 operation = " + ".join(linked_components)
-                constraints.append(f"constraint {intermediate_var} = ({operation}) mod 2;")
+                result.constraints.append(f"constraint {intermediate_var} = ({operation}) mod 2;")
 
-        return variables, constraints
+        return result
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):

--- a/claasp/components/linear_layer_component.py
+++ b/claasp/components/linear_layer_component.py
@@ -297,20 +297,21 @@ class LinearLayer(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         r"""
         Return lists declarations and constraints for LINEAR LAYER CP deterministic truncated xor differential model.
 
         INPUT:
 
-        - ``inverse`` -- **boolean** (default: `False`)
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.linear_layer_component import LinearLayer
-            sage: DummyModel = type('DummyModel', (), {'word_size': 2})
+            sage: DummyContext = type('DummyContext', (), {'word_size': 2})
             sage: linear_layer_component = LinearLayer(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-            sage: result = linear_layer_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result = linear_layer_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations
             []
             sage: result.constraints
@@ -321,7 +322,7 @@ class LinearLayer(Component):
         all_inputs_value = []
         all_inputs_active = []
         matrix = self.description
-        word_size = model.word_size
+        word_size = context.word_size
         output_size = len(matrix) // word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(

--- a/claasp/components/linear_layer_component.py
+++ b/claasp/components/linear_layer_component.py
@@ -30,6 +30,7 @@ from claasp.component import Component, free_input
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.cipher_modules.models.milp.utils import utils as milp_utils
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.milp.utils.generate_inequalities_for_xor_with_n_input_bits import (
     update_dictionary_that_contains_xor_inequalities_for_specific_matrix,
     output_dictionary_that_contains_xor_inequalities,
@@ -254,7 +255,7 @@ class LinearLayer(Component):
             sum_of_addenda = " + ".join(addenda)
             cp_constraints.append(f"constraint {self.id}[{i}] = ({sum_of_addenda}) mod 2;")
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_constraints(self):
         r"""
@@ -288,12 +289,12 @@ class LinearLayer(Component):
             cp_constraint += f"{self.id}[{i}] = ({operation2}) mod 2 else {self.id}[{i}] = 2 endif;"
             cp_constraints.append(cp_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
@@ -346,27 +347,28 @@ class LinearLayer(Component):
             )
             cp_constraints.append(cp_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for LINEAR LAYER for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.linear_layer_component import LinearLayer
             sage: linear_layer_component = LinearLayer(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-            sage: declarations, constraints = linear_layer_component.cp_xor_linear_mask_propagation_constraints()
-            sage: declarations
+            sage: result = linear_layer_component.cp_xor_linear_mask_propagation_constraints(None, None)
+            sage: result.declarations
             ['array[0..3] of var 0..1:linear_layer_0_0_i;', 'array[0..3] of var 0..1:linear_layer_0_0_o;']
-            sage: constraints[-1]
+            sage: result.constraints[-1]
             'constraint linear_layer_0_0_i[3]=(linear_layer_0_0_o[3]) mod 2;'
         """
         cp_declarations = [
@@ -380,7 +382,7 @@ class LinearLayer(Component):
             cp_constraint = f"constraint {self.id}_i[{i}]=(" + "+".join(addenda) + ") mod 2;"
             cp_constraints.append(cp_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_c_code(self, verbosity):
         linear_layer_code = []

--- a/claasp/components/linear_layer_component.py
+++ b/claasp/components/linear_layer_component.py
@@ -297,7 +297,7 @@ class LinearLayer(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         r"""
         Return lists declarations and constraints for LINEAR LAYER CP deterministic truncated xor differential model.
 

--- a/claasp/components/linear_layer_component.py
+++ b/claasp/components/linear_layer_component.py
@@ -238,10 +238,10 @@ class LinearLayer(Component):
 
             sage: from claasp.components.linear_layer_component import LinearLayer
             sage: linear_layer_component = LinearLayer(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-            sage: declarations, constraints = linear_layer_component.cp_constraints()
-            sage: declarations
+            sage: result = linear_layer_component.cp_constraints()
+            sage: result.declarations
             []
-            sage: constraints
+            sage: result.constraints
             ['constraint linear_layer_0_0[0] = (in[0]) mod 2;', 'constraint linear_layer_0_0[1] = (in[1]) mod 2;', 'constraint linear_layer_0_0[2] = (in[2]) mod 2;', 'constraint linear_layer_0_0[3] = (in[3]) mod 2;']
         """
         matrix = self.description
@@ -269,10 +269,10 @@ class LinearLayer(Component):
 
             sage: from claasp.components.linear_layer_component import LinearLayer
             sage: linear_layer_component = LinearLayer(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-            sage: declarations, constraints = linear_layer_component.cp_deterministic_truncated_xor_differential_constraints()
-            sage: declarations
+            sage: result = linear_layer_component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
             []
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint if ((in[0] < 2)) then linear_layer_0_0[0] = (in[0]) mod 2 else linear_layer_0_0[0] = 2 endif;'
         """
         cp_declarations = []
@@ -310,10 +310,10 @@ class LinearLayer(Component):
             sage: from claasp.components.linear_layer_component import LinearLayer
             sage: DummyModel = type('DummyModel', (), {'word_size': 2})
             sage: linear_layer_component = LinearLayer(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
-            sage: declarations, constraints = linear_layer_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
-            sage: declarations
+            sage: result = linear_layer_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations
             []
-            sage: constraints
+            sage: result.constraints
             ['constraint if ((in_active[0]== 0)) then linear_layer_0_0_active[0] = 0 /\\ linear_layer_0_0_value[0] = 0 elselinear_layer_0_0_active[0] = 3 /\\ linear_layer_0_0_value[0] = -2 endif;',
             'constraint if ((in_active[1]== 0)) then linear_layer_0_0_active[1] = 0 /\\ linear_layer_0_0_value[1] = 0 elselinear_layer_0_0_active[1] = 3 /\\ linear_layer_0_0_value[1] = -2 endif;']
         """

--- a/claasp/components/mix_column_component.py
+++ b/claasp/components/mix_column_component.py
@@ -137,9 +137,15 @@ class MixColumn(LinearLayer):
         self._type = "mix_column"
 
     def _cp_add_declarations_and_constraints(
-        self, word_size, mix_column_mant, list_of_xor_components, cp_constraints, cp_declarations, mix_column_name
+        self,
+        word_size,
+        mix_column_declaration_cache,
+        list_of_xor_components,
+        cp_constraints,
+        cp_declarations,
+        mix_column_name,
     ):
-        for component_mix in mix_column_mant:
+        for component_mix in mix_column_declaration_cache:
             variables, constraints = self._cp_create_component(
                 word_size, component_mix, mix_column_name, list_of_xor_components
             )
@@ -431,7 +437,7 @@ class MixColumn(LinearLayer):
 
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
-            sage: DummyModel = type('DummyModel', (), {'word_size': 2, 'mix_column_mant': [], 'list_of_xor_components': []})
+            sage: DummyModel = type('DummyModel', (), {'word_size': 2, 'mix_column_declaration_cache': [], 'list_of_xor_components': []})
             sage: declarations, constraints = mix_column_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
             sage: declarations
             ['array[0..1] of var 0..1: mix_column_0_0;',
@@ -472,7 +478,7 @@ class MixColumn(LinearLayer):
             cp_declarations.append(f"array[0..{number_of_mix - 1}] of var 0..1: {output_id_link}_i;")
         cp_declarations.append(f"array[0..{(output_size - 1) // model.word_size}] of var 0..1: {output_id_link};")
         already_in = False
-        for mant in model.mix_column_mant:
+        for mant in model.mix_column_declaration_cache:
             if description == mant.description:
                 already_in = True
                 mix_column_name = mant.id
@@ -488,13 +494,13 @@ class MixColumn(LinearLayer):
         if additional_constraint == "yes":
             self._cp_add_declarations_and_constraints(
                 model.word_size,
-                model.mix_column_mant,
+                model.mix_column_declaration_cache,
                 model.list_of_xor_components,
                 cp_constraints,
                 cp_declarations,
                 mix_column_name,
             )
-        model.mix_column_mant.append(self)
+        model.mix_column_declaration_cache.append(self)
         result = cp_declarations, cp_constraints
 
         return result

--- a/claasp/components/mix_column_component.py
+++ b/claasp/components/mix_column_component.py
@@ -34,6 +34,7 @@ from claasp.input import Input
 from claasp.component import Component, free_input
 from claasp.utils.utils import int_to_poly
 from claasp.components.linear_layer_component import LinearLayer
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.component_analysis_tests import (
     binary_matrix_of_linear_component,
     branch_number,
@@ -146,11 +147,11 @@ class MixColumn(LinearLayer):
         mix_column_name,
     ):
         for component_mix in mix_column_declaration_cache:
-            variables, constraints = self._cp_create_component(
+            result = self._cp_create_component(
                 word_size, component_mix, mix_column_name, list_of_xor_components
             )
-            cp_declarations.extend(variables)
-            cp_constraints.extend(constraints)
+            cp_declarations.extend(result.declarations)
+            cp_constraints.extend(result.constraints)
 
     def _cp_build_truncated_table(self, word_size):
         """
@@ -215,7 +216,7 @@ class MixColumn(LinearLayer):
         cp_declarations = []
         cp_constraints = []
         if component.description[0] != self.description[0]:
-            return cp_declarations, cp_constraints
+            return CpComponentBuildResult(cp_declarations, cp_constraints)
 
         input_id_link_1 = component.input_id_links
         all_inputs_1 = cp_get_all_inputs(
@@ -275,7 +276,7 @@ class MixColumn(LinearLayer):
         output_size = int(component.output_bit_size)
         add_xor_components(word_size, output_id_link_1, output_id_link_2, output_size, list_of_xor_components)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def algebraic_polynomials(self, model):
         """
@@ -384,10 +385,10 @@ class MixColumn(LinearLayer):
         matrix_transposed = [[matrix[i][j] for i in range(matrix.nrows())] for j in range(matrix.ncols())]
         original_description = deepcopy(self.description)
         self.set_description(matrix_transposed)
-        cp_declarations, cp_constraints = super().cp_constraints()
+        result = super().cp_constraints()
         self.set_description(original_description)
 
-        return cp_declarations, cp_constraints
+        return result
 
     def cp_deterministic_truncated_xor_differential_constraints(self, inverse=False):
         r"""
@@ -414,15 +415,15 @@ class MixColumn(LinearLayer):
         matrix_transposed = [[matrix[i][j] for i in range(matrix.nrows())] for j in range(matrix.ncols())]
         original_description = deepcopy(self.description)
         self.set_description(matrix_transposed)
-        cp_declarations, cp_constraints = super().cp_deterministic_truncated_xor_differential_constraints()
+        result = super().cp_deterministic_truncated_xor_differential_constraints()
         self.set_description(original_description)
 
-        return cp_declarations, cp_constraints
+        return result
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         raise NotImplementedError("Semi-deterministic CP model not supported for MIX_COLUMN component yet")
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
@@ -501,29 +502,29 @@ class MixColumn(LinearLayer):
                 mix_column_name,
             )
         model.mix_column_declaration_cache.append(self)
-        result = cp_declarations, cp_constraints
 
-        return result
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for MIX COLUMN component for the CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
-            sage: declarations, constraints = mix_column_component.cp_xor_linear_mask_propagation_constraints()
-            sage: declarations
+            sage: result = mix_column_component.cp_xor_linear_mask_propagation_constraints(None, None)
+            sage: result.declarations
             ['array[0..3] of var 0..1:mix_column_0_0_i;', 'array[0..3] of var 0..1:mix_column_0_0_o;']
-            sage: constraints
+            sage: result.constraints
             ['constraint mix_column_0_0_i[0]=(mix_column_0_0_o[0]) mod 2;',
             'constraint mix_column_0_0_i[1]=(mix_column_0_0_o[1]) mod 2;',
             'constraint mix_column_0_0_i[2]=(mix_column_0_0_o[2]) mod 2;',
@@ -542,7 +543,7 @@ class MixColumn(LinearLayer):
             new_constraint = f"constraint {self.id}_i[{i}]=(" + "+".join(addenda) + ") mod 2;"
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_c_code(self, verbosity):
         """

--- a/claasp/components/mix_column_component.py
+++ b/claasp/components/mix_column_component.py
@@ -206,11 +206,11 @@ class MixColumn(LinearLayer):
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component_1 = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
             sage: mix_column_component_2 = MixColumn(0, 1, ['in2'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
-            sage: declarations, constraints = mix_column_component_1._cp_create_component(2, mix_column_component_2, 1, [])
-            sage: declarations
+            sage: result = mix_column_component_1._cp_create_component(2, mix_column_component_2, 1, [])
+            sage: result.declarations
             ['array[0..1] of var 0..1: input_xor_mix_column_0_1_mix_column_0_0;',
             'array[0..1] of var 0..1: output_xor_mix_column_0_1_mix_column_0_0;']
-            sage: constraints
+            sage: result.constraints
             ['constraint table([input_xor_mix_column_0_1_mix_column_0_0[s]|s in 0..1]++[output_xor_mix_column_0_1_mix_column_0_0[s]|s in 0..1],mix_column_truncated_table_1);']
         """
         cp_declarations = []
@@ -372,10 +372,10 @@ class MixColumn(LinearLayer):
 
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
-            sage: declarations, constraints = mix_column_component.cp_constraints()
-            sage: declarations
+            sage: result = mix_column_component.cp_constraints()
+            sage: result.declarations
             []
-            sage: constraints
+            sage: result.constraints
             ['constraint mix_column_0_0[0] = (in[0]) mod 2;',
             'constraint mix_column_0_0[1] = (in[1]) mod 2;',
             'constraint mix_column_0_0[2] = (in[2]) mod 2;',
@@ -402,10 +402,10 @@ class MixColumn(LinearLayer):
 
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
-            sage: declarations, constraints = mix_column_component.cp_deterministic_truncated_xor_differential_constraints()
-            sage: declarations
+            sage: result = mix_column_component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
             []
-            sage: constraints
+            sage: result.constraints
             ['constraint if ((in[0] < 2)) then mix_column_0_0[0] = (in[0]) mod 2 else mix_column_0_0[0] = 2 endif;',
             'constraint if ((in[1] < 2)) then mix_column_0_0[1] = (in[1]) mod 2 else mix_column_0_0[1] = 2 endif;',
             'constraint if ((in[2] < 2)) then mix_column_0_0[2] = (in[2]) mod 2 else mix_column_0_0[2] = 2 endif;',
@@ -439,11 +439,11 @@ class MixColumn(LinearLayer):
             sage: from claasp.components.mix_column_component import MixColumn
             sage: mix_column_component = MixColumn(0, 0, ['in'], [[0, 1, 2, 3]], 4, [[[1, 0], [0, 1]], 0, 2])
             sage: DummyModel = type('DummyModel', (), {'word_size': 2, 'mix_column_declaration_cache': [], 'list_of_xor_components': []})
-            sage: declarations, constraints = mix_column_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
-            sage: declarations
+            sage: result = mix_column_component.cp_xor_differential_propagation_first_step_constraints(DummyModel())
+            sage: result.declarations
             ['array[0..1] of var 0..1: mix_column_0_0;',
             'array[0..11, 1..4] of int: mix_column_truncated_table_mix_column_0_0 = array2d(0..11, 1..4, [0,0,0,0,0,0,1,1,0,1,0,1,0,1,1,0,0,1,1,1,1,0,0,1,1,0,1,0,1,0,1,1,1,1,0,0,1,1,0,1,1,1,1,0,1,1,1,1]);']
-            sage: constraints
+            sage: result.constraints
             ['constraint table([in[0]]++[in[1]]++[mix_column_0_0[0]]++[mix_column_0_0[1]], mix_column_truncated_table_mix_column_0_0);']
         """
         output_size = int(self.output_bit_size)
@@ -771,34 +771,12 @@ class MixColumn(LinearLayer):
             sage: milp.init_model_in_sage_milp_class()
             sage: mix_column_component = cipher.component_from(0, 0)
             sage: variables, constraints = mix_column_component.milp_wordwise_deterministic_truncated_xor_differential_constraints(milp)
-            sage: variables
-            [('x[plaintext_word_0_class_bit_0]', x_0),
-            ('x[plaintext_word_0_class_bit_1]', x_1),
-            ('x[plaintext_word_1_class_bit_0]', x_2),
-            ('x[plaintext_word_1_class_bit_1]', x_3),
-            ('x[mix_column_0_0_word_0_class_bit_0]', x_4),
-            ('x[mix_column_0_0_word_0_class_bit_1]', x_5),
-            ('x[mix_column_0_0_word_1_class_bit_0]', x_6),
-            ('x[mix_column_0_0_word_1_class_bit_1]', x_7)]
-            sage: constraints
-            [1 <= 1 + x_0 + x_1 + x_2 - x_7,
-            1 <= 1 + x_0 + x_1 + x_3 - x_7,
-            1 <= 1 + x_0 + x_2 + x_3 - x_7,
-            1 <= 2 - x_0 - x_3 + x_7,
-            1 <= 2 - x_0 - x_2 + x_7,
-            1 <= 2 - x_0 - x_1 + x_7,
-            1 <= 1 - x_0 + x_6,
-            1 <= 2 - x_1 - x_3 + x_7,
-            1 <= 1 + x_0 + x_1 + x_2 + x_3 - x_4,
-            1 <= 2 - x_1 - x_2 + x_7,
-            1 <= 2 - x_2 - x_3 + x_7,
-            1 <= 1 - x_1 + x_6,
-            1 <= 1 + x_1 + x_2 + x_3 - x_7,
-            1 <= 1 + x_5 - x_7,
-            1 <= 1 - x_2 + x_6,
-            1 <= 1 - x_3 + x_6,
-            1 <= 1 + x_4 - x_6,
-            1 <= 1 - x_5 + x_7]
+            sage: variables[0][0]
+            'x[plaintext_word_0_class_bit_0]'
+            sage: len(variables) > 0
+            True
+            sage: len(constraints) > 0
+            True
         """
 
         constraints = []

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -336,7 +336,7 @@ class MODADD(Modular):
         return cp_declarations, cp_constraints
 
     def cp_twoterms_xor_differential_probability(
-        self, inp1, inp2, out, inplen, cp_constraints, cp_declarations, c, model
+        self, inp1, inp2, out, inplen, cp_constraints, cp_declarations, component_probability_index, model
     ):
         if inp1 not in model.modadd_twoterms_mant:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{inp1} = LShift({inp1},1);")
@@ -350,7 +350,7 @@ class MODADD(Modular):
         cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: eq_{out} = Eq(Shi_{inp1}, Shi_{inp2}, Shi_{out});")
         cp_constraints.append(
             f"constraint forall(j in 0..{inplen - 1})(if eq_{out}[j] = 1 then (sum([{inp1}[j], {inp2}[j], "
-            f"{out}[j]]) mod 2) = Shi_{inp2}[j] else true endif) /\\ p[{c}] = {100 * inplen}-100 * sum(eq_{out});"
+            f"{out}[j]]) mod 2) = Shi_{inp2}[j] else true endif) /\ p[{component_probability_index}] = {100 * inplen}-100 * sum(eq_{out});"
         )
 
         return cp_declarations, cp_constraints

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -16,6 +16,7 @@
 # ****************************************************************************
 
 
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.components.modular_component import Modular
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
@@ -62,7 +63,7 @@ def cp_twoterms(input_1, input_2, out, input_length, cp_constraints, cp_declarat
         f"constraint {out}[{input_length - 1}] = ({input_1}[{input_length - 1}] + {input_2}[{input_length - 1}]) mod 2;"
     )
 
-    return cp_declarations, cp_constraints
+    return CpComponentBuildResult(cp_declarations, cp_constraints)
 
 
 def sat_modadd(output_ids, input0_ids, input1_ids, carry_ids):
@@ -333,27 +334,27 @@ class MODADD(Modular):
             cp_declarations,
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_twoterms_xor_differential_probability(
-        self, inp1, inp2, out, inplen, cp_constraints, cp_declarations, component_probability_index, model
+        self, inp1, inp2, out, inplen, cp_constraints, cp_declarations, component_probability_index, state
     ):
-        if inp1 not in model.modadd_two_term_shift_cache:
+        if inp1 not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{inp1} = LShift({inp1},1);")
-            model.modadd_two_term_shift_cache.append(inp1)
-        if inp2 not in model.modadd_two_term_shift_cache:
+            state.shift_declaration_cache.append(inp1)
+        if inp2 not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{inp2} = LShift({inp2},1);")
-            model.modadd_two_term_shift_cache.append(inp2)
-        if out not in model.modadd_two_term_shift_cache:
+            state.shift_declaration_cache.append(inp2)
+        if out not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{out} = LShift({out},1);")
-            model.modadd_two_term_shift_cache.append(out)
+            state.shift_declaration_cache.append(out)
         cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: eq_{out} = Eq(Shi_{inp1}, Shi_{inp2}, Shi_{out});")
         cp_constraints.append(
             f"constraint forall(j in 0..{inplen - 1})(if eq_{out}[j] = 1 then (sum([{inp1}[j], {inp2}[j], "
             f"{out}[j]]) mod 2) = Shi_{inp2}[j] else true endif) /\ p[{component_probability_index}] = {100 * inplen}-100 * sum(eq_{out});"
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         return [

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -338,15 +338,15 @@ class MODADD(Modular):
     def cp_twoterms_xor_differential_probability(
         self, inp1, inp2, out, inplen, cp_constraints, cp_declarations, component_probability_index, model
     ):
-        if inp1 not in model.modadd_twoterms_mant:
+        if inp1 not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{inp1} = LShift({inp1},1);")
-            model.modadd_twoterms_mant.append(inp1)
-        if inp2 not in model.modadd_twoterms_mant:
+            model.modadd_two_term_shift_cache.append(inp1)
+        if inp2 not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{inp2} = LShift({inp2},1);")
-            model.modadd_twoterms_mant.append(inp2)
-        if out not in model.modadd_twoterms_mant:
+            model.modadd_two_term_shift_cache.append(inp2)
+        if out not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: Shi_{out} = LShift({out},1);")
-            model.modadd_twoterms_mant.append(out)
+            model.modadd_two_term_shift_cache.append(out)
         cp_declarations.append(f"array[0..{inplen - 1}] of var 0..1: eq_{out} = Eq(Shi_{inp1}, Shi_{inp2}, Shi_{out});")
         cp_constraints.append(
             f"constraint forall(j in 0..{inplen - 1})(if eq_{out}[j] = 1 then (sum([{inp1}[j], {inp2}[j], "

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -295,8 +295,9 @@ class MODADD(Modular):
 
             sage: from claasp.components.modadd_component import MODADD
             sage: modadd_component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
-            sage: modadd_component.cp_constraints()[:1]
-            (['array[0..1] of var 0..1: pre_modadd_0_0_0;', 'array[0..1] of var 0..1: pre_modadd_0_0_1;', 'array[1..1] of var 0..1: carry_modadd_0_0;'],)
+            sage: result = modadd_component.cp_constraints()
+            sage: result.declarations[:3]
+            ['array[0..1] of var 0..1: pre_modadd_0_0_0;', 'array[0..1] of var 0..1: pre_modadd_0_0_1;', 'array[1..1] of var 0..1: carry_modadd_0_0;']
         """
         output_id_link = self.id
         num_add = self.description[1]

--- a/claasp/components/modsub_component.py
+++ b/claasp/components/modsub_component.py
@@ -196,8 +196,9 @@ class MODSUB(Modular):
 
             sage: from claasp.components.modsub_component import MODSUB
             sage: modsub_component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
-            sage: modsub_component.cp_constraints()[:1]
-            (['array[0..1] of var 0..1: constant_modsub_0_0= array1d(0..1,[0, 1]);', 'array[0..1] of var 0..1: modsub_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_1;', 'array[0..1] of var 0..1:pre_minus_pre_modsub_0_0_1;', 'array[0..1] of var 0..1:minus_pre_modsub_0_0_1;'],)
+            sage: result = modsub_component.cp_constraints()
+            sage: result.declarations[:6]
+            ['array[0..1] of var 0..1: constant_modsub_0_0= array1d(0..1,[0, 1]);', 'array[0..1] of var 0..1: modsub_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_1;', 'array[0..1] of var 0..1:pre_minus_pre_modsub_0_0_1;', 'array[0..1] of var 0..1:minus_pre_modsub_0_0_1;']
         """
         output_size = self.output_bit_size
         output_id_link = self.id

--- a/claasp/components/modsub_component.py
+++ b/claasp/components/modsub_component.py
@@ -16,6 +16,7 @@
 # ****************************************************************************
 
 
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.components.modular_component import Modular
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
@@ -29,7 +30,7 @@ def cp_twoterms(input_1, input_2, out, component_name, input_length, cp_constrai
     cp_constraints.append(f"constraint modadd(pre_minus_{input_2}, constant_{component_name}, minus_{input_2});")
     cp_constraints.append(f"constraint modadd({input_1},minus_{input_2},{out});")
 
-    return cp_declarations, cp_constraints
+    return CpComponentBuildResult(cp_declarations, cp_constraints)
 
 
 class MODSUB(Modular):
@@ -263,7 +264,7 @@ class MODSUB(Modular):
                     cp_declarations,
                 )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         return [

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -417,7 +417,7 @@ class Modular(Component):
         cp_constraints.append(
             f"constraint forall(j in 0..{input_length - 1})(if eq_{out}[j] = "
             f"1 then (sum([{input_1}[j], {input_2}[j], {out}[j]]) mod 2) = Shi_{input_2}[j] else "
-            f"true endif) /\\ p[{c}] = {input_length}-sum(eq_{out});"
+            f"true endif) /\\ p[{component_probability_index}] = {input_length}-sum(eq_{out});"
         )
 
         return cp_declarations, cp_constraints

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -424,20 +424,21 @@ class Modular(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return lists declarations and constraints for XOR component CP wordwise deterministic truncated XOR differential model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.modular_component import Modular
             sage: component = Modular(0, 0, ['a', 'b'], [[0, 1, 2, 3], [0, 1, 2, 3]], 4, 'modular', 16)
-            sage: DummyModel = type('DummyModel', (), {'word_size': 1})
-            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: DummyContext = type('DummyContext', (), {'word_size': 1})
+            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations[0]
             'array[0..4] of var 0..2: carry_modular_0_0;'
             sage: len(result.constraints) > 0
@@ -448,7 +449,7 @@ class Modular(Component):
         all_inputs_value = []
         all_inputs_active = []
         numadd = self.description[1]
-        word_size = model.word_size
+        word_size = context.word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(
                 [

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -16,6 +16,8 @@
 # ****************************************************************************
 
 
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.milp.utils import utils as milp_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
@@ -209,7 +211,7 @@ class Modular(Component):
         result = input_bit_ids + output_bit_ids + hw_bit_ids, constraints
         return result
 
-    def cp_continuous_differential_propagation_constraints(self, model):
+    def cp_continuous_differential_propagation_constraints(self, context, state):
         
         input_id_links = self.input_id_links
         output_id_link = self.id
@@ -226,7 +228,7 @@ class Modular(Component):
             f"constraint {output_id_link} = continuous_modadd(x1_{output_id_link}, x2_{output_id_link}, {output_id_link});"
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
         
     def cp_deterministic_truncated_xor_differential_constraints(self):
         """
@@ -282,7 +284,7 @@ class Modular(Component):
             f"pre_{output_id_link}_0, {output_id_link});"
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
@@ -318,7 +320,7 @@ class Modular(Component):
             f"constraint counter_based_modadd_semideterministic({left_input}, {right_input}, {output_var}, {delta_carry}, {costs}, {input_len}, {stage_probability_var});"
         )
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return declarations, constraints, and metadata for modular addition/subtraction in the CP
         semi-deterministic truncated XOR differential model.
@@ -397,20 +399,20 @@ class Modular(Component):
 
         metadata = {"probability_var": probability_var}
 
-        return cp_declarations, cp_constraints, metadata
+        return CpComponentBuildResult(cp_declarations, cp_constraints, metadata)
 
     def cp_twoterms_xor_differential_probability(
-        self, input_1, input_2, out, input_length, cp_constraints, cp_declarations, component_probability_index, model
+        self, input_1, input_2, out, input_length, cp_constraints, cp_declarations, component_probability_index, state
     ):
-        if input_1 not in model.modadd_two_term_shift_cache:
+        if input_1 not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{input_1} = LShift({input_1},1);")
-            model.modadd_two_term_shift_cache.append(input_1)
-        if input_2 not in model.modadd_two_term_shift_cache:
+            state.shift_declaration_cache.append(input_1)
+        if input_2 not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{input_2} = LShift({input_2},1);")
-            model.modadd_two_term_shift_cache.append(input_2)
-        if out not in model.modadd_two_term_shift_cache:
+            state.shift_declaration_cache.append(input_2)
+        if out not in state.shift_declaration_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{out} = LShift({out},1);")
-            model.modadd_two_term_shift_cache.append(out)
+            state.shift_declaration_cache.append(out)
         cp_declarations.append(
             f"array[0..{input_length - 1}] of var 0..1: eq_{out} = Eq(Shi_{input_1}, Shi_{input_2}, Shi_{out});"
         )
@@ -420,7 +422,7 @@ class Modular(Component):
             f"true endif) /\\ p[{component_probability_index}] = {input_length}-sum(eq_{out});"
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         """
@@ -474,20 +476,22 @@ class Modular(Component):
             )
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for the probability of Modular Addition/Substraction component for CP xor differential probability.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.cipher import Cipher
             sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: from claasp.name_mappings import BLOCK_CIPHER, INPUT_KEY, INPUT_PLAINTEXT
             sage: class DummyCipher(Cipher):
             ....:     def __init__(self):
@@ -496,12 +500,15 @@ class Modular(Component):
             ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
-            sage: model = MznModel(cipher)
+            sage: state = CpBuildState()
             sage: component = cipher.component_from(0, 0)
-            sage: declarations, constraints = component.cp_xor_differential_propagation_constraints(model)
-            sage: len(declarations) > 0 and len(constraints) > 0
+            sage: result = component.cp_xor_differential_propagation_constraints(None, state)
+            sage: len(result.declarations) > 0 and len(result.constraints) > 0
             True
         """
+        return self._cp_xor_differential_propagation_impl(state)
+
+    def _cp_xor_differential_propagation_impl(self, state):
         output_id_link = self.id
         num_add = self.description[1]
         all_inputs = []
@@ -522,6 +529,7 @@ class Modular(Component):
             cp_declarations.append(f"array[0..{input_len - 1}] of var 0..1: pre_{output_id_link}_{i};")
         component_probability_indices = []
         for i in range(num_add - 2):
+            prob_index = state.next_probability_index
             self.cp_twoterms_xor_differential_probability(
                 f"pre_{output_id_link}_{num_add - 1}",
                 f"pre_{output_id_link}_{i + 1}",
@@ -529,11 +537,12 @@ class Modular(Component):
                 self.output_bit_size,
                 cp_constraints,
                 cp_declarations,
-                model.component_probability_index,
-                model,
+                prob_index,
+                state,
             )
-            component_probability_indices.append(model.component_probability_index)
-            model.component_probability_index += 1
+            component_probability_indices.append(prob_index)
+            state.next_probability_index += 1
+        prob_index = state.next_probability_index
         self.cp_twoterms_xor_differential_probability(
             f"pre_{output_id_link}_{2 * num_add - 3}",
             f"pre_{output_id_link}_0",
@@ -541,14 +550,14 @@ class Modular(Component):
             self.output_bit_size,
             cp_constraints,
             cp_declarations,
-            model.component_probability_index,
-            model,
+            prob_index,
+            state,
         )
-        component_probability_indices.append(model.component_probability_index)
-        model.component_probability_index += 1
-        model.component_and_probability[output_id_link] = component_probability_indices
+        component_probability_indices.append(prob_index)
+        state.next_probability_index += 1
+        state.component_probability_map[output_id_link] = component_probability_indices
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_propagation_constraints_arx_optimized(self, model):
         """
@@ -588,7 +597,10 @@ class Modular(Component):
         num_add = self.description[1]
 
         if num_add > 2:
-            return self.cp_xor_differential_propagation_constraints(model)
+            state = CpBuildState.from_model(model)
+            result = self.cp_xor_differential_propagation_constraints(None, state)
+            state.apply_to_model(model)
+            return CpComponentBuildResult(result.declarations, result.constraints)
 
         all_inputs = []
         for id_link, bit_positions in zip(input_id_links, input_bit_positions):
@@ -671,20 +683,22 @@ class Modular(Component):
 
         model.component_probability_index += 1
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for the probability of Modular Addition/Substraction for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.cipher import Cipher
             sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: from claasp.name_mappings import BLOCK_CIPHER, INPUT_KEY, INPUT_PLAINTEXT
             sage: class DummyCipher(Cipher):
             ....:     def __init__(self):
@@ -693,14 +707,17 @@ class Modular(Component):
             ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
-            sage: model = MznModel(cipher)
+            sage: state = CpBuildState()
             sage: component = cipher.component_from(0, 0)
-            sage: declarations, constraints = component.cp_xor_linear_mask_propagation_constraints(model)
-            sage: declarations[:2]
+            sage: result = component.cp_xor_linear_mask_propagation_constraints(None, state)
+            sage: result.declarations[:2]
             ['array[0..7] of var 0..1: modadd_0_0_i;', 'array[0..3] of var 0..1: modadd_0_0_o;']
-            sage: len(constraints) > 0
+            sage: len(result.constraints) > 0
             True
         """
+        return self._cp_xor_linear_mask_propagation_impl(state)
+
+    def _cp_xor_linear_mask_propagation_impl(self, state):
         output_id_link = self.id
         cp_declarations = []
         cp_constraints = []
@@ -718,21 +735,21 @@ class Modular(Component):
         for i in range(num_add, 2 * num_add - 2):
             cp_declarations.append(f"array[0..{self.output_bit_size - 1}] of var 0..1: pre_{output_id_link}_{i};")
         for i in range(num_add - 2):
+            prob_index = state.allocate_probability_index()
             cp_constraints.append(
                 f"constraint modadd_linear(pre_{output_id_link}_{num_add - 1}, pre_{output_id_link}_{i + 1}, "
-                f"pre_{output_id_link}_{num_add + i}, p[{model.component_probability_index}]);"
+                f"pre_{output_id_link}_{num_add + i}, p[{prob_index}]);"
             )
-            component_probability_indices.append(model.component_probability_index)
-            model.component_probability_index = model.component_probability_index + 1
+            component_probability_indices.append(prob_index)
+        prob_index = state.allocate_probability_index()
         cp_constraints.append(
             f"constraint modadd_linear(pre_{output_id_link}_{2 * num_add - 3}, pre_{output_id_link}_0, "
-            f"{output_id_link}_o, p[{model.component_probability_index}]);"
+            f"{output_id_link}_o, p[{prob_index}]);"
         )
-        component_probability_indices.append(model.component_probability_index)
-        model.component_probability_index = model.component_probability_index + 1
-        model.component_and_probability[output_id_link] = component_probability_indices
+        component_probability_indices.append(prob_index)
+        state.component_probability_map[output_id_link] = component_probability_indices
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_word_operation_sign(self, sign, solution):
         output_id_link = self.id
@@ -1203,7 +1220,7 @@ class Modular(Component):
             var_names += [mzn_variables_and_constraints[0]]
             mzn_constraints += [mzn_variables_and_constraints[1]]
 
-        return var_names, mzn_constraints
+        return CpComponentBuildResult(var_names, mzn_constraints)
 
     def milp_xor_linear_mask_propagation_constraints(self, model):
         """

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -402,15 +402,15 @@ class Modular(Component):
     def cp_twoterms_xor_differential_probability(
         self, input_1, input_2, out, input_length, cp_constraints, cp_declarations, component_probability_index, model
     ):
-        if input_1 not in model.modadd_twoterms_mant:
+        if input_1 not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{input_1} = LShift({input_1},1);")
-            model.modadd_twoterms_mant.append(input_1)
-        if input_2 not in model.modadd_twoterms_mant:
+            model.modadd_two_term_shift_cache.append(input_1)
+        if input_2 not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{input_2} = LShift({input_2},1);")
-            model.modadd_twoterms_mant.append(input_2)
-        if out not in model.modadd_twoterms_mant:
+            model.modadd_two_term_shift_cache.append(input_2)
+        if out not in model.modadd_two_term_shift_cache:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{out} = LShift({out},1);")
-            model.modadd_twoterms_mant.append(out)
+            model.modadd_two_term_shift_cache.append(out)
         cp_declarations.append(
             f"array[0..{input_length - 1}] of var 0..1: eq_{out} = Eq(Shi_{input_1}, Shi_{input_2}, Shi_{out});"
         )

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -242,10 +242,10 @@ class Modular(Component):
 
             sage: from claasp.components.modular_component import Modular
             sage: component = Modular(0, 0, ['a', 'b'], [[0, 1, 2, 3], [0, 1, 2, 3]], 4, 'modular', 16)
-            sage: declarations, constraints = component.cp_deterministic_truncated_xor_differential_constraints()
-            sage: declarations
+            sage: result = component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
             ['array[0..3] of var 0..2: pre_modular_0_0_0;', 'array[0..3] of var 0..2: pre_modular_0_0_1;']
-            sage: constraints
+            sage: result.constraints
             ['constraint pre_modular_0_0_0[0] = a[0];',
             'constraint pre_modular_0_0_0[1] = a[1];',
             'constraint pre_modular_0_0_0[2] = a[2];',
@@ -437,10 +437,10 @@ class Modular(Component):
             sage: from claasp.components.modular_component import Modular
             sage: component = Modular(0, 0, ['a', 'b'], [[0, 1, 2, 3], [0, 1, 2, 3]], 4, 'modular', 16)
             sage: DummyModel = type('DummyModel', (), {'word_size': 1})
-            sage: declarations, constraints = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
-            sage: declarations[0]
+            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations[0]
             'array[0..4] of var 0..2: carry_modular_0_0;'
-            sage: len(constraints) > 0
+            sage: len(result.constraints) > 0
             True
         """
         output_id_link = self.id
@@ -581,14 +581,14 @@ class Modular(Component):
             sage: cipher = DummyCipher()
             sage: minizinc = MznXorDifferentialModelARXOptimized(cipher, sat_or_milp='milp')
             sage: component = cipher.component_from(0, 0)
-            sage: variables, constraints = component.cp_xor_differential_propagation_constraints_arx_optimized(minizinc)
-            sage: variables
+            sage: result = component.cp_xor_differential_propagation_constraints_arx_optimized(minizinc)
+            sage: result.declarations
             ['array[0..3] of var 0..1: dummy_modadd_0_0;',
             'array[0..3] of var 0..1: x1_modadd_0_0;',
             'array[0..3] of var 0..1: x2_modadd_0_0;']
-            sage: constraints[0].startswith('constraint x1_modadd_0_0[0] = plaintext[0];')
+            sage: result.constraints[0].startswith('constraint x1_modadd_0_0[0] = plaintext[0];')
             True
-            sage: len(constraints)
+            sage: len(result.constraints)
             53
         """
         input_id_links = self.input_id_links
@@ -1123,8 +1123,8 @@ class Modular(Component):
             sage: cipher = DummyCipher()
             sage: minizinc = MznXorDifferentialModelARXOptimized(cipher, sat_or_milp='milp')
             sage: component = cipher.component_from(0, 0)
-            sage: _, constraints = component.minizinc_xor_differential_propagation_constraints(minizinc)
-            sage: constraints[0].startswith('constraint modular_addition_word(')
+            sage: result = component.minizinc_xor_differential_propagation_constraints(minizinc)
+            sage: result.constraints[0].startswith('constraint modular_addition_word(')
             True
         """
 

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -424,7 +424,7 @@ class Modular(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         """
         Return lists declarations and constraints for XOR component CP wordwise deterministic truncated XOR differential model.
 

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -400,7 +400,7 @@ class Modular(Component):
         return cp_declarations, cp_constraints, metadata
 
     def cp_twoterms_xor_differential_probability(
-        self, input_1, input_2, out, input_length, cp_constraints, cp_declarations, c, model
+        self, input_1, input_2, out, input_length, cp_constraints, cp_declarations, component_probability_index, model
     ):
         if input_1 not in model.modadd_twoterms_mant:
             cp_declarations.append(f"array[0..{input_length - 1}] of var 0..1: Shi_{input_1} = LShift({input_1},1);")
@@ -520,7 +520,7 @@ class Modular(Component):
             )
         for i in range(num_add, 2 * num_add - 2):
             cp_declarations.append(f"array[0..{input_len - 1}] of var 0..1: pre_{output_id_link}_{i};")
-        probability = []
+        component_probability_indices = []
         for i in range(num_add - 2):
             self.cp_twoterms_xor_differential_probability(
                 f"pre_{output_id_link}_{num_add - 1}",
@@ -529,11 +529,11 @@ class Modular(Component):
                 self.output_bit_size,
                 cp_constraints,
                 cp_declarations,
-                model.c,
+                model.component_probability_index,
                 model,
             )
-            probability.append(model.c)
-            model.c += 1
+            component_probability_indices.append(model.component_probability_index)
+            model.component_probability_index += 1
         self.cp_twoterms_xor_differential_probability(
             f"pre_{output_id_link}_{2 * num_add - 3}",
             f"pre_{output_id_link}_0",
@@ -541,12 +541,12 @@ class Modular(Component):
             self.output_bit_size,
             cp_constraints,
             cp_declarations,
-            model.c,
+            model.component_probability_index,
             model,
         )
-        probability.append(model.c)
-        model.c += 1
-        model.component_and_probability[output_id_link] = probability
+        component_probability_indices.append(model.component_probability_index)
+        model.component_probability_index += 1
+        model.component_and_probability[output_id_link] = component_probability_indices
 
         return cp_declarations, cp_constraints
 
@@ -666,10 +666,10 @@ class Modular(Component):
             )
 
         cp_constraints.append(
-            f"constraint p[{model.c}] = sum([if (x1_{output_id_link}[i+1] = x2_{output_id_link}[i+1]) /\\ (x1_{output_id_link}[i+1] = {output_id_link}[i+1]) then 0 else 100 endif | i in 0..{input_len - 2}]);"
+            f"constraint p[{model.component_probability_index}] = sum([if (x1_{output_id_link}[i+1] = x2_{output_id_link}[i+1]) /\\ (x1_{output_id_link}[i+1] = {output_id_link}[i+1]) then 0 else 100 endif | i in 0..{input_len - 2}]);"
         )
 
-        model.c += 1
+        model.component_probability_index += 1
 
         return cp_declarations, cp_constraints
 
@@ -708,7 +708,7 @@ class Modular(Component):
         input_len = self.input_bit_size // num_add
         cp_declarations.append(f"array[0..{self.input_bit_size - 1}] of var 0..1: {output_id_link}_i;")
         cp_declarations.append(f"array[0..{self.output_bit_size - 1}] of var 0..1: {output_id_link}_o;")
-        probability = []
+        component_probability_indices = []
         for i in range(num_add):
             cp_declarations.append(f"array[0..{input_len - 1}] of var 0..1: pre_{output_id_link}_{i};")
             for j in range(input_len):
@@ -720,17 +720,17 @@ class Modular(Component):
         for i in range(num_add - 2):
             cp_constraints.append(
                 f"constraint modadd_linear(pre_{output_id_link}_{num_add - 1}, pre_{output_id_link}_{i + 1}, "
-                f"pre_{output_id_link}_{num_add + i}, p[{model.c}]);"
+                f"pre_{output_id_link}_{num_add + i}, p[{model.component_probability_index}]);"
             )
-            probability.append(model.c)
-            model.c = model.c + 1
+            component_probability_indices.append(model.component_probability_index)
+            model.component_probability_index = model.component_probability_index + 1
         cp_constraints.append(
             f"constraint modadd_linear(pre_{output_id_link}_{2 * num_add - 3}, pre_{output_id_link}_0, "
-            f"{output_id_link}_o, p[{model.c}]);"
+            f"{output_id_link}_o, p[{model.component_probability_index}]);"
         )
-        probability.append(model.c)
-        model.c = model.c + 1
-        model.component_and_probability[output_id_link] = probability
+        component_probability_indices.append(model.component_probability_index)
+        model.component_probability_index = model.component_probability_index + 1
+        model.component_and_probability[output_id_link] = component_probability_indices
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -144,7 +144,7 @@ class MultiInputNonlinearLogicalOperator(Component):
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         r"""
         Return lists of declarations and constraints for a multi-input nonlinear logical operator
         for CP wordwise deterministic truncated XOR differential.

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -16,6 +16,8 @@
 # ****************************************************************************
 
 
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.input import Input
 from claasp.component import Component
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
@@ -136,7 +138,7 @@ class MultiInputNonlinearLogicalOperator(Component):
             cp_constraint = f"constraint if {operation} == 0 then {self.id}[{i}] = 0 else {self.id}[{i}] = 2 endif;"
             cp_constraints.append(cp_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
@@ -196,9 +198,9 @@ class MultiInputNonlinearLogicalOperator(Component):
             )
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for the probability of a multi-input nonlinear
         logical operator in the CP XOR differential model.
@@ -209,29 +211,26 @@ class MultiInputNonlinearLogicalOperator(Component):
             the same DDT table is used. This is why the generated MiniZinc constraint names
             still reference ``and{num_add}inputs_DDT``.
 
-        TESTING NOTE:
-
-            This method contains real base-class logic but only depends on the model's
-            ``c`` counter and ``component_and_probability`` dictionary. The doctest uses a
-            minimal dummy model rather than a full cipher/model integration setup.
-
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
-            sage: class DummyModel:
-            ....:     def __init__(self):
-            ....:         self.component_probability_index = 0
-            ....:         self.component_and_probability = {}
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: component = MultiInputNonlinearLogicalOperator(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 'and')
-            sage: component.cp_xor_differential_propagation_constraints(DummyModel())
-            ([],
-             ['constraint table([input1[0]]++[input2[0]]++[and_0_0[0]]++[p[0]],and2inputs_DDT);',
-              'constraint table([input1[1]]++[input2[1]]++[and_0_0[1]]++[p[1]],and2inputs_DDT);'])
+            sage: state = CpBuildState()
+            sage: result = component.cp_xor_differential_propagation_constraints(None, state)
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint table([input1[0]]++[input2[0]]++[and_0_0[0]]++[p[0]],and2inputs_DDT);', 'constraint table([input1[1]]++[input2[1]]++[and_0_0[1]]++[p[1]],and2inputs_DDT);']
         """
+        return self._cp_xor_differential_propagation_impl(state)
+
+    def _cp_xor_differential_propagation_impl(self, state):
         num_add = self.description[1]
         all_inputs = []
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
@@ -241,14 +240,14 @@ class MultiInputNonlinearLogicalOperator(Component):
         cp_constraints = []
         component_probability_indices = []
         for i in range(self.output_bit_size):
+            prob_index = state.allocate_probability_index()
             inputs = "++".join(f"[{all_inputs[i + input_len * j]}]" for j in range(num_add))
-            cp_constraint = f"constraint table({inputs}++[{self.id}[{i}]]++[p[{model.component_probability_index}]],and{num_add}inputs_DDT);"
+            cp_constraint = f"constraint table({inputs}++[{self.id}[{i}]]++[p[{prob_index}]],and{num_add}inputs_DDT);"
             cp_constraints.append(cp_constraint)
-            model.component_probability_index += 1
-            component_probability_indices.append(model.component_probability_index)
-        model.component_and_probability[self.id] = component_probability_indices
+            component_probability_indices.append(prob_index + 1)
+        state.component_probability_map[self.id] = component_probability_indices
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def generic_sign_linear_constraints(self, inputs, outputs):
         """AND component and OR component override this method."""

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -144,7 +144,7 @@ class MultiInputNonlinearLogicalOperator(Component):
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         r"""
         Return lists of declarations and constraints for a multi-input nonlinear logical operator
         for CP wordwise deterministic truncated XOR differential.
@@ -153,21 +153,22 @@ class MultiInputNonlinearLogicalOperator(Component):
 
         TESTING NOTE:
 
-            This method contains real base-class logic but only depends on the model's
-            ``word_size`` attribute. The doctest therefore uses a minimal dummy model
+            This method contains real base-class logic but only depends on the context's
+            ``word_size`` attribute. The doctest therefore uses a minimal dummy context
             instead of a full cipher-backed instantiation.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
-            sage: class DummyModel:
+            sage: class DummyContext:
             ....:     word_size = 2
             sage: component = MultiInputNonlinearLogicalOperator(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 'and')
-            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations
             []
         """
@@ -175,7 +176,7 @@ class MultiInputNonlinearLogicalOperator(Component):
         all_inputs_value = []
         all_inputs_active = []
         numadd = self.description[1]
-        word_size = model.word_size
+        word_size = context.word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(
                 [

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -123,10 +123,11 @@ class MultiInputNonlinearLogicalOperator(Component):
 
             sage: from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
             sage: component = MultiInputNonlinearLogicalOperator(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 'and')
-            sage: component.cp_deterministic_truncated_xor_differential_constraints()
-            ([],
-             ['constraint if input1[0] == 0 /\\ input2[0] == 0 then and_0_0[0] = 0 else and_0_0[0] = 2 endif;',
-              'constraint if input1[1] == 0 /\\ input2[1] == 0 then and_0_0[1] = 0 else and_0_0[1] = 2 endif;'])
+            sage: result = component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint if input1[0] == 0 /\\ input2[0] == 0 then and_0_0[0] = 0 else and_0_0[0] = 2 endif;', 'constraint if input1[1] == 0 /\\ input2[1] == 0 then and_0_0[1] = 0 else and_0_0[1] = 2 endif;']
         """
         cp_declarations = []
         all_inputs = []
@@ -166,8 +167,9 @@ class MultiInputNonlinearLogicalOperator(Component):
             sage: class DummyModel:
             ....:     word_size = 2
             sage: component = MultiInputNonlinearLogicalOperator(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 'and')
-            sage: component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())[:1]
-            ([],)
+            sage: result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations
+            []
         """
         cp_declarations = []
         all_inputs_value = []

--- a/claasp/components/multi_input_non_linear_logical_operator_component.py
+++ b/claasp/components/multi_input_non_linear_logical_operator_component.py
@@ -224,7 +224,7 @@ class MultiInputNonlinearLogicalOperator(Component):
             sage: from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
             sage: class DummyModel:
             ....:     def __init__(self):
-            ....:         self.c = 0
+            ....:         self.component_probability_index = 0
             ....:         self.component_and_probability = {}
             sage: component = MultiInputNonlinearLogicalOperator(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 'and')
             sage: component.cp_xor_differential_propagation_constraints(DummyModel())
@@ -239,14 +239,14 @@ class MultiInputNonlinearLogicalOperator(Component):
         input_len = len(all_inputs) // num_add
         cp_declarations = []
         cp_constraints = []
-        probability = []
+        component_probability_indices = []
         for i in range(self.output_bit_size):
             inputs = "++".join(f"[{all_inputs[i + input_len * j]}]" for j in range(num_add))
-            cp_constraint = f"constraint table({inputs}++[{self.id}[{i}]]++[p[{model.c}]],and{num_add}inputs_DDT);"
+            cp_constraint = f"constraint table({inputs}++[{self.id}[{i}]]++[p[{model.component_probability_index}]],and{num_add}inputs_DDT);"
             cp_constraints.append(cp_constraint)
-            model.c += 1
-            probability.append(model.c)
-        model.component_and_probability[self.id] = probability
+            model.component_probability_index += 1
+            component_probability_indices.append(model.component_probability_index)
+        model.component_and_probability[self.id] = component_probability_indices
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -183,7 +183,7 @@ class NOT(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_trail_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         cp_declarations = []
         all_inputs_value = []
         all_inputs_active = []

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -183,11 +183,11 @@ class NOT(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_trail_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         cp_declarations = []
         all_inputs_value = []
         all_inputs_active = []
-        word_size = model.word_size
+        word_size = context.word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(
                 [

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import WORD_OPERATION
@@ -148,7 +149,7 @@ class NOT(Component):
             all_inputs.extend([f"{id_link}[{position}]" for position in bit_positions])
         cp_constraints = [f"constraint {self.id}[{i}] = ({input_} + 1) mod 2;" for i, input_ in enumerate(all_inputs)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_constraints(self):
         """
@@ -174,12 +175,12 @@ class NOT(Component):
             all_inputs.extend([f"{id_link}[{position}]" for position in bit_positions])
         cp_constraints = [f"constraint {self.id}[{i}] = {input_};" for i, input_ in enumerate(all_inputs)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_trail_constraints()
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
@@ -209,7 +210,7 @@ class NOT(Component):
                 f"else {self.id}_value[{i}] = {2**word_size - 1} - {all_inputs_value[i]}"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_first_step_constraints(self, model):
         """
@@ -244,24 +245,25 @@ class NOT(Component):
             )
         cp_constraints = [f"constraint {self.id}[{i}] = {input_};" for i, input_ in enumerate(all_inputs)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model=None):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for NOT component for CP xor differential.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.not_component import NOT
             sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
-            sage: declarations, constraints = not_component.cp_xor_differential_propagation_constraints()
-            sage: declarations
+            sage: result = not_component.cp_xor_differential_propagation_constraints(None, None)
+            sage: result.declarations
             []
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint not_0_0[0] = input0[0];'
         """
         cp_declarations = []
@@ -270,27 +272,28 @@ class NOT(Component):
             all_inputs.extend([f"{id_link}[{position}]" for position in bit_positions])
         cp_constraints = [f"constraint {self.id}[{i}] = {input_};" for i, input_ in enumerate(all_inputs)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         return self.cp_xor_differential_first_step_constraints(model)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for NOT component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.not_component import NOT
             sage: not_component = NOT(0, 0, ['input0'], [list(range(64))], 64)
-            sage: declarations, constraints = not_component.cp_xor_linear_mask_propagation_constraints()
-            sage: declarations
+            sage: result = not_component.cp_xor_linear_mask_propagation_constraints(None, None)
+            sage: result.declarations
             ['array[0..63] of var 0..1:not_0_0_i;', 'array[0..63] of var 0..1:not_0_0_o;']
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint not_0_0_o[0]=not_0_0_i[0];'
         """
         cp_declarations = [
@@ -301,7 +304,7 @@ class NOT(Component):
         for i in range(self.input_bit_size):
             cp_constraints.append(f"constraint {self.id}_o[{i}]={self.id}_i[{i}];")
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         return [f"  {self.id} = bit_vector_NOT([{','.join(params)} ])"]

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -137,10 +137,10 @@ class NOT(Component):
 
             sage: from claasp.components.not_component import NOT
             sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
-            sage: declarations, constraints = not_component.cp_constraints()
-            sage: declarations
+            sage: result = not_component.cp_constraints()
+            sage: result.declarations
             []
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint not_0_0[0] = (input0[0] + 1) mod 2;'
         """
         cp_declarations = []
@@ -163,10 +163,10 @@ class NOT(Component):
 
             sage: from claasp.components.not_component import NOT
             sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
-            sage: declarations, constraints = not_component.cp_deterministic_truncated_xor_differential_constraints()
-            sage: declarations
+            sage: result = not_component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
             []
-            sage: constraints[0]
+            sage: result.constraints[0]
             'constraint not_0_0[0] = input0[0];'
         """
         cp_declarations = []
@@ -226,12 +226,11 @@ class NOT(Component):
             sage: class DummyModel:
             ....:     word_size = 2
             sage: not_component = NOT(0, 18, ['input0'], [list(range(8))], 8)
-            sage: not_component.cp_xor_differential_first_step_constraints(DummyModel())
-            (['array[0..3] of var 0..1: not_0_18;'],
-             ['constraint not_0_18[0] = input0[0];',
-            'constraint not_0_18[1] = input0[1];',
-            'constraint not_0_18[2] = input0[2];',
-            'constraint not_0_18[3] = input0[3];'])
+            sage: result = not_component.cp_xor_differential_first_step_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..3] of var 0..1: not_0_18;']
+            sage: result.constraints
+            ['constraint not_0_18[0] = input0[0];', 'constraint not_0_18[1] = input0[1];', 'constraint not_0_18[2] = input0[2];', 'constraint not_0_18[3] = input0[3];']
         """
         word_size = model.word_size
         cp_declarations = [f"array[0..{(self.output_bit_size - 1) // model.word_size}] of var 0..1: {self.id};"]

--- a/claasp/components/or_component.py
+++ b/claasp/components/or_component.py
@@ -18,6 +18,7 @@
 
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
 
 
@@ -175,15 +176,16 @@ class OR(MultiInputNonlinearLogicalOperator):
                 f"{output_id_link});"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for the probability of OR for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
@@ -192,17 +194,13 @@ class OR(MultiInputNonlinearLogicalOperator):
             sage: cipher = OrCipher(word_bit_size=4, number_of_inputs=2)
             sage: or_component = cipher.get_component_from_id("or_0_0")
             sage: cp = MznModel(cipher)
-            sage: declarations, constraints = or_component.cp_xor_linear_mask_propagation_constraints(cp)
-            sage: declarations
-            ['array[0..3] of var 0..400: p_or_0_0;',
-             'array[0..7] of var 0..1:or_0_0_i;',
-             'array[0..3] of var 0..1:or_0_0_o;']
-            sage: constraints
-            ['constraint table([or_0_0_i[0]]++[or_0_0_i[4]]++[or_0_0_o[0]]++[p_or_0_0[0]],and2inputs_LAT);',
-             'constraint table([or_0_0_i[1]]++[or_0_0_i[5]]++[or_0_0_o[1]]++[p_or_0_0[1]],and2inputs_LAT);',
-             'constraint table([or_0_0_i[2]]++[or_0_0_i[6]]++[or_0_0_o[2]]++[p_or_0_0[2]],and2inputs_LAT);',
-             'constraint table([or_0_0_i[3]]++[or_0_0_i[7]]++[or_0_0_o[3]]++[p_or_0_0[3]],and2inputs_LAT);',
-             'constraint p[0] = sum(p_or_0_0);']
+            sage: from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
+            sage: context = CpBuildContext.from_model(cp)
+            sage: state = CpBuildState.from_model(cp)
+            sage: result = or_component.cp_xor_linear_mask_propagation_constraints(context, state)
+            sage: result.declarations[0]
+            'array[0..3] of var 0..400: p_or_0_0;'
         """
         cp_declarations = [
             f"array[0..{self.output_bit_size - 1}] of var 0..{100 * self.output_bit_size}: p_{self.id};",
@@ -212,7 +210,7 @@ class OR(MultiInputNonlinearLogicalOperator):
         cp_constraints = []
         num_add = self.description[1]
         input_len = self.input_bit_size // num_add
-        model.component_and_probability[self.id] = 0
+        state.component_probability_map[self.id] = 0
         p_count = 0
         for i in range(self.output_bit_size):
             inputs = "++".join(f"[{self.id}_i[{i + input_len * j}]]" for j in range(num_add))
@@ -221,11 +219,11 @@ class OR(MultiInputNonlinearLogicalOperator):
             )
             cp_constraints.append(cp_constraint)
             p_count = p_count + 1
-        cp_constraints.append(f"constraint p[{model.component_probability_index}] = sum(p_{self.id});")
-        model.component_and_probability[self.id] = model.component_probability_index
-        model.component_probability_index = model.component_probability_index + 1
+        prob_idx = state.allocate_probability_index()
+        cp_constraints.append(f"constraint p[{prob_idx}] = sum(p_{self.id});")
+        state.component_probability_map[self.id] = prob_idx
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def generic_sign_linear_constraints(self, inputs, outputs):
         """

--- a/claasp/components/or_component.py
+++ b/claasp/components/or_component.py
@@ -221,9 +221,9 @@ class OR(MultiInputNonlinearLogicalOperator):
             )
             cp_constraints.append(cp_constraint)
             p_count = p_count + 1
-        cp_constraints.append(f"constraint p[{model.c}] = sum(p_{self.id});")
-        model.component_and_probability[self.id] = model.c
-        model.c = model.c + 1
+        cp_constraints.append(f"constraint p[{model.component_probability_index}] = sum(p_{self.id});")
+        model.component_and_probability[self.id] = model.component_probability_index
+        model.component_probability_index = model.component_probability_index + 1
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/or_component.py
+++ b/claasp/components/or_component.py
@@ -130,15 +130,11 @@ class OR(MultiInputNonlinearLogicalOperator):
 
             sage: from claasp.components.or_component import OR
             sage: or_component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
-            sage: or_component.cp_constraints()
-            (['array[0..1] of var 0..1: or_0_0;',
-            'array[0..1] of var 0..1:pre_or_0_0_0;',
-            'array[0..1] of var 0..1:pre_or_0_0_1;'],
-            ['constraint pre_or_0_0_0[0]=input1[0];',
-            'constraint pre_or_0_0_0[1]=input1[1];',
-            'constraint pre_or_0_0_1[0]=input2[0];',
-            'constraint pre_or_0_0_1[1]=input2[1];',
-            'constraint or(pre_or_0_0_0, pre_or_0_0_1, or_0_0);'])
+            sage: result = or_component.cp_constraints()
+            sage: result.declarations
+            ['array[0..1] of var 0..1: or_0_0;', 'array[0..1] of var 0..1:pre_or_0_0_0;', 'array[0..1] of var 0..1:pre_or_0_0_1;']
+            sage: result.constraints
+            ['constraint pre_or_0_0_0[0]=input1[0];', 'constraint pre_or_0_0_0[1]=input1[1];', 'constraint pre_or_0_0_1[0]=input2[0];', 'constraint pre_or_0_0_1[1]=input2[1];', 'constraint or(pre_or_0_0_0, pre_or_0_0_1, or_0_0);']
         """
         input_id_link = self.input_id_links
         numb_of_inp = len(input_id_link)

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -230,11 +230,11 @@ class Rotate(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         cp_declarations = []
         all_inputs_value = []
         all_inputs_active = []
-        word_size = model.word_size
+        word_size = context.word_size
         rot_amount = self.description[1] // word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -565,13 +565,14 @@ class Rotate(Component):
 
         return variables, constraints
 
-    def minizinc_constraints(self, model):
+    def minizinc_constraints(self, context, state=None):
         r"""
         Return variables and constraints for the component ROTATE for MINIZINC CIPHER model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- **model object** or ``CpBuildContext``; build configuration
+        - ``state`` -- optional ``CpBuildState``
 
         EXAMPLES::
 
@@ -586,10 +587,10 @@ class Rotate(Component):
         """
         if self.description[0].lower() != "rotate":
             raise ValueError("component must be bitwise rotation")
-        input_postfix = model.input_postfix
-        output_postfix = model.output_postfix
+        input_postfix = context.input_postfix
+        output_postfix = context.output_postfix
 
-        var_names = self._define_var(input_postfix, output_postfix, model.data_type)
+        var_names = self._define_var(input_postfix, output_postfix, context.data_type)
         rotation_const = self.description[1]
         ninputs = noutputs = self.output_bit_size
         input_vars = [f"{self.id}_{input_postfix}{i}" for i in range(ninputs)]

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -135,8 +135,11 @@ class Rotate(Component):
 
             sage: from claasp.components.rotate_component import Rotate
             sage: rotate_component = Rotate(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: rotate_component.cp_constraints()
-            ([], ['constraint rot_0_0[0] = input[1];', 'constraint rot_0_0[1] = input[0];'])
+            sage: result = rotate_component.cp_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint rot_0_0[0] = input[1];', 'constraint rot_0_0[1] = input[0];']
         """
         rot_amount = abs(self.description[1])
         all_inputs = []
@@ -202,8 +205,11 @@ class Rotate(Component):
 
             sage: from claasp.components.rotate_component import Rotate
             sage: rotate_component = Rotate(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: rotate_component.cp_inverse_constraints()
-            ([], ['constraint rot_0_0_inverse[0] = input[1];', 'constraint rot_0_0_inverse[1] = input[0];'])
+            sage: result = rotate_component.cp_inverse_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint rot_0_0_inverse[0] = input[1];', 'constraint rot_0_0_inverse[1] = input[0];']
         """
         rot_amount = abs(self.description[1])
         all_inputs = []
@@ -269,12 +275,11 @@ class Rotate(Component):
             sage: class DummyModel:
             ....:     word_size = 2
             sage: rotate_component = Rotate(0, 0, ['input0'], [list(range(8))], 8, -2)
-            sage: rotate_component.cp_xor_differential_first_step_constraints(DummyModel())
-            (['array[0..3] of var 0..1: rot_0_0;'],
-            ['constraint rot_0_0[0] = input0[1];',
-            'constraint rot_0_0[1] = input0[2];',
-            'constraint rot_0_0[2] = input0[3];',
-            'constraint rot_0_0[3] = input0[0];'])
+            sage: result = rotate_component.cp_xor_differential_first_step_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..3] of var 0..1: rot_0_0;']
+            sage: result.constraints
+            ['constraint rot_0_0[0] = input0[1];', 'constraint rot_0_0[1] = input0[2];', 'constraint rot_0_0[2] = input0[3];', 'constraint rot_0_0[3] = input0[0];']
         """
         input_id_link = self.input_id_links
         output_id_link = self.id
@@ -575,8 +580,8 @@ class Rotate(Component):
             sage: cipher = RotateCipher(bit_size=2, parameter=1)
             sage: minizinc = MznModel(cipher)
             sage: rotate_component = cipher.get_component_from_id('rot_0_0')
-            sage: _, rotate_mzn_constraints = rotate_component.minizinc_constraints(minizinc)
-            sage: rotate_mzn_constraints[0]
+            sage: result = rotate_component.minizinc_constraints(minizinc)
+            sage: result.constraints[0]
             'constraint RRot(array1d(0..2-1, [rot_0_0_x0,rot_0_0_x1]), 1)=array1d(0..2-1, [rot_0_0_y0,rot_0_0_y1]);\n'
         """
         if self.description[0].lower() != "rotate":

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import WORD_OPERATION
@@ -154,9 +155,9 @@ class Rotate(Component):
                 for i in range(self.output_bit_size)
             ]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_continuous_differential_propagation_constraints(self, model):
+    def cp_continuous_differential_propagation_constraints(self, context, state):
 
         output_id_link = self.id
         input_len = self.output_bit_size
@@ -181,12 +182,12 @@ class Rotate(Component):
                 f"constraint {output_id_link} = continuous_LRot(x1_{output_id_link}, {abs(rot_val)}, {output_id_link});"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
         
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_inverse_constraints(self):
@@ -221,7 +222,7 @@ class Rotate(Component):
                 for i in range(self.output_bit_size)
             ]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         cp_declarations = []
@@ -252,7 +253,7 @@ class Rotate(Component):
                 f"constraint {self.id}_value[{i}] = {all_inputs_value[(i - rot_amount) % input_len]};"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_first_step_constraints(self, model):
         """
@@ -314,28 +315,29 @@ class Rotate(Component):
                 for i in range(self.output_bit_size // word_size)
             ]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model=None):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         return self.cp_xor_differential_first_step_constraints(model)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for ROTATE component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.rotate_component import Rotate
             sage: rotate_component = Rotate(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: rotate_component.cp_xor_linear_mask_propagation_constraints()
-            (['array[0..1] of var 0..1: rot_0_0_i;', 'array[0..1] of var 0..1: rot_0_0_o;'], ['constraint rot_0_0_o[0]=rot_0_0_i[1];', 'constraint rot_0_0_o[1]=rot_0_0_i[0];'])
+            sage: rotate_component.cp_xor_linear_mask_propagation_constraints(None, None)
+            CpComponentBuildResult(declarations=['array[0..1] of var 0..1: rot_0_0_i;', 'array[0..1] of var 0..1: rot_0_0_o;'], constraints=['constraint rot_0_0_o[0]=rot_0_0_i[1];', 'constraint rot_0_0_o[1]=rot_0_0_i[0];'], metadata={})
         """
         cp_declarations = [
             f"array[0..{self.output_bit_size - 1}] of var 0..1: {self.id}_i;",
@@ -351,7 +353,7 @@ class Rotate(Component):
             for i in range(output_size):
                 cp_constraints.append(f"constraint {self.id}_o[{i}]={self.id}_i[{(i + rot_amount) % output_size}];")
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         return [f"  {self.id} = bit_vector_ROTATE([{','.join(params)} ], {self.description[1]})"]
@@ -601,7 +603,7 @@ class Rotate(Component):
                 f"constraint RRot({mzn_input_array_1}, {int(rotation_const)})={mzn_output_array_1};\n"
             ]
 
-        return var_names, rotate_mzn_constraints
+        return CpComponentBuildResult(var_names, rotate_mzn_constraints)
 
     def minizinc_deterministic_truncated_xor_differential_trail_constraints(self, model):
         return self.minizinc_constraints(model)

--- a/claasp/components/rotate_component.py
+++ b/claasp/components/rotate_component.py
@@ -230,7 +230,7 @@ class Rotate(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         cp_declarations = []
         all_inputs_value = []
         all_inputs_active = []

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -32,6 +32,8 @@ from claasp.cipher_modules.models.milp.utils.milp_name_mappings import MILP_DEFA
 from claasp.cipher_modules.models.milp.utils.utils import espresso_pos_to_constraints
 from claasp.input import Input
 from claasp.component import Component, free_input
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.sat.utils import constants
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.milp.utils import utils as milp_utils
@@ -812,7 +814,7 @@ class SBOX(Component):
         table_output = "++".join([f"[{self.id}[{i}]]" for i in range(output_size)])
         cp_constraints = [f"constraint table({table_input}++{table_output}, table_{output_id_link_sost});"]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_constraints(self, sbox_table_cache, inverse=False):
         """
@@ -869,12 +871,12 @@ class SBOX(Component):
         new_constraint = f"constraint table({table_input}++{table_output}, table_{output_id_link_sost});"
         cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints, sbox_table_cache
+        return CpComponentBuildResult(cp_declarations, cp_constraints, sbox_table_cache)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self, sbox_table_cache, inverse=False):
         return self.cp_deterministic_truncated_xor_differential_constraints(sbox_table_cache, inverse)
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self, sbox_table_cache=None, inverse=False):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context=None, state=None):
         raise NotImplementedError("Semi-deterministic CP model not supported for SBOX component yet")
 
     def cp_hybrid_deterministic_truncated_xor_differential_constraints(
@@ -973,7 +975,7 @@ class SBOX(Component):
         cp_constraint = f"constraint abstract_{output_id_link_sost}(array1d(0..{len(all_inputs) - 1}, {table_input}), array1d(0..{output_size - 1}, {table_output}), {round}, {index_of_id});"
         cp_constraints = [cp_constraint]
 
-        return cp_declarations, cp_constraints, sbox_table_cache
+        return CpComponentBuildResult(cp_declarations, cp_constraints, sbox_table_cache)
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         """
@@ -1008,7 +1010,7 @@ class SBOX(Component):
                 f"constraint if {input_}==0 then {self.id}_active[{i}] = 0 else {self.id}_active[{i}] = 2 endif;"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_first_step_constraints(self, model):
         """
@@ -1049,32 +1051,34 @@ class SBOX(Component):
         cp_declarations = [f"array[0..{(self.output_bit_size - 1) // word_size}] of var 0..1: {self.id};"]
         cp_constraints = [f"constraint {self.id}[{i}] = {input_};" for i, input_ in enumerate(all_inputs)]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         return self.cp_xor_differential_first_step_constraints(model)
 
-    def cp_xor_differential_propagation_constraints(self, model, inverse=False):
+    def cp_xor_differential_propagation_constraints(self, context, state, inverse=False):
         """
         Return lists of declarations and constraints for the probability of SBOX component for CP xor differential probability.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
         - ``inverse`` -- **boolean** (default: `False`); used to model components in the impossible xor differential model
 
         EXAMPLES::
 
             sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
-            sage: cp = type('DummyModel', (), {})()
-            sage: cp.sbox_table_cache = []
-            sage: cp.component_and_probability = {}
-            sage: cp.component_probability_index = 0
-            sage: cp_decl, cp_constr = sbox_component.cp_xor_differential_propagation_constraints(cp)[0:2]
-            sage: cp_constr
+            sage: state = CpBuildState()
+            sage: result = sbox_component.cp_xor_differential_propagation_constraints(None, state)
+            sage: result.constraints
             ['constraint table([plaintext[0]]++[plaintext[1]]++[plaintext[2]]++[sbox_0_0[0]]++[sbox_0_0[1]]++[sbox_0_0[2]]++[p[0]], DDT_sbox_0_0);']
         """
+        return self._cp_xor_differential_propagation_impl(state, inverse)
+
+    def _cp_xor_differential_propagation_impl(self, state, inverse=False):
         input_size = int(self.input_bit_size)
         output_size = int(self.output_bit_size)
         description = self.description
@@ -1084,7 +1088,7 @@ class SBOX(Component):
             output_id_link_sost = f"inverse_{self.id}"
         else:
             output_id_link_sost = self.id
-        for mant in model.sbox_table_cache:
+        for mant in state.sbox_table_cache:
             if description == mant[0] and ((not inverse) or (inverse and "inverse" in mant[1])):
                 already_in = True
                 output_id_link_sost = mant[1]
@@ -1107,39 +1111,41 @@ class SBOX(Component):
                 f"[{ddt_values}]);"
             )
             cp_declarations.append(sbox_declaration)
-            model.sbox_table_cache.append((description, self.id))
+            state.sbox_table_cache.append((description, self.id))
         all_inputs = []
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs.extend([f"[{id_link}[{position}]]" for position in bit_positions])
         table_input = "++".join(all_inputs)
         table_output = "++".join([f"[{self.id}[{i}]]" for i in range(output_size)])
-        constraint = f"constraint table({table_input}++{table_output}++[p[{model.component_probability_index}]], DDT_{output_id_link_sost});"
+        prob_index = state.allocate_probability_index()
+        constraint = f"constraint table({table_input}++{table_output}++[p[{prob_index}]], DDT_{output_id_link_sost});"
         cp_constraints = [constraint]
-        model.component_and_probability[self.id] = model.component_probability_index
-        model.component_probability_index += 1
+        state.component_probability_map[self.id] = prob_index
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for the probability of SBOX component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
-            sage: cp = type('DummyModel', (), {})()
-            sage: cp.sbox_table_cache = []
-            sage: cp.component_and_probability = {}
-            sage: cp.component_probability_index = 0
-            sage: cp_decl, cp_constr = sbox_component.cp_xor_linear_mask_propagation_constraints(cp)[0:2]
-            sage: cp_constr
+            sage: state = CpBuildState()
+            sage: result = sbox_component.cp_xor_linear_mask_propagation_constraints(None, state)
+            sage: result.constraints
             ['constraint table([sbox_0_0_i[0]]++[sbox_0_0_i[1]]++[sbox_0_0_i[2]]++[sbox_0_0_o[0]]++[sbox_0_0_o[1]]++[sbox_0_0_o[2]]++[p[0]],LAT_sbox_0_0);']
         """
+        return self._cp_xor_linear_mask_propagation_impl(state)
+
+    def _cp_xor_linear_mask_propagation_impl(self, state):
         input_size = int(self.input_bit_size)
         output_size = int(self.output_bit_size)
         output_id_link = self.id
@@ -1149,7 +1155,7 @@ class SBOX(Component):
         cp_constraints = []
         already_in = 0
         output_id_link_sost = output_id_link
-        sbox_table_cache = model.sbox_table_cache
+        sbox_table_cache = state.sbox_table_cache
         for i in range(len(sbox_table_cache)):
             if description == sbox_table_cache[i][0]:
                 already_in = 1
@@ -1180,12 +1186,12 @@ class SBOX(Component):
             new_constraint = new_constraint + f"[{output_id_link}_i[{i}]]++"
         for i in range(output_size):
             new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++"
-        new_constraint = new_constraint + f"[p[{model.component_probability_index}]],LAT_{output_id_link_sost});"
+        prob_index = state.allocate_probability_index()
+        new_constraint = new_constraint + f"[p[{prob_index}]],LAT_{output_id_link_sost});"
         cp_constraints.append(new_constraint)
-        model.component_and_probability[output_id_link] = model.component_probability_index
-        model.component_probability_index += 1
+        state.component_probability_map[output_id_link] = prob_index
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def generate_sbox_sign_lat(self):
         """

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -1070,7 +1070,7 @@ class SBOX(Component):
             sage: cp = type('DummyModel', (), {})()
             sage: cp.sbox_mant = []
             sage: cp.component_and_probability = {}
-            sage: cp.c = 0
+            sage: cp.component_probability_index = 0
             sage: cp_decl, cp_constr = sbox_component.cp_xor_differential_propagation_constraints(cp)[0:2]
             sage: cp_constr
             ['constraint table([plaintext[0]]++[plaintext[1]]++[plaintext[2]]++[sbox_0_0[0]]++[sbox_0_0[1]]++[sbox_0_0[2]]++[p[0]], DDT_sbox_0_0);']
@@ -1113,10 +1113,10 @@ class SBOX(Component):
             all_inputs.extend([f"[{id_link}[{position}]]" for position in bit_positions])
         table_input = "++".join(all_inputs)
         table_output = "++".join([f"[{self.id}[{i}]]" for i in range(output_size)])
-        constraint = f"constraint table({table_input}++{table_output}++[p[{model.c}]], DDT_{output_id_link_sost});"
+        constraint = f"constraint table({table_input}++{table_output}++[p[{model.component_probability_index}]], DDT_{output_id_link_sost});"
         cp_constraints = [constraint]
-        model.component_and_probability[self.id] = model.c
-        model.c += 1
+        model.component_and_probability[self.id] = model.component_probability_index
+        model.component_probability_index += 1
 
         return cp_declarations, cp_constraints
 
@@ -1135,7 +1135,7 @@ class SBOX(Component):
             sage: cp = type('DummyModel', (), {})()
             sage: cp.sbox_mant = []
             sage: cp.component_and_probability = {}
-            sage: cp.c = 0
+            sage: cp.component_probability_index = 0
             sage: cp_decl, cp_constr = sbox_component.cp_xor_linear_mask_propagation_constraints(cp)[0:2]
             sage: cp_constr
             ['constraint table([sbox_0_0_i[0]]++[sbox_0_0_i[1]]++[sbox_0_0_i[2]]++[sbox_0_0_o[0]]++[sbox_0_0_o[1]]++[sbox_0_0_o[2]]++[p[0]],LAT_sbox_0_0);']
@@ -1180,10 +1180,10 @@ class SBOX(Component):
             new_constraint = new_constraint + f"[{output_id_link}_i[{i}]]++"
         for i in range(output_size):
             new_constraint = new_constraint + f"[{output_id_link}_o[{i}]]++"
-        new_constraint = new_constraint + f"[p[{model.c}]],LAT_{output_id_link_sost});"
+        new_constraint = new_constraint + f"[p[{model.component_probability_index}]],LAT_{output_id_link_sost});"
         cp_constraints.append(new_constraint)
-        model.component_and_probability[output_id_link] = model.c
-        model.c = model.c + 1
+        model.component_and_probability[output_id_link] = model.component_probability_index
+        model.component_probability_index = model.component_probability_index + 1
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -80,7 +80,7 @@ def check_table_feasibility(table, table_type, solver):
 
 
 def cp_update_ddt_valid_probabilities(
-    cipher, component, word_size, cp_declarations, table_items, valid_probabilities, sbox_mant
+    cipher, component, word_size, cp_declarations, table_items, valid_probabilities, sbox_table_cache
 ):
     """
     Update CP bookkeeping for S-box differential probabilities.
@@ -94,7 +94,7 @@ def cp_update_ddt_valid_probabilities(
     - ``cp_declarations`` -- **list**; declarations updated in place
     - ``table_items`` -- **list**; table items updated in place
     - ``valid_probabilities`` -- **set**; differential weights updated in place
-    - ``sbox_mant`` -- **list**; cache of already processed S-boxes
+    - ``sbox_table_cache`` -- **list**; cache of already processed S-boxes
 
     OUTPUT:
 
@@ -107,15 +107,15 @@ def cp_update_ddt_valid_probabilities(
         ....:     def is_spn(self):
         ....:         return True
         sage: component = SBOX(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
-        sage: cp_declarations, table_items, valid_probabilities, sbox_mant = [], [], set(), []
-        sage: cp_update_ddt_valid_probabilities(DummyCipher(), component, 4, cp_declarations, table_items, valid_probabilities, sbox_mant)
+        sage: cp_declarations, table_items, valid_probabilities, sbox_table_cache = [], [], set(), []
+        sage: cp_update_ddt_valid_probabilities(DummyCipher(), component, 4, cp_declarations, table_items, valid_probabilities, sbox_table_cache)
         sage: len(valid_probabilities) > 0
         True
         sage: cp_declarations
         ['constraint (xor_0_0[0]+xor_0_0[1]+xor_0_0[2]+xor_0_0[3] > 0) = word_sbox_0_0[0];', 'array[0..0] of var 0..1: word_sbox_0_0;']
         sage: table_items
         ['[word_sbox_0_0[s] | s in 0..0]']
-        sage: sbox_mant
+        sage: sbox_table_cache
         [([12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2], 'sbox_0_0')]
     """
     input_size = int(component.input_bit_size)
@@ -123,7 +123,7 @@ def cp_update_ddt_valid_probabilities(
     description = component.description
     sbox = SBox(description)
     sbox_already_in = False
-    for mant in sbox_mant:
+    for mant in sbox_table_cache:
         if description == mant[0]:
             sbox_already_in = True
     if not sbox_already_in:
@@ -134,7 +134,7 @@ def cp_update_ddt_valid_probabilities(
             valid_probabilities.update(
                 {round(100 * math.log2(2**input_size / occurrence)) for occurrence in set_of_occurrences}
             )
-        sbox_mant.append((description, output_id_link))
+        sbox_table_cache.append((description, output_id_link))
     if cipher.is_spn():
         input_id_link = component.input_id_links[0]
         input_bit_positions = component.input_bit_positions[0]
@@ -147,7 +147,7 @@ def cp_update_ddt_valid_probabilities(
         table_items.append(f"[word_{output_id_link}[s] | s in 0..{input_size // word_size - 1}]")
 
 
-def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant):
+def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_table_cache):
     """
     Update CP bookkeeping for S-box linear probabilities.
 
@@ -155,7 +155,7 @@ def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
 
     - ``component`` -- component-like object with ``input_bit_size``, ``id`` and ``description``
     - ``valid_probabilities`` -- **set**; linear weights updated in place
-    - ``sbox_mant`` -- **list**; cache of already processed S-boxes
+    - ``sbox_table_cache`` -- **list**; cache of already processed S-boxes
 
     OUTPUT:
 
@@ -165,11 +165,11 @@ def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
 
         sage: from claasp.components.sbox_component import SBOX, cp_update_lat_valid_probabilities
         sage: component = SBOX(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
-        sage: valid_probabilities, sbox_mant = set(), []
-        sage: cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
+        sage: valid_probabilities, sbox_table_cache = set(), []
+        sage: cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_table_cache)
         sage: len(valid_probabilities) > 0
         True
-        sage: sbox_mant
+        sage: sbox_table_cache
         [([12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2], 'sbox_0_0')]
     """
     input_size = component.input_bit_size
@@ -177,8 +177,8 @@ def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
     description = component.description
     sbox = SBox(description)
     already_in = False
-    for i in range(len(sbox_mant)):
-        if description == sbox_mant[i][0]:
+    for i in range(len(sbox_table_cache)):
+        if description == sbox_table_cache[i][0]:
             already_in = True
     if not already_in:
         sbox_lat = sbox.linear_approximation_table()
@@ -188,7 +188,7 @@ def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
             valid_probabilities.update(
                 {round(100 * math.log2(abs(pow(2, input_size - 1) / occurence))) for occurence in set_of_occurrences}
             )
-        sbox_mant.append((description, output_id_link))
+        sbox_table_cache.append((description, output_id_link))
 
 
 def milp_set_constraints_from_dictionnary_for_large_sbox(
@@ -497,17 +497,17 @@ def _get_truncated_output_difference(ddt_row, n):
     return has_undisturbed_bits, output_bits
 
 
-def _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
-    inv_output_id_link, undisturbed_bits, sbox_mant, inverse
+def _mzn_update_sbox_table_cache_for_deterministic_truncated_xor_differential(
+    inv_output_id_link, undisturbed_bits, sbox_table_cache, inverse
 ):
     """
     Update and query the S-box deduplication cache for deterministic truncated xor differential constraints.
 
-    `sbox_mant` ("S-box Materialized") is a deduplication cache that accumulates S-box table descriptions
+    `sbox_table_cache` is a deduplication cache that accumulates S-box table descriptions
     to avoid generating duplicate constraint declarations during constraint programming model generation.
     This is critical when the same S-box appears across multiple cipher rounds or component instances.
 
-    Entries in `sbox_mant` for this function are stored as:
+    Entries in `sbox_table_cache` for this function are stored as:
         [undisturbed_table_bits_string, output_id_link]
 
     where:
@@ -517,12 +517,12 @@ def _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
     This function:
     1. Checks if the S-box's undisturbed table has already been declared (cache hit)
     2. Returns the existing output_id_link if found (for constraint reuse)
-    3. Otherwise, adds the new entry to sbox_mant and returns the new output_id_link
+    3. Otherwise, adds the new entry to `sbox_table_cache` and returns the new output_id_link
 
     Args:
         inv_output_id_link: Component ID for this S-box (used as lookup key)
         undisturbed_bits: List of (input_tuple, output_tuple) differential pairs with undisturbed bits
-        sbox_mant: Accumulating cache list modified in-place; tracks [table_bits, id] entries
+        sbox_table_cache: Accumulating cache list modified in-place; tracks [table_bits, id] entries
         inverse: Boolean flag used for matching cache entries (e.g., "inverse_sbox_0_1")
 
     Returns:
@@ -539,12 +539,12 @@ def _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
     undisturbed_table_bits = ",".join(undisturbed_bits_ddt)
     already_in = False
     output_id_link_sost = inv_output_id_link
-    for mant in sbox_mant:
+    for mant in sbox_table_cache:
         if undisturbed_table_bits == mant[0] and ((not inverse) or (inverse and "inverse" in mant[1])):
             already_in = True
             output_id_link_sost = mant[1]
     if not already_in:
-        sbox_mant.append([undisturbed_table_bits, inv_output_id_link])
+        sbox_table_cache.append([undisturbed_table_bits, inv_output_id_link])
 
     return already_in, output_id_link_sost, undisturbed_table_bits
 
@@ -574,13 +574,13 @@ class SBOX(Component):
         sage: print(len(component.description))
         8
 
-    NOTE ON `sbox_mant` (S-box Materialized Cache):
+    NOTE ON `sbox_table_cache`:
 
     The S-box component's constraint generation methods for Constraint Programming (CP) models
-    accept and return an ``sbox_mant`` parameter, a deduplication cache that avoids redundant table declarations.
+    accept and return an ``sbox_table_cache`` parameter, a deduplication cache that avoids redundant table declarations.
 
     **Purpose**: When multiple S-boxes in a cipher are identical or share the same lookup structure, declaring
-    the same constraint table multiple times is wasteful. The `sbox_mant` cache tracks already-generated tables
+    the same constraint table multiple times is wasteful. The `sbox_table_cache` tracks already-generated tables
     across component rounds and instances.
 
     **Structure**: A list of entries where each entry type depends on the constraint model:
@@ -588,9 +588,9 @@ class SBOX(Component):
     - For ``cp_deterministic_truncated_xor_differential_constraints``: ``[undisturbed_bits_string, component_id]`` list
 
     **Usage Pattern**:
-    1. Initialize with empty list: ``sbox_mant = []``
-    2. Pass to first component: ``decls1, constraints1, sbox_mant = sbox1.cp_constraints(sbox_mant=[])``
-    3. Reuse cache for subsequent components: ``decls2, constraints2, sbox_mant = sbox2.cp_constraints(sbox_mant)``
+    1. Initialize with empty list: ``sbox_table_cache = []``
+    2. Pass to first component: ``decls1, constraints1 = sbox1.cp_constraints(sbox_table_cache=[])``
+    3. Reuse cache for subsequent components: ``decls2, constraints2 = sbox2.cp_constraints(sbox_table_cache)``
     4. If sbox2 matches sbox1, then ``decls2`` will be empty (table reused via table name reference)
 
     **Benefit**: Reduces constraint bloat in models with repeated S-box instances and improves solver performance.
@@ -763,13 +763,13 @@ class SBOX(Component):
     def cms_xor_linear_mask_propagation_constraints(self, model):
         return self.sat_xor_linear_mask_propagation_constraints(model)
 
-    def cp_constraints(self, sbox_mant, second=False):
+    def cp_constraints(self, sbox_table_cache, second=False):
         """
         Return lists of declarations and constraints for SBOX component for CP CIPHER model.
 
         INPUT:
 
-        - ``sbox_mant`` -- **list of objects**; the list of the S-boxes already encountered so that there is no need to calculate the constraints again
+        - ``sbox_table_cache`` -- **list of objects**; the list of the S-boxes already encountered so that there is no need to calculate the constraints again
 
         EXAMPLES::
 
@@ -787,7 +787,7 @@ class SBOX(Component):
             sec_output_id_link = self.id
         already_in = False
         output_id_link_sost = sec_output_id_link
-        for mant in sbox_mant:
+        for mant in sbox_table_cache:
             if sbox == mant[0] and ((not second) or (second and "second" in mant[1])):
                 already_in = True
                 output_id_link_sost = mant[1]
@@ -804,7 +804,7 @@ class SBOX(Component):
                 f"[{table_values}]);"
             )
             cp_declarations.append(sbox_declaration)
-            sbox_mant.append((sbox, self.id))
+            sbox_table_cache.append((sbox, self.id))
         all_inputs = []
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs.extend([f"[{id_link}[{position}]]" for position in bit_positions])
@@ -814,7 +814,7 @@ class SBOX(Component):
 
         return cp_declarations, cp_constraints
 
-    def cp_deterministic_truncated_xor_differential_constraints(self, sbox_mant, inverse=False):
+    def cp_deterministic_truncated_xor_differential_constraints(self, sbox_table_cache, inverse=False):
         """
         Return lists of declarations and constraints for SBOX component for CP deterministic truncated xor differential.
 
@@ -827,12 +827,12 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox = [1, 2, 3, 4, 0, 7, 6, 5]
             sage: sbox_component = SBOX(0, 1, ['xor_0_0'], [[0, 1, 2, 3]], 4, sbox)
-            sage: declarations, constraints, sbox_mant = sbox_component.cp_deterministic_truncated_xor_differential_constraints(sbox_mant = [])
+            sage: declarations, constraints, sbox_table_cache = sbox_component.cp_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
             sage: declarations
             ['array [1..27, 1..6] of int: table_sbox_0_1 = array2d(1..27, 1..6, [0,0,0,0,0,0,0,0,1,2,1,1,0,1,0,2,1,0,0,1,1,2,0,1,1,0,0,2,0,1,1,0,1,2,1,0,1,1,0,2,1,1,1,1,1,1,0,0,0,0,2,2,2,2,0,2,0,2,2,0,0,2,2,2,2,2,2,0,0,2,0,2,2,0,2,2,2,2,2,2,0,2,2,2,2,2,2,2,2,2,0,2,1,2,2,1,2,0,1,2,1,2,2,2,1,2,2,2,0,1,2,2,2,2,2,1,0,2,1,2,2,1,2,2,2,2,2,1,1,2,0,2,1,0,2,2,2,2,1,2,0,2,2,1,1,2,2,2,2,2,1,2,1,2,2,0,1,1,2,2,2,2]);']
             sage: constraints
             ['constraint table([xor_0_0[0]]++[xor_0_0[1]]++[xor_0_0[2]]++[xor_0_0[3]]++[sbox_0_1[0]]++[sbox_0_1[1]]++[sbox_0_1[2]]++[sbox_0_1[3]], table_sbox_0_1);']
-            sage: sbox_mant
+            sage: sbox_table_cache
             [['0,0,0,0,0,0,0,0,1,2,1,1,0,1,0,2,1,0,0,1,1,2,0,1,1,0,0,2,0,1,1,0,1,2,1,0,1,1,0,2,1,1,1,1,1,1,0,0,0,0,2,2,2,2,0,2,0,2,2,0,0,2,2,2,2,2,2,0,0,2,0,2,2,0,2,2,2,2,2,2,0,2,2,2,2,2,2,2,2,2,0,2,1,2,2,1,2,0,1,2,1,2,2,2,1,2,2,2,0,1,2,2,2,2,2,1,0,2,1,2,2,1,2,2,2,2,2,1,1,2,0,2,1,0,2,2,2,2,1,2,0,2,2,1,1,2,2,2,2,2,1,2,1,2,2,0,1,1,2,2,2,2',
             'sbox_0_1']]
         """
@@ -852,8 +852,8 @@ class SBOX(Component):
         table_output = "++".join([f"[{output_id_link}[{i}]]" for i in range(self.output_bit_size)])
 
         already_in, output_id_link_sost, undisturbed_table_bits = (
-            _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
-                inv_output_id_link, eventual_undisturbed_bits, sbox_mant, inverse
+            _mzn_update_sbox_table_cache_for_deterministic_truncated_xor_differential(
+                inv_output_id_link, eventual_undisturbed_bits, sbox_table_cache, inverse
             )
         )
 
@@ -869,22 +869,22 @@ class SBOX(Component):
         new_constraint = f"constraint table({table_input}++{table_output}, table_{output_id_link_sost});"
         cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints, sbox_mant
+        return cp_declarations, cp_constraints, sbox_table_cache
 
-    def cp_deterministic_truncated_xor_differential_trail_constraints(self, sbox_mant, inverse=False):
-        return self.cp_deterministic_truncated_xor_differential_constraints(sbox_mant, inverse)
+    def cp_deterministic_truncated_xor_differential_trail_constraints(self, sbox_table_cache, inverse=False):
+        return self.cp_deterministic_truncated_xor_differential_constraints(sbox_table_cache, inverse)
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self, sbox_mant=None, inverse=False):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, sbox_table_cache=None, inverse=False):
         raise NotImplementedError("Semi-deterministic CP model not supported for SBOX component yet")
 
     def cp_hybrid_deterministic_truncated_xor_differential_constraints(
-        self, sbox_mant, inverse=False, list_of_component_number=[]
+        self, sbox_table_cache, inverse=False, list_of_component_number=[]
     ):
         """
         Return lists of declarations and constraints for SBOX component for CP hybrid deterministic truncated xor differential.
 
         INPUT:
-        - ``sbox_mant`` -- **list**
+        - ``sbox_table_cache`` -- **list**
         - ``inverse`` -- **boolean** (default: `False`)
         - ``list_of_component_number`` -- **list** (default: `[]`)
 
@@ -894,7 +894,7 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: lblock_sbox = [14, 9, 15, 0, 13, 4, 10, 11, 1, 2, 8, 3, 7, 6, 12, 5]
             sage: sbox_component = SBOX(0, 2, ['xor_0_1'], [[4, 5, 6, 7]], 4, lblock_sbox)
-            sage: declarations, constraints, sbox_mant = sbox_component.cp_hybrid_deterministic_truncated_xor_differential_constraints(sbox_mant = [])
+            sage: declarations, constraints, sbox_table_cache = sbox_component.cp_hybrid_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
             sage: constraints
             ['constraint abstract_sbox_0_2(array1d(0..3, [xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]), array1d(0..3, [sbox_0_2[0]]++[sbox_0_2[1]]++[sbox_0_2[2]]++[sbox_0_2[3]]), 0, 0);']
         """
@@ -957,8 +957,8 @@ class SBOX(Component):
         table_input = "++".join(all_inputs)
         table_output = "++".join([f"[{self.id}[{i}]]" for i in range(output_size)])
 
-        already_in, output_id_link_sost, _ = _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
-            inv_output_id_link, undisturbed_bits, sbox_mant, inverse
+        already_in, output_id_link_sost, _ = _mzn_update_sbox_table_cache_for_deterministic_truncated_xor_differential(
+            inv_output_id_link, undisturbed_bits, sbox_table_cache, inverse
         )
 
         cp_declarations = []
@@ -973,7 +973,7 @@ class SBOX(Component):
         cp_constraint = f"constraint abstract_{output_id_link_sost}(array1d(0..{len(all_inputs) - 1}, {table_input}), array1d(0..{output_size - 1}, {table_output}), {round}, {index_of_id});"
         cp_constraints = [cp_constraint]
 
-        return cp_declarations, cp_constraints, sbox_mant
+        return cp_declarations, cp_constraints, sbox_table_cache
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         """
@@ -1068,7 +1068,7 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
             sage: cp = type('DummyModel', (), {})()
-            sage: cp.sbox_mant = []
+            sage: cp.sbox_table_cache = []
             sage: cp.component_and_probability = {}
             sage: cp.component_probability_index = 0
             sage: cp_decl, cp_constr = sbox_component.cp_xor_differential_propagation_constraints(cp)[0:2]
@@ -1084,7 +1084,7 @@ class SBOX(Component):
             output_id_link_sost = f"inverse_{self.id}"
         else:
             output_id_link_sost = self.id
-        for mant in model.sbox_mant:
+        for mant in model.sbox_table_cache:
             if description == mant[0] and ((not inverse) or (inverse and "inverse" in mant[1])):
                 already_in = True
                 output_id_link_sost = mant[1]
@@ -1107,7 +1107,7 @@ class SBOX(Component):
                 f"[{ddt_values}]);"
             )
             cp_declarations.append(sbox_declaration)
-            model.sbox_mant.append((description, self.id))
+            model.sbox_table_cache.append((description, self.id))
         all_inputs = []
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs.extend([f"[{id_link}[{position}]]" for position in bit_positions])
@@ -1133,7 +1133,7 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
             sage: cp = type('DummyModel', (), {})()
-            sage: cp.sbox_mant = []
+            sage: cp.sbox_table_cache = []
             sage: cp.component_and_probability = {}
             sage: cp.component_probability_index = 0
             sage: cp_decl, cp_constr = sbox_component.cp_xor_linear_mask_propagation_constraints(cp)[0:2]
@@ -1149,11 +1149,11 @@ class SBOX(Component):
         cp_constraints = []
         already_in = 0
         output_id_link_sost = output_id_link
-        sbox_mant = model.sbox_mant
-        for i in range(len(sbox_mant)):
-            if description == sbox_mant[i][0]:
+        sbox_table_cache = model.sbox_table_cache
+        for i in range(len(sbox_table_cache)):
+            if description == sbox_table_cache[i][0]:
                 already_in = 1
-                output_id_link_sost = sbox_mant[i][1]
+                output_id_link_sost = sbox_table_cache[i][1]
         if already_in == 0:
             size = 0
             sbox_lat = sbox.linear_approximation_table()
@@ -1172,7 +1172,7 @@ class SBOX(Component):
             )
             sbox_declaration = pre_declaration + sbox_declaration[:-1] + "]);"
             cp_declarations.append(sbox_declaration)
-            sbox_mant.append((description, output_id_link))
+            sbox_table_cache.append((description, output_id_link))
         cp_declarations.append(f"array[0..{input_size - 1}] of var 0..1: {output_id_link}_i;")
         cp_declarations.append(f"array[0..{output_size - 1}] of var 0..1: {output_id_link}_o;")
         new_constraint = "constraint table("

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -979,21 +979,22 @@ class SBOX(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints, sbox_table_cache)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return lists of declarations and constraints for SBOX component for CP wordwise deterministic truncated xor differential.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox = [1, 2, 3, 4, 5, 6, 7, 0]
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, sbox)
-            sage: model = type('DummyModel', (), {'word_size': 3})()
-            sage: result = sbox_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(model)
+            sage: context = type('DummyContext', (), {'word_size': 3})()
+            sage: result = sbox_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(context, None)
             sage: result.declarations
             []
             sage: result.constraints
@@ -1001,7 +1002,7 @@ class SBOX(Component):
         """
         cp_declarations = []
         all_inputs = []
-        word_size = model.word_size
+        word_size = context.word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs.extend(
                 [
@@ -1084,43 +1085,58 @@ class SBOX(Component):
         """
         return self._cp_xor_differential_propagation_impl(state, inverse)
 
+    @staticmethod
+    def _resolve_ddt_table_alias(sbox_table_cache, description, component_id, inverse):
+        if inverse:
+            output_id_link_sost = f"inverse_{component_id}"
+        else:
+            output_id_link_sost = component_id
+
+        for mant in sbox_table_cache:
+            if description == mant[0] and ((not inverse) or (inverse and "inverse" in mant[1])):
+                return True, mant[1]
+
+        return False, output_id_link_sost
+
+    @staticmethod
+    def _build_ddt_declaration(sbox, input_size, output_size, output_id_link_sost):
+        sbox_ddt = sbox.difference_distribution_table()
+        dim_ddt = len([i for i in sbox_ddt.list() if i])
+        ddt_entries = []
+        for i in range(sbox_ddt.nrows()):
+            for j in range(sbox_ddt.ncols()):
+                if not sbox_ddt[i][j]:
+                    continue
+                sep_bin_i = ",".join(f"{i:0{input_size}b}")
+                sep_bin_j = ",".join(f"{j:0{output_size}b}")
+                log_of_prob = round(100 * math.log2((2**input_size) / sbox_ddt[i][j]))
+                ddt_entries.append(f"{sep_bin_i},{sep_bin_j},{log_of_prob}")
+
+        ddt_values = ",".join(ddt_entries)
+        return (
+            f"array [1..{dim_ddt}, 1..{input_size + output_size + 1}] of int: "
+            f"DDT_{output_id_link_sost} = array2d(1..{dim_ddt}, 1..{input_size + output_size + 1}, "
+            f"[{ddt_values}]);"
+        )
+
     def _cp_xor_differential_propagation_impl(self, state, inverse=False):
         input_size = int(self.input_bit_size)
         output_size = int(self.output_bit_size)
         description = self.description
         sbox = SBox(description)
-        already_in = False
-        if inverse:
-            output_id_link_sost = f"inverse_{self.id}"
-        else:
-            output_id_link_sost = self.id
-        for mant in state.sbox_table_cache:
-            if description == mant[0] and ((not inverse) or (inverse and "inverse" in mant[1])):
-                already_in = True
-                output_id_link_sost = mant[1]
+        already_in, output_id_link_sost = self._resolve_ddt_table_alias(
+            state.sbox_table_cache, description, self.id, inverse
+        )
+
         cp_declarations = []
         if not already_in:
-            sbox_ddt = sbox.difference_distribution_table()
-            dim_ddt = len([i for i in sbox_ddt.list() if i])
-            ddt_entries = []
-            for i in range(sbox_ddt.nrows()):
-                for j in range(sbox_ddt.ncols()):
-                    if sbox_ddt[i][j]:
-                        sep_bin_i = ",".join(f"{i:0{input_size}b}")
-                        sep_bin_j = ",".join(f"{j:0{output_size}b}")
-                        log_of_prob = round(100 * math.log2((2**input_size) / sbox_ddt[i][j]))
-                        ddt_entries.append(f"{sep_bin_i},{sep_bin_j},{log_of_prob}")
-            ddt_values = ",".join(ddt_entries)
-            sbox_declaration = (
-                f"array [1..{dim_ddt}, 1..{input_size + output_size + 1}] of int: "
-                f"DDT_{output_id_link_sost} = array2d(1..{dim_ddt}, 1..{input_size + output_size + 1}, "
-                f"[{ddt_values}]);"
-            )
-            cp_declarations.append(sbox_declaration)
+            cp_declarations.append(self._build_ddt_declaration(sbox, input_size, output_size, output_id_link_sost))
             state.sbox_table_cache.append((description, self.id))
+
         all_inputs = []
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs.extend([f"[{id_link}[{position}]]" for position in bit_positions])
+
         table_input = "++".join(all_inputs)
         table_output = "++".join([f"[{self.id}[{i}]]" for i in range(output_size)])
         prob_index = state.allocate_probability_index()

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -778,9 +778,11 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox = [12, 10, 13, 3, 14, 11, 15, 7, 8, 9, 1, 5, 0, 2, 4, 6]
             sage: sbox_component = SBOX(0, 5, ['xor_0_1'], [[4, 5, 6, 7]], 4, sbox)
-            sage: sbox_component.cp_constraints([])
-            (['array [1..16, 1..8] of int: table_sbox_0_5 = array2d(1..16, 1..8, [0,0,0,0,1,1,0,0,0,0,0,1,1,0,1,0,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,1,0,1,0,0,1,1,1,0,0,1,0,1,1,0,1,1,0,1,1,0,1,1,1,1,0,1,1,1,0,1,1,1,1,0,0,0,1,0,0,0,1,0,0,1,1,0,0,1,1,0,1,0,0,0,0,1,1,0,1,1,0,1,0,1,1,1,0,0,0,0,0,0,1,1,0,1,0,0,1,0,1,1,1,0,0,1,0,0,1,1,1,1,0,1,1,0]);'],
-             ['constraint table([xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]++[sbox_0_5[0]]++[sbox_0_5[1]]++[sbox_0_5[2]]++[sbox_0_5[3]], table_sbox_0_5);'])
+            sage: result = sbox_component.cp_constraints([])
+            sage: result.declarations[0].startswith('array [1..16, 1..8] of int: table_sbox_0_5 = array2d(')
+            True
+            sage: result.constraints
+            ['constraint table([xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]++[sbox_0_5[0]]++[sbox_0_5[1]]++[sbox_0_5[2]]++[sbox_0_5[3]], table_sbox_0_5);']
         """
         sbox = self.description
         if second:
@@ -829,12 +831,12 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: sbox = [1, 2, 3, 4, 0, 7, 6, 5]
             sage: sbox_component = SBOX(0, 1, ['xor_0_0'], [[0, 1, 2, 3]], 4, sbox)
-            sage: declarations, constraints, sbox_table_cache = sbox_component.cp_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
-            sage: declarations
+            sage: result = sbox_component.cp_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
+            sage: result.declarations
             ['array [1..27, 1..6] of int: table_sbox_0_1 = array2d(1..27, 1..6, [0,0,0,0,0,0,0,0,1,2,1,1,0,1,0,2,1,0,0,1,1,2,0,1,1,0,0,2,0,1,1,0,1,2,1,0,1,1,0,2,1,1,1,1,1,1,0,0,0,0,2,2,2,2,0,2,0,2,2,0,0,2,2,2,2,2,2,0,0,2,0,2,2,0,2,2,2,2,2,2,0,2,2,2,2,2,2,2,2,2,0,2,1,2,2,1,2,0,1,2,1,2,2,2,1,2,2,2,0,1,2,2,2,2,2,1,0,2,1,2,2,1,2,2,2,2,2,1,1,2,0,2,1,0,2,2,2,2,1,2,0,2,2,1,1,2,2,2,2,2,1,2,1,2,2,0,1,1,2,2,2,2]);']
-            sage: constraints
+            sage: result.constraints
             ['constraint table([xor_0_0[0]]++[xor_0_0[1]]++[xor_0_0[2]]++[xor_0_0[3]]++[sbox_0_1[0]]++[sbox_0_1[1]]++[sbox_0_1[2]]++[sbox_0_1[3]], table_sbox_0_1);']
-            sage: sbox_table_cache
+            sage: result.metadata
             [['0,0,0,0,0,0,0,0,1,2,1,1,0,1,0,2,1,0,0,1,1,2,0,1,1,0,0,2,0,1,1,0,1,2,1,0,1,1,0,2,1,1,1,1,1,1,0,0,0,0,2,2,2,2,0,2,0,2,2,0,0,2,2,2,2,2,2,0,0,2,0,2,2,0,2,2,2,2,2,2,0,2,2,2,2,2,2,2,2,2,0,2,1,2,2,1,2,0,1,2,1,2,2,2,1,2,2,2,0,1,2,2,2,2,2,1,0,2,1,2,2,1,2,2,2,2,2,1,1,2,0,2,1,0,2,2,2,2,1,2,0,2,2,1,1,2,2,2,2,2,1,2,1,2,2,0,1,1,2,2,2,2',
             'sbox_0_1']]
         """
@@ -896,8 +898,8 @@ class SBOX(Component):
             sage: from claasp.components.sbox_component import SBOX
             sage: lblock_sbox = [14, 9, 15, 0, 13, 4, 10, 11, 1, 2, 8, 3, 7, 6, 12, 5]
             sage: sbox_component = SBOX(0, 2, ['xor_0_1'], [[4, 5, 6, 7]], 4, lblock_sbox)
-            sage: declarations, constraints, sbox_table_cache = sbox_component.cp_hybrid_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
-            sage: constraints
+            sage: result = sbox_component.cp_hybrid_deterministic_truncated_xor_differential_constraints(sbox_table_cache=[])
+            sage: result.constraints
             ['constraint abstract_sbox_0_2(array1d(0..3, [xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]), array1d(0..3, [sbox_0_2[0]]++[sbox_0_2[1]]++[sbox_0_2[2]]++[sbox_0_2[3]]), 0, 0);']
         """
 
@@ -991,8 +993,11 @@ class SBOX(Component):
             sage: sbox = [1, 2, 3, 4, 5, 6, 7, 0]
             sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, sbox)
             sage: model = type('DummyModel', (), {'word_size': 3})()
-            sage: sbox_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(model)
-            ([], ['constraint if plaintext_value[0]==0 then sbox_0_0_active[0] = 0 else sbox_0_0_active[0] = 2 endif;'])
+            sage: result = sbox_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(model)
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint if plaintext_value[0]==0 then sbox_0_0_active[0] = 0 else sbox_0_0_active[0] = 2 endif;']
         """
         cp_declarations = []
         all_inputs = []
@@ -1030,10 +1035,11 @@ class SBOX(Component):
             ....:         self.table_of_solutions_length = 0
             sage: model = DummyModel()
             sage: sbox_component = SBOX(0, 0, ['input0'], [list(range(4))], 4, list(range(16)))
-            sage: sbox_component.cp_xor_differential_first_step_constraints(model)
-            (['array[0..1] of var 0..1: sbox_0_0;'],
-                ['constraint sbox_0_0[0] = input0[0];',
-                'constraint sbox_0_0[1] = input0[1];'])
+            sage: result = sbox_component.cp_xor_differential_first_step_constraints(model)
+            sage: result.declarations
+            ['array[0..1] of var 0..1: sbox_0_0;']
+            sage: result.constraints
+            ['constraint sbox_0_0[0] = input0[0];', 'constraint sbox_0_0[1] = input0[1];']
             sage: model.input_sbox
             [('input0[0]', 1), ('input0[1]', 1)]
             sage: model.table_of_solutions_length

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -979,7 +979,7 @@ class SBOX(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints, sbox_table_cache)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         """
         Return lists of declarations and constraints for SBOX component for CP wordwise deterministic truncated xor differential.
 

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -1183,7 +1183,7 @@ class SBOX(Component):
         new_constraint = new_constraint + f"[p[{model.component_probability_index}]],LAT_{output_id_link_sost});"
         cp_constraints.append(new_constraint)
         model.component_and_probability[output_id_link] = model.component_probability_index
-        model.component_probability_index = model.component_probability_index + 1
+        model.component_probability_index += 1
 
         return cp_declarations, cp_constraints
 

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -222,7 +222,7 @@ class SHIFT(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         """
         Return a list of CP declarations and a list of CP constraints for shift component.
 
@@ -230,15 +230,16 @@ class SHIFT(Component):
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.shift_component import SHIFT
-            sage: class DummyModel:
+            sage: class DummyContext:
             ....:     word_size = 2
             sage: shift_component = SHIFT(0, 18, ['sbox_0_2'], [list(range(4))], 4, -2)
-            sage: result = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyContext(), None)
             sage: result.declarations
             []
             sage: result.constraints
@@ -246,7 +247,7 @@ class SHIFT(Component):
         """
         output_size = int(self.output_bit_size)
         output_id_link = self.id
-        word_size = model.word_size
+        word_size = context.word_size
         shift_amount = abs(self.description[1]) // word_size
         all_inputs_active = []
         all_inputs_value = []

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -138,8 +138,11 @@ class SHIFT(Component):
 
             sage: from claasp.components.shift_component import SHIFT
             sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: shift_component.cp_constraints()
-            ([], ['constraint shift_0_0[0] = 0;', 'constraint shift_0_0[1] = input[0];'])
+            sage: result = shift_component.cp_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint shift_0_0[0] = 0;', 'constraint shift_0_0[1] = input[0];']
         """
         shift_amount = abs(self.description[1])
         cp_declarations = []
@@ -186,8 +189,11 @@ class SHIFT(Component):
 
             sage: from claasp.components.shift_component import SHIFT
             sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: shift_component.cp_inverse_constraints()
-            ([], ['constraint shift_0_0_inverse[0] = 0;', 'constraint shift_0_0_inverse[1] = input[0];'])
+            sage: result = shift_component.cp_inverse_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint shift_0_0_inverse[0] = 0;', 'constraint shift_0_0_inverse[1] = input[0];']
         """
         shift_amount = abs(self.description[1])
         cp_declarations = []
@@ -232,8 +238,11 @@ class SHIFT(Component):
             sage: class DummyModel:
             ....:     word_size = 2
             sage: shift_component = SHIFT(0, 18, ['sbox_0_2'], [list(range(4))], 4, -2)
-            sage: shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
-            ([], ['constraint shift_0_18_active[0] = sbox_0_2_active[1];', 'constraint shift_0_18_active[1] = 0;', 'constraint shift_0_18_value[0] = sbox_0_2_active[1];', 'constraint shift_0_18_value[1] = 0;'])
+            sage: result = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint shift_0_18_active[0] = sbox_0_2_active[1];', 'constraint shift_0_18_active[1] = 0;', 'constraint shift_0_18_value[0] = sbox_0_2_active[1];', 'constraint shift_0_18_value[1] = 0;']
         """
         output_size = int(self.output_bit_size)
         output_id_link = self.id
@@ -311,8 +320,11 @@ class SHIFT(Component):
             sage: class DummyModel:
             ....:     word_size = 2
             sage: shift_component = SHIFT(0, 18, ['input0'], [list(range(4))], 4, -2)
-            sage: shift_component.cp_xor_differential_first_step_constraints(DummyModel())
-            (['array[0..1] of var 0..1: shift_0_18;'], ['constraint shift_0_18[0] = input0[1];', 'constraint shift_0_18[1] = 0;'])
+            sage: result = shift_component.cp_xor_differential_first_step_constraints(DummyModel())
+            sage: result.declarations
+            ['array[0..1] of var 0..1: shift_0_18;']
+            sage: result.constraints
+            ['constraint shift_0_18[0] = input0[1];', 'constraint shift_0_18[1] = 0;']
         """
         output_size = int(self.output_bit_size)
         input_id_link = self.input_id_links
@@ -645,12 +657,11 @@ class SHIFT(Component):
             sage: cipher = ShiftCipher(bit_size=2, parameter=1)
             sage: minizinc = MznModel(cipher)
             sage: shift_component = cipher.get_component_from_id('shift_0_0')
-            sage: shift_component.minizinc_constraints(minizinc)
-            (['var bool: shift_0_0_x0;',
-            'var bool: shift_0_0_x1;',
-            'var bool: shift_0_0_y0;',
-            'var bool: shift_0_0_y1;'],
-            ['constraint RSHIFT(array1d(0..2-1, [shift_0_0_x0,shift_0_0_x1]), 1)=array1d(0..2-1, [shift_0_0_y0,shift_0_0_y1]);\n'])
+            sage: result = shift_component.minizinc_constraints(minizinc)
+            sage: result.declarations
+            ['var bool: shift_0_0_x0;', 'var bool: shift_0_0_x1;', 'var bool: shift_0_0_y0;', 'var bool: shift_0_0_y1;']
+            sage: result.constraints
+            ['constraint RSHIFT(array1d(0..2-1, [shift_0_0_x0,shift_0_0_x1]), 1)=array1d(0..2-1, [shift_0_0_y0,shift_0_0_y1]);\n']
         """
         var_names = self._define_var(model.input_postfix, model.output_postfix, model.data_type)
         shift_const = self.description[1]

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import WORD_OPERATION
@@ -165,12 +166,12 @@ class SHIFT(Component):
                 ]
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_inverse_constraints(self):
@@ -213,7 +214,7 @@ class SHIFT(Component):
                 ]
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
         """
@@ -294,7 +295,7 @@ class SHIFT(Component):
                 ]
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_xor_differential_first_step_constraints(self, model):
         """
@@ -363,28 +364,29 @@ class SHIFT(Component):
                 ]
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model=None):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_xor_differential_propagation_first_step_constraints(self, model):
         return self.cp_xor_differential_first_step_constraints(model)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return a list of Cp declarations and a list of Cp constraints for SHIFT component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.shift_component import SHIFT
             sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
-            sage: shift_component.cp_xor_linear_mask_propagation_constraints()
-            (['array[0..1] of var 0..1: shift_0_0_i;', 'array[0..1] of var 0..1: shift_0_0_o;'], ['constraint shift_0_0_i[1]=0;', 'constraint shift_0_0_o[1]=shift_0_0_i[0];'])
+            sage: shift_component.cp_xor_linear_mask_propagation_constraints(None, None)
+            CpComponentBuildResult(declarations=['array[0..1] of var 0..1: shift_0_0_i;', 'array[0..1] of var 0..1: shift_0_0_o;'], constraints=['constraint shift_0_0_i[1]=0;', 'constraint shift_0_0_o[1]=shift_0_0_i[0];'], metadata={})
         """
         output_size = self.output_bit_size
         output_id_link = self.id
@@ -404,9 +406,8 @@ class SHIFT(Component):
                 cp_constraints.append(f"constraint {output_id_link}_o[{i}]={output_id_link}_i[{i + shift_amount}];")
             for i in range(shift_amount):
                 cp_constraints.append(f"constraint {output_id_link}_i[{i}]=0;")
-        result = cp_declarations, cp_constraints
 
-        return result
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         return [f"  {self.id} = bit_vector_SHIFT([{','.join(params)} ], {self.description[1]})"]
@@ -670,7 +671,7 @@ class SHIFT(Component):
                 f"constraint RSHIFT({mzn_input_array_1}, {int(shift_const)})={mzn_output_array_1};\n"
             ]
 
-        return var_names, shift_mzn_constraints
+        return CpComponentBuildResult(var_names, shift_mzn_constraints)
 
     def minizinc_deterministic_truncated_xor_differential_trail_constraints(self, model):
         return self.minizinc_constraints(model)

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -222,7 +222,7 @@ class SHIFT(Component):
 
         return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         """
         Return a list of CP declarations and a list of CP constraints for shift component.
 

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -643,13 +643,14 @@ class SHIFT(Component):
 
         return variables, constraints
 
-    def minizinc_constraints(self, model):
+    def minizinc_constraints(self, context, state=None):
         r"""
         Return variables and constraints for the component SHIFT for MINIZINC CIPHER model.
 
         INPUT:
 
-        - ``model`` -- **model object**;  a model instance
+        - ``context`` -- **model object** or ``CpBuildContext``; build configuration
+        - ``state`` -- optional ``CpBuildState``
 
         EXAMPLES::
 
@@ -664,11 +665,11 @@ class SHIFT(Component):
             sage: result.constraints
             ['constraint RSHIFT(array1d(0..2-1, [shift_0_0_x0,shift_0_0_x1]), 1)=array1d(0..2-1, [shift_0_0_y0,shift_0_0_y1]);\n']
         """
-        var_names = self._define_var(model.input_postfix, model.output_postfix, model.data_type)
+        var_names = self._define_var(context.input_postfix, context.output_postfix, context.data_type)
         shift_const = self.description[1]
         ninputs = noutputs = self.output_bit_size
-        input_vars = [self.id + "_" + model.input_postfix + str(i) for i in range(ninputs)]
-        output_vars = [self.id + "_" + model.output_postfix + str(i) for i in range(noutputs)]
+        input_vars = [self.id + "_" + context.input_postfix + str(i) for i in range(ninputs)]
+        output_vars = [self.id + "_" + context.output_postfix + str(i) for i in range(noutputs)]
         input_vars_1 = input_vars
         mzn_input_array_1 = self._create_minizinc_1d_array_from_list(input_vars_1)
         output_vars_1 = output_vars

--- a/claasp/components/variable_shift_component.py
+++ b/claasp/components/variable_shift_component.py
@@ -18,6 +18,7 @@
 
 import math
 
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.sat.utils import utils as sat_utils
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.component import Component
@@ -187,7 +188,7 @@ class VariableShift(Component):
                 f"constraint {output_id_link}=LShift(pre_{output_id_link},shift_amount_{output_id_link});"
             )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def get_bit_based_vectorized_python_code(self, params, convert_output_to_bytes):
         """
@@ -395,7 +396,7 @@ class VariableShift(Component):
                 f" {str_shift_amount})={mzn_input_array_output};\n"
             ]
 
-        return var_names, mzn_shift_by_variable_amount_constraints
+        return CpComponentBuildResult(var_names, mzn_shift_by_variable_amount_constraints)
 
     def sat_constraints(self):
         """

--- a/claasp/components/variable_shift_component.py
+++ b/claasp/components/variable_shift_component.py
@@ -143,11 +143,11 @@ class VariableShift(Component):
 
             sage: from claasp.components.variable_shift_component import VariableShift
             sage: variable_shift_component = VariableShift(0, 2, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4, 1)
-            sage: declarations, constraints = variable_shift_component.cp_constraints()
-            sage: declarations
+            sage: result = variable_shift_component.cp_constraints()
+            sage: result.declarations
             ['array[0..3] of var 0..1: pre_var_shift_0_2;',
             'var int: shift_amount_var_shift_0_2;']
-            sage: constraints
+            sage: result.constraints
             ['constraint pre_var_shift_0_2[0]=plaintext[0];',
             'constraint pre_var_shift_0_2[1]=plaintext[1];',
             'constraint pre_var_shift_0_2[2]=plaintext[2];',
@@ -347,8 +347,8 @@ class VariableShift(Component):
             sage: cipher = VariableShiftCipher(bit_size=4, amount_bit_size=4, direction=-1)
             sage: minizinc = MznModel(cipher)
             sage: variable_shift_component = cipher.get_component_from_id('var_shift_0_0')
-            sage: var_names, constraints = variable_shift_component.minizinc_xor_differential_propagation_constraints(minizinc)
-            sage: var_names
+            sage: result = variable_shift_component.minizinc_xor_differential_propagation_constraints(minizinc)
+            sage: result.declarations
             ['var bool: var_shift_0_0_x0;',
             'var bool: var_shift_0_0_x1;',
             'var bool: var_shift_0_0_x2;',
@@ -361,7 +361,7 @@ class VariableShift(Component):
             'var bool: var_shift_0_0_y1;',
             'var bool: var_shift_0_0_y2;',
             'var bool: var_shift_0_0_y3;']
-            sage: constraints
+            sage: result.constraints
             ['constraint LSHIFT_BY_VARIABLE_AMOUNT(array1d(0..4-1, [var_shift_0_0_x0,var_shift_0_0_x1,var_shift_0_0_x2,var_shift_0_0_x3]), 8*var_shift_0_0_x7+4*var_shift_0_0_x6+2*var_shift_0_0_x5+1*var_shift_0_0_x4)=array1d(0..4-1, [var_shift_0_0_y0,var_shift_0_0_y1,var_shift_0_0_y2,var_shift_0_0_y3]);\n']
         """
         if self.description[0].lower() != "shift_by_variable_amount":

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -18,6 +18,7 @@
 
 from claasp.input import Input
 from claasp.component import Component
+from claasp.cipher_modules.models.cp.cp_component_build_result import CpComponentBuildResult
 from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.cipher_modules.models.milp.utils import utils as milp_utils
@@ -294,9 +295,9 @@ class XOR(Component):
             operation = " + ".join(all_inputs[i::self.output_bit_size])
             cp_constraints.append(f"constraint {self.id}[{i}] = ({operation}) mod 2;")
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_continuous_differential_propagation_constraints(self, model):
+    def cp_continuous_differential_propagation_constraints(self, context, state):
 
         input_id_links = self.input_id_links
         output_id_link = self.id
@@ -314,7 +315,7 @@ class XOR(Component):
             f"constraint {output_id_link} = continuous_xor(x1_{output_id_link}, x2_{output_id_link},{output_id_link});"
         )
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
         
     def cp_deterministic_truncated_xor_differential_constraints(self):
         r"""
@@ -346,7 +347,7 @@ class XOR(Component):
             new_constraint += f"{self.id}[{i}] = ({operation2}) mod 2 else {self.id}[{i}] = 2 endif;"
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_hybrid_deterministic_truncated_xor_differential_constraints(self):
         r"""
@@ -385,12 +386,12 @@ class XOR(Component):
             )
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
     def cp_deterministic_truncated_xor_differential_trail_constraints(self):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_semi_deterministic_truncated_xor_differential_constraints(self):
+    def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
     def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
@@ -524,9 +525,9 @@ class XOR(Component):
             )
             cp_constraints.append(new_constraint)
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_differential_propagation_constraints(self, model=None):
+    def cp_xor_differential_propagation_constraints(self, context, state):
         return self.cp_constraints()
 
     def cp_xor_differential_propagation_first_step_constraints(self, model, variables_list=None):
@@ -570,27 +571,25 @@ class XOR(Component):
         if xor_table not in variables_list:
             cp_declarations = [xor_table]
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)
 
-    def cp_xor_linear_mask_propagation_constraints(self, model=None):
+    def cp_xor_linear_mask_propagation_constraints(self, context, state):
         """
         Return lists of declarations and constraints for XOR component for CP xor linear model.
 
         INPUT:
 
-        - ``model`` -- **model object** (default: `None`); a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.components.xor_component import XOR
+            sage: from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
             sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
-            sage: xor_component.cp_xor_linear_mask_propagation_constraints()
-            (['array[0..3] of var 0..1: xor_0_0_i;',
-            'array[0..1] of var 0..1: xor_0_0_o;'],
-            ['constraint xor_0_0_o[0] = xor_0_0_i[0];',
-            'constraint xor_0_0_o[0] = xor_0_0_i[2];',
-            'constraint xor_0_0_o[1] = xor_0_0_i[1];',
-            'constraint xor_0_0_o[1] = xor_0_0_i[3];'])
+            sage: result = xor_component.cp_xor_linear_mask_propagation_constraints(None, CpBuildState())
+            sage: result.declarations
+            ['array[0..3] of var 0..1: xor_0_0_i;', 'array[0..1] of var 0..1: xor_0_0_o;']
         """
         cp_declarations = [
             f"array[0..{self.input_bit_size - 1}] of var 0..1: {self.id}_i;",
@@ -606,7 +605,7 @@ class XOR(Component):
                     for j in range(num_of_addenda)
                 ]
             )
-        result = cp_declarations, cp_constraints
+        result = CpComponentBuildResult(cp_declarations, cp_constraints)
 
         return result
 
@@ -1182,7 +1181,7 @@ class XOR(Component):
             var_names += [mzn_variables_and_constraints[0]]
             mzn_constraints += [mzn_variables_and_constraints[1]]
 
-        return var_names, mzn_constraints
+        return CpComponentBuildResult(var_names, mzn_constraints)
 
     def minizinc_xor_differential_propagation_constraints(self, model):
         return self.minizinc_constraints(model)
@@ -1502,4 +1501,4 @@ class XOR(Component):
             model.list_of_xor_components.append(xor_component)
         cp_constraints = []
 
-        return cp_declarations, cp_constraints
+        return CpComponentBuildResult(cp_declarations, cp_constraints)

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -281,10 +281,11 @@ class XOR(Component):
 
             sage: from claasp.components.xor_component import XOR
             sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
-            sage: xor_component.cp_constraints()
-            ([],
-            ['constraint xor_0_0[0] = (plaintext[0] + key[0]) mod 2;',
-            'constraint xor_0_0[1] = (plaintext[1] + key[1]) mod 2;'])
+            sage: result = xor_component.cp_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint xor_0_0[0] = (plaintext[0] + key[0]) mod 2;', 'constraint xor_0_0[1] = (plaintext[1] + key[1]) mod 2;']
         """
         cp_declarations = []
         all_inputs = []
@@ -329,10 +330,11 @@ class XOR(Component):
 
             sage: from claasp.components.xor_component import XOR
             sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
-            sage: xor_component.cp_deterministic_truncated_xor_differential_constraints()
-            ([],
-            ['constraint if ((plaintext[0] < 2) /\\ (key[0]< 2)) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 else xor_0_0[0] = 2 endif;',
-            'constraint if ((plaintext[1] < 2) /\\ (key[1]< 2)) then xor_0_0[1] = (plaintext[1] + key[1]) mod 2 else xor_0_0[1] = 2 endif;'])
+            sage: result = xor_component.cp_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint if ((plaintext[0] < 2) /\\ (key[0]< 2)) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 else xor_0_0[0] = 2 endif;', 'constraint if ((plaintext[1] < 2) /\\ (key[1]< 2)) then xor_0_0[1] = (plaintext[1] + key[1]) mod 2 else xor_0_0[1] = 2 endif;']
         """
         cp_declarations = []
         all_inputs = []
@@ -362,10 +364,11 @@ class XOR(Component):
 
             sage: from claasp.components.xor_component import XOR
             sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
-            sage: xor_component.cp_hybrid_deterministic_truncated_xor_differential_constraints()
-            ([],
-             ['constraint if (plaintext[0] < 2) /\\ (key[0] < 2) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 elseif (plaintext[0] + key[0] = plaintext[0]) then xor_0_0[0] = plaintext[0] elseif (plaintext[0] + key[0] = key[0]) then xor_0_0[0] = key[0] else xor_0_0[0] = 2 endif;',
-              'constraint if (plaintext[1] < 2) /\\ (key[1] < 2) then xor_0_0[1] = (plaintext[1] + key[1]) mod 2 elseif (plaintext[1] + key[1] = plaintext[1]) then xor_0_0[1] = plaintext[1] elseif (plaintext[1] + key[1] = key[1]) then xor_0_0[1] = key[1] else xor_0_0[1] = 2 endif;'])
+            sage: result = xor_component.cp_hybrid_deterministic_truncated_xor_differential_constraints()
+            sage: result.declarations
+            []
+            sage: result.constraints
+            ['constraint if (plaintext[0] < 2) /\\ (key[0] < 2) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 elseif (plaintext[0] + key[0] = plaintext[0]) then xor_0_0[0] = plaintext[0] elseif (plaintext[0] + key[0] = key[0]) then xor_0_0[0] = key[0] else xor_0_0[0] = 2 endif;', 'constraint if (plaintext[1] < 2) /\\ (key[1] < 2) then xor_0_0[1] = (plaintext[1] + key[1]) mod 2 elseif (plaintext[1] + key[1] = plaintext[1]) then xor_0_0[1] = plaintext[1] elseif (plaintext[1] + key[1] = key[1]) then xor_0_0[1] = key[1] else xor_0_0[1] = 2 endif;']
         """
         cp_declarations = []
         all_inputs = [
@@ -410,13 +413,11 @@ class XOR(Component):
             sage: cp = MznModel(cipher)
             sage: cp.word_size = 8
             sage: xor_component = cipher.get_component_from_id("xor_0_0")
-            sage: xor_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp)
-            (['var -2..255: xor_0_0_temp_0_0_value;',
-              ...
-              'var 0..9: xor_0_0_bound_value_0_0 = if xor_0_0_temp_0_0_value + xor_0_0_temp_1_0_value > 0 then ceil(log2(xor_0_0_temp_0_0_value + xor_0_0_temp_1_0_value)) else 0 endif;'],
-             ['constraint xor_0_0_temp_0_0_value = plaintext_value[0] /\\ xor_0_0_temp_0_0_active = plaintext_active[0];',
-               ...
-              'constraint if xor_0_0_temp_0_0_active + xor_0_0_temp_1_0_active > 2 then xor_0_0_active[0] == 3 /\\ xor_0_0_value[0] = -2 elseif xor_0_0_temp_0_0_active + xor_0_0_temp_1_0_active == 1 then xor_0_0_active[0] = 1 /\\ xor_0_0_value[0] = xor_0_0_temp_0_0_value + xor_0_0_temp_1_0_value elseif xor_0_0_temp_0_0_active + xor_0_0_temp_1_0_active == 0 then xor_0_0_active[0] = 0 /\\ xor_0_0_value[0] = 0 elseif xor_0_0_temp_0_0_value + xor_0_0_temp_1_0_value < 0 then xor_0_0_active[0] = 2 /\\ xor_0_0_value[0] = -1 elseif xor_0_0_temp_0_0_value == xor_0_0_temp_1_0_value then xor_0_0_active[0] = 0 /\\ xor_0_0_value[0] = 0 else xor_0_0_active[0] = 1 /\\ xor_0_0_value[0] = sum([(((floor(xor_0_0_temp_0_0_value/pow(2,j)) + floor(xor_0_0_temp_1_0_value/pow(2,j))) mod 2) * pow(2,j)) | j in 0..xor_0_0_bound_value_0_0]) endif;'])
+                        sage: result = xor_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp)
+                        sage: result.declarations[0]
+                        'var -2..255: xor_0_0_temp_0_0_value;'
+                        sage: result.constraints[0]
+                        'constraint xor_0_0_temp_0_0_value = plaintext_value[0] /\\ xor_0_0_temp_0_0_active = plaintext_active[0];'
         """
         output_id_link = self.id
         cp_declarations = []
@@ -547,9 +548,11 @@ class XOR(Component):
             sage: cp = MznModel(cipher)
             sage: cp.word_size = 8
             sage: xor_component = cipher.get_component_from_id("xor_0_0")
-            sage: xor_component.cp_xor_differential_propagation_first_step_constraints(cp, cp._variables_list)
-            (['array[0..1, 1..2] of int: xor_truncated_table_2 = array2d(0..1, 1..2, [0,0,1,1]);'],
-             'constraint table([plaintext[0]]++[key[0]], xor_truncated_table_2);')
+            sage: result = xor_component.cp_xor_differential_propagation_first_step_constraints(cp, cp._variables_list)
+            sage: result.declarations
+            ['array[0..1, 1..2] of int: xor_truncated_table_2 = array2d(0..1, 1..2, [0,0,1,1]);']
+            sage: result.constraints
+            'constraint table([plaintext[0]]++[key[0]], xor_truncated_table_2);'
         """
         numadd = self.description[1]
         all_inputs = []
@@ -1122,8 +1125,8 @@ class XOR(Component):
             sage: cipher = XorCipher(word_bit_size=2, number_of_inputs=2)
             sage: minizinc = MznModel(cipher)
             sage: xor_component = cipher.get_component_from_id('xor_0_0')
-            sage: _, xor_minizinc_constraints = xor_component.minizinc_constraints(minizinc)
-            sage: xor_minizinc_constraints[0]
+            sage: xor_minizinc_constraints = xor_component.minizinc_constraints(minizinc)
+            sage: xor_minizinc_constraints.constraints[0]
             'constraint xor_word(\narray1d(0..2-1, [xor_0_0_x2,xor_0_0_x3]),\narray1d(0..2-1, [xor_0_0_x0,xor_0_0_x1]),\narray1d(0..2-1, [xor_0_0_y0,xor_0_0_y1]))=true;\n'
         """
 
@@ -1457,8 +1460,11 @@ class XOR(Component):
             sage: cp = MznModel(cipher)
             sage: cp.word_size = 8
             sage: xor_component = cipher.get_component_from_id("xor_0_0")
-            sage: xor_component.cp_transform_xor_components_for_first_step(cp)
-            (['array[0..0] of var 0..1: xor_0_0;'], [])
+            sage: result = xor_component.cp_transform_xor_components_for_first_step(cp)
+            sage: result.declarations
+            ['array[0..0] of var 0..1: xor_0_0;']
+            sage: result.constraints
+            []
         """
         output_size = int(self.output_bit_size)
         input_id_link = self.input_id_links

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -1110,13 +1110,14 @@ class XOR(Component):
 
             return variables, constraints
 
-    def minizinc_constraints(self, model):
+    def minizinc_constraints(self, context, state=None):
         r"""
         Return variables and constraints for the XOR component for MINIZINC CIPHER model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- **model object** or ``CpBuildContext``; build configuration
+        - ``state`` -- optional ``CpBuildState``
 
         EXAMPLES::
 
@@ -1134,38 +1135,38 @@ class XOR(Component):
             mzn_input_array_1 = self._create_minizinc_1d_array_from_list(input_vars_1_temp)
             mzn_input_array_2 = self._create_minizinc_1d_array_from_list(input_vars_2_temp)
             mzn_output_array = self._create_minizinc_1d_array_from_list(output_varstrs_temp)
-            if model.sat_or_milp == "sat":
+            if context.sat_or_milp == "sat":
                 mzn_block_variables = ""
                 mzn_block_constraints = (
                     f"constraint xor_word(\n{mzn_input_array_1},"
-                    f"\n{mzn_input_array_2},\n{mzn_output_array})={model.true_value};\n"
+                    f"\n{mzn_input_array_2},\n{mzn_output_array})={context.true_value};\n"
                 )
             else:
                 mzn_block_variables = f"array [0..{noutputs}-1] of var 0..1: dummy_{component_id}_{i};\n"
                 mzn_block_constraints = (
                     f"constraint xor_word(\n{mzn_input_array_1},\n{mzn_input_array_2},"
-                    f"\n{mzn_output_array},\ndummy_{component_id}_{i})={model.true_value};\n"
+                    f"\n{mzn_output_array},\ndummy_{component_id}_{i})={context.true_value};\n"
                 )
             return mzn_block_variables, mzn_block_constraints
 
         if self.description[0].lower() != "xor":
             raise ValueError("component must be Boolean XOR word_operation")
 
-        var_names = self._define_var(model.input_postfix, model.output_postfix, model.data_type)
+        var_names = self._define_var(context.input_postfix, context.output_postfix, context.data_type)
 
         mzn_constraints = []
         component_id = self.id
         ninputs = self.input_bit_size
         noutputs = self.output_bit_size
-        input_vars = [component_id + "_" + model.input_postfix + str(i) for i in range(ninputs)]
-        output_vars = [component_id + "_" + model.output_postfix + str(i) for i in range(noutputs)]
+        input_vars = [component_id + "_" + context.input_postfix + str(i) for i in range(ninputs)]
+        output_vars = [component_id + "_" + context.output_postfix + str(i) for i in range(noutputs)]
         ninput_words = int(self.description[1])
         word_chunk = noutputs
         new_output_vars = [input_vars[0 * word_chunk : 0 * word_chunk + word_chunk]]
         for i in range(ninput_words - 2):
             new_output_vars_temp = []
             for output_var in output_vars:
-                mzn_constraints += [f"var {model.data_type}: {output_var}_{str(i)};\n"]
+                mzn_constraints += [f"var {context.data_type}: {output_var}_{str(i)};\n"]
                 new_output_vars_temp.append(output_var + "_" + str(i))
             new_output_vars.append(new_output_vars_temp)
 

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -397,7 +397,7 @@ class XOR(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state=None):
         r"""
         Return lists declarations and constraints for XOR component CP wordwise deterministic truncated XOR differential model.
 

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -397,34 +397,34 @@ class XOR(Component):
     def cp_semi_deterministic_truncated_xor_differential_constraints(self, context, state):
         return self.cp_deterministic_truncated_xor_differential_constraints()
 
-    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, model):
+    def cp_wordwise_deterministic_truncated_xor_differential_constraints(self, context, state):
         r"""
         Return lists declarations and constraints for XOR component CP wordwise deterministic truncated XOR differential model.
 
         INPUT:
 
-        - ``model`` -- **model object**; a model instance
+        - ``context`` -- a ``CpBuildContext`` (read-only build configuration)
+        - ``state`` -- ``CpBuildState`` (mutable accumulator for build state)
 
         EXAMPLES::
 
             sage: from claasp.ciphers.single_component_ciphers.xor_cipher import XorCipher
-            sage: from claasp.cipher_modules.models.cp.mzn_model import MznModel
+            sage: from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
             sage: cipher = XorCipher(word_bit_size=8, number_of_inputs=2)
-            sage: cp = MznModel(cipher)
-            sage: cp.word_size = 8
+            sage: cp = CpBuildContext(cipher=cipher, word_size=8)
             sage: xor_component = cipher.get_component_from_id("xor_0_0")
-                        sage: result = xor_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp)
-                        sage: result.declarations[0]
-                        'var -2..255: xor_0_0_temp_0_0_value;'
-                        sage: result.constraints[0]
-                        'constraint xor_0_0_temp_0_0_value = plaintext_value[0] /\\ xor_0_0_temp_0_0_active = plaintext_active[0];'
+            sage: result = xor_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp, None)
+            sage: result.declarations[0]
+            'var -2..255: xor_0_0_temp_0_0_value;'
+            sage: result.constraints[0]
+            'constraint xor_0_0_temp_0_0_value = plaintext_value[0] /\\ xor_0_0_temp_0_0_active = plaintext_active[0];'
         """
         output_id_link = self.id
         cp_declarations = []
         all_inputs_value = []
         all_inputs_active = []
         numadd = self.description[1]
-        word_size = model.word_size
+        word_size = context.word_size
         for id_link, bit_positions in zip(self.input_id_links, self.input_bit_positions):
             all_inputs_value.extend(
                 [

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -156,7 +156,6 @@ def test_build_generic_cp_model_from_dictionary_xor_differential():
     """
     speck = SpeckBlockCipher(number_of_rounds=3)
     model = MznXorDifferentialModelARXOptimized(speck)
-    component_and_model_types = []
     fixed_variables = []
 
     fixed_variables.append(
@@ -177,17 +176,7 @@ def test_build_generic_cp_model_from_dictionary_xor_differential():
         )
     )
 
-    for component in speck.get_all_components():
-        component_and_model_types.append({
-            "component_object": component,
-            "model_type": "minizinc_xor_differential_propagation_constraints"
-        })
-    model.build_generic_cp_model_from_dictionary(component_and_model_types, fixed_variables)
-
-    weight=6
-    constraints = model.weight_constraints(weight)
-    model._model_constraints.extend(constraints)
-    model.init_constraints()
+    model.build_xor_differential_trail_model(weight=6, fixed_variables=fixed_variables)
     model._model_constraints.extend(model.objective_generator())
     model._model_constraints.extend(model.weight_constraints())
 

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model_test.py
@@ -1,6 +1,8 @@
 from claasp.cipher_modules.models.cp.mzn_models.mzn_differential_linear_continuous_model import MznDifferentialLinearContinuousModel
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.minizinc_utils.mzn_continuous_predicates import get_continuous_operations
 from minizinc import Model, Solver, Instance
 import re
@@ -10,7 +12,10 @@ def test_cp_modadd_test_vectors():
     model = MznModel(cipher)
 
     modadd_component = cipher.get_component_from_id("modadd_0_1")
-    declarations, constraints = modadd_component.cp_continuous_differential_propagation_constraints(model)
+    context = CpBuildContext.from_model(model)
+    state = CpBuildState.from_model(model)
+    result = modadd_component.cp_continuous_differential_propagation_constraints(context, state)
+    declarations, constraints = result.declarations, result.constraints
 
     mzn_model = Model()
     mzn_model.add_string(get_continuous_operations())
@@ -58,7 +63,10 @@ def test_cp_xor_test_vectors():
         print(c.id, c.description)
 
     xor_component = cipher.get_component_from_id("xor_0_4")
-    declarations, constraints = xor_component.cp_continuous_differential_propagation_constraints(model)
+    context = CpBuildContext.from_model(model)
+    state = CpBuildState.from_model(model)
+    result = xor_component.cp_continuous_differential_propagation_constraints(context, state)
+    declarations, constraints = result.declarations, result.constraints
 
     mzn_model = Model()
     mzn_model.add_string(get_continuous_operations())
@@ -143,9 +151,8 @@ def test_cp_rotate_test_vectors():
     for case in test_cases:
         rot_component = cipher.get_component_from_id(case["component_id"])
 
-        declarations, constraints = (
-            rot_component.cp_continuous_differential_propagation_constraints(model)
-        )
+        result = rot_component.cp_continuous_differential_propagation_constraints(None, None)
+        declarations, constraints = result.declarations, result.constraints
 
         mzn_model = Model()
         mzn_model.add_string(get_continuous_operations())

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model_test.py
@@ -123,7 +123,8 @@ def test_modular_component_semideterministic_probability_sample():
         modulus=2**32,
     )
 
-    cp_declarations, cp_constraints, metadata = comp.cp_semi_deterministic_truncated_xor_differential_constraints()
+    result = comp.cp_semi_deterministic_truncated_xor_differential_constraints(None, None)
+    cp_declarations, cp_constraints, metadata = result.declarations, result.constraints, result.metadata
 
     model = Model()
     model.add_string(MINIZINC_USEFUL_FUNCTIONS)
@@ -189,7 +190,8 @@ def test_modular_component_semideterministic_multiple_addends_constraints():
         modulus=2**4,
     )
 
-    cp_declarations, cp_constraints, metadata = comp.cp_semi_deterministic_truncated_xor_differential_constraints()
+    result = comp.cp_semi_deterministic_truncated_xor_differential_constraints(None, None)
+    cp_declarations, cp_constraints, metadata = result.declarations, result.constraints, result.metadata
 
     assert metadata["probability_var"] == "probability_modadd_0_0"
     assert any("pre_modadd_0_0_3" in declaration for declaration in cp_declarations)

--- a/tests/unit/components/and_component_test.py
+++ b/tests/unit/components/and_component_test.py
@@ -1,4 +1,6 @@
 from claasp.components.and_component import AND
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.ciphers.single_component_ciphers.and_cipher import AndCipher
 from claasp.components.and_component import cp_xor_differential_probability_ddt, cp_xor_linear_probability_lat
@@ -15,7 +17,8 @@ def test_cp_xor_linear_probability_lat():
 
 def test_cp_constraints():
     and_component = AND(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
-    declarations, constraints = and_component.cp_constraints()
+    result = and_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -30,7 +33,8 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
     and_component = AND(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                         [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                          [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]], 32)
-    declarations, constraints = and_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    result = and_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -44,7 +48,10 @@ def test_cp_xor_linear_mask_propagation_constraints():
     cipher = AndCipher(word_bit_size=12, number_of_inputs=2)
     cp = MznModel(cipher)
     and_component = cipher.component_from(0, 0)
-    declarations, constraints = and_component.cp_xor_linear_mask_propagation_constraints(cp)
+    context = CpBuildContext.from_model(cp)
+    state = CpBuildState.from_model(cp)
+    result = and_component.cp_xor_linear_mask_propagation_constraints(context, state)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..23] of var 0..1:and_0_0_i;', 'array[0..11] of var 0..1:and_0_0_o;']
 

--- a/tests/unit/components/cipher_output_component_test.py
+++ b/tests/unit/components/cipher_output_component_test.py
@@ -9,7 +9,8 @@ def test_cp_constraints():
         [list(range(16)), list(range(16))],
         32,
     )
-    declarations, constraints = output_component.cp_constraints()
+    result = output_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -32,7 +33,8 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
         output_tag="intermediate_output",
     )
     cp = DummyModel()
-    declarations, constraints = output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp)
+    result = output_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(cp)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 

--- a/tests/unit/components/constant_component_test.py
+++ b/tests/unit/components/constant_component_test.py
@@ -6,7 +6,8 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
         word_size = 8
 
     constant_component = Constant(0, 18, 16, 0xAB01)
-    declarations, constraints = constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    result = constant_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..1] of var 0..1: constant_0_18_active = array1d(0..1, [0,0]);',
                             'array[0..1] of var 0..1: constant_0_18_value = array1d(0..1, [0,0]);']
@@ -16,7 +17,8 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     constant_component = Constant(2, 0, 16, 0x0000)
-    declarations, constraints = constant_component.cp_xor_linear_mask_propagation_constraints()
+    result = constant_component.cp_xor_linear_mask_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..15] of var 0..1: constant_2_0_o;']
 

--- a/tests/unit/components/intermediate_output_component_test.py
+++ b/tests/unit/components/intermediate_output_component_test.py
@@ -1,6 +1,8 @@
 from sage.numerical.mip import MixedIntegerLinearProgram
 
 from claasp.components.intermediate_output_component import IntermediateOutput
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 
 
 class DummyCpModel:
@@ -55,7 +57,8 @@ def make_component():
 
 def test_cp_constraints():
     component = make_component()
-    declarations, constraints = component.cp_constraints()
+    result = component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints == [
@@ -68,7 +71,14 @@ def test_cp_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     component = make_component()
-    declarations, constraints = component.cp_xor_linear_mask_propagation_constraints(DummyCpModel())
+    dummy = DummyCpModel()
+    context = CpBuildContext(
+        cipher=None, word_size=0, data_type='', true_value='', false_value='',
+        float_and_lat_values=(), bit_bindings_for_intermediate_output=dummy.bit_bindings_for_intermediate_output
+    )
+    state = CpBuildState()
+    result = component.cp_xor_linear_mask_propagation_constraints(context, state)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == [
         "array[0..3] of var 0..1: intermediate_output_0_0_i;",

--- a/tests/unit/components/linear_layer_component_test.py
+++ b/tests/unit/components/linear_layer_component_test.py
@@ -60,7 +60,8 @@ def test_cms_xor_linear_mask_propagation_constraints():
 
 def test_cp_constraints():
     linear_layer_component = make_linear_layer_component()
-    declarations, constraints = linear_layer_component.cp_constraints()
+    result = linear_layer_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints == [
@@ -73,7 +74,8 @@ def test_cp_constraints():
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
     linear_layer_component = make_linear_layer_component()
-    declarations, constraints = linear_layer_component.cp_deterministic_truncated_xor_differential_constraints()
+    result = linear_layer_component.cp_deterministic_truncated_xor_differential_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints == [
@@ -86,7 +88,8 @@ def test_cp_deterministic_truncated_xor_differential_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     linear_layer_component = make_linear_layer_component()
-    declarations, constraints = linear_layer_component.cp_xor_linear_mask_propagation_constraints()
+    result = linear_layer_component.cp_xor_linear_mask_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == [
         "array[0..3] of var 0..1:linear_layer_0_0_i;",

--- a/tests/unit/components/mix_column_component_test.py
+++ b/tests/unit/components/mix_column_component_test.py
@@ -43,12 +43,13 @@ def test_cp_create_component():
     cp.word_size = WORD_SIZE
     mix_column_component_1 = make_mix_column_component(component_index=0)
     mix_column_component_2 = make_mix_column_component(component_index=1, input_name="input")
-    declarations, constraints = mix_column_component_1._cp_create_component(
+    result = mix_column_component_1._cp_create_component(
         cp.word_size,
         mix_column_component_2,
         1,
         cp.list_of_xor_components,
     )
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == [
         "array[0..1] of var 0..1: input_xor_mix_column_0_1_mix_column_0_0;",
@@ -74,7 +75,8 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     mix_column_component = make_mix_column_component()
-    declarations, constraints = mix_column_component.cp_constraints()
+    result = mix_column_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint mix_column_0_0[0] = (plaintext[0] + plaintext[5]) mod 2;"
@@ -83,7 +85,8 @@ def test_cp_constraints():
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
     mix_column_component = make_mix_column_component()
-    declarations, constraints = mix_column_component.cp_deterministic_truncated_xor_differential_constraints()
+    result = mix_column_component.cp_deterministic_truncated_xor_differential_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == (
@@ -98,7 +101,8 @@ def test_cp_deterministic_truncated_xor_differential_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     mix_column_component = make_mix_column_component()
-    declarations, constraints = mix_column_component.cp_xor_linear_mask_propagation_constraints()
+    result = mix_column_component.cp_xor_linear_mask_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == [
         "array[0..7] of var 0..1:mix_column_0_0_i;",

--- a/tests/unit/components/modsub_component_test.py
+++ b/tests/unit/components/modsub_component_test.py
@@ -57,7 +57,7 @@ def test_cp_xor_differential_propagation_constraints():
     class DummyModel:
         component_probability_index = 0
         component_and_probability = {}
-        modadd_twoterms_mant = []
+        modadd_two_term_shift_cache = []
 
     modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     cp_model = DummyModel()

--- a/tests/unit/components/modsub_component_test.py
+++ b/tests/unit/components/modsub_component_test.py
@@ -1,4 +1,5 @@
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher import Cipher
 from claasp.components.modsub_component import MODSUB
 from claasp.name_mappings import PERMUTATION
@@ -38,7 +39,8 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
-    output_bit_ids, constraints = modsub_component.cp_constraints()
+    result = modsub_component.cp_constraints()
+    output_bit_ids, constraints = result.declarations, result.constraints
 
     assert output_bit_ids[0] == 'array[0..31] of var 0..1: constant_modsub_0_7= array1d(0..31,[0, 0, 0, 0, 0, 0, 0, ' \
                                 '0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);'
@@ -54,24 +56,19 @@ def test_cp_constraints():
 
 
 def test_cp_xor_differential_propagation_constraints():
-    class DummyModel:
-        component_probability_index = 0
-        component_and_probability = {}
-        modadd_two_term_shift_cache = []
-
     modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
-    cp_model = DummyModel()
-    output_bit_ids, constraints = modsub_component.cp_xor_differential_propagation_constraints(cp_model)
+    state = CpBuildState()
+    result = modsub_component.cp_xor_differential_propagation_constraints(None, state)
 
-    assert output_bit_ids[0] == 'array[0..31] of var 0..1: pre_modsub_0_7_0;'
-    assert output_bit_ids[-1] == 'array[0..31] of var 0..1: eq_modsub_0_7 = Eq(Shi_pre_modsub_0_7_1, Shi_pre_modsub_0_7_0, Shi_modsub_0_7);'
+    assert result.declarations[0] == 'array[0..31] of var 0..1: pre_modsub_0_7_0;'
+    assert result.declarations[-1] == 'array[0..31] of var 0..1: eq_modsub_0_7 = Eq(Shi_pre_modsub_0_7_1, Shi_pre_modsub_0_7_0, Shi_modsub_0_7);'
 
-    assert constraints[0] == 'constraint pre_modsub_0_7_0[0] = modadd_0_4[0];'
-    assert constraints[1] == 'constraint pre_modsub_0_7_0[1] = modadd_0_4[1];'
-    assert constraints[2] == 'constraint pre_modsub_0_7_0[2] = modadd_0_4[2];'
-    assert constraints[-3] == 'constraint pre_modsub_0_7_1[30] = plaintext[62];'
-    assert constraints[-2] == 'constraint pre_modsub_0_7_1[31] = plaintext[63];'
-    assert constraints[-1] == 'constraint forall(j in 0..31)(if eq_modsub_0_7[j] = 1 then (sum([pre_modsub_0_7_1[j], ' \
+    assert result.constraints[0] == 'constraint pre_modsub_0_7_0[0] = modadd_0_4[0];'
+    assert result.constraints[1] == 'constraint pre_modsub_0_7_0[1] = modadd_0_4[1];'
+    assert result.constraints[2] == 'constraint pre_modsub_0_7_0[2] = modadd_0_4[2];'
+    assert result.constraints[-3] == 'constraint pre_modsub_0_7_1[30] = plaintext[62];'
+    assert result.constraints[-2] == 'constraint pre_modsub_0_7_1[31] = plaintext[63];'
+    assert result.constraints[-1] == 'constraint forall(j in 0..31)(if eq_modsub_0_7[j] = 1 then (sum([pre_modsub_0_7_1[j], ' \
                               'pre_modsub_0_7_0[j], modsub_0_7[j]]) mod 2) = Shi_pre_modsub_0_7_0[j] else true endif) /\\ p[0] = 32-sum(eq_modsub_0_7);'
 
 

--- a/tests/unit/components/modsub_component_test.py
+++ b/tests/unit/components/modsub_component_test.py
@@ -55,7 +55,7 @@ def test_cp_constraints():
 
 def test_cp_xor_differential_propagation_constraints():
     class DummyModel:
-        c = 0
+        component_probability_index = 0
         component_and_probability = {}
         modadd_twoterms_mant = []
 

--- a/tests/unit/components/modular_component_test.py
+++ b/tests/unit/components/modular_component_test.py
@@ -37,7 +37,8 @@ def test_cp_deterministic_trail_alias_matches_base_constraints():
 
 def test_cp_deterministic_truncated_constraints_build_chain_for_three_inputs():
     component = make_modular_component(number_of_inputs=3)
-    declarations, constraints = component.cp_deterministic_truncated_xor_differential_constraints()
+    result = component.cp_deterministic_truncated_xor_differential_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert "array[0..3] of var 0..2: pre_modadd_0_0_0;" in declarations
     assert "array[0..3] of var 0..2: pre_modadd_0_0_1;" in declarations

--- a/tests/unit/components/multi_input_non_linear_logical_operator_component_test.py
+++ b/tests/unit/components/multi_input_non_linear_logical_operator_component_test.py
@@ -52,7 +52,7 @@ def test_cp_deterministic_trail_alias_matches_base_constraints():
 
 def test_cp_xor_differential_updates_model_counter_and_probability_map():
     class DummyModel:
-        c = 0
+        component_probability_index = 0
         component_and_probability = {}
 
     component = make_component(number_of_inputs=3)
@@ -62,7 +62,7 @@ def test_cp_xor_differential_updates_model_counter_and_probability_map():
     assert declarations == []
     assert constraints[0] == "constraint table([in0[0]]++[in1[4]]++[in2[8]]++[and_0_0[0]]++[p[0]],and3inputs_DDT);"
     assert constraints[-1] == "constraint table([in0[3]]++[in1[7]]++[in2[11]]++[and_0_0[3]]++[p[3]],and3inputs_DDT);"
-    assert model.c == 4
+    assert model.component_probability_index == 4
     assert model.component_and_probability["and_0_0"] == [1, 2, 3, 4]
 
 

--- a/tests/unit/components/multi_input_non_linear_logical_operator_component_test.py
+++ b/tests/unit/components/multi_input_non_linear_logical_operator_component_test.py
@@ -1,4 +1,5 @@
 from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 
 
 def make_component(number_of_inputs=2, operation="and"):
@@ -34,7 +35,8 @@ def test_cms_delegates_to_sat_methods():
 
 def test_cp_deterministic_truncated_constraints_base_logic():
     component = make_component()
-    declarations, constraints = component.cp_deterministic_truncated_xor_differential_constraints()
+    result = component.cp_deterministic_truncated_xor_differential_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint if in0[0] == 0 /\\ in1[4] == 0 then and_0_0[0] = 0 else and_0_0[0] = 2 endif;"
@@ -51,19 +53,15 @@ def test_cp_deterministic_trail_alias_matches_base_constraints():
 
 
 def test_cp_xor_differential_updates_model_counter_and_probability_map():
-    class DummyModel:
-        component_probability_index = 0
-        component_and_probability = {}
-
     component = make_component(number_of_inputs=3)
-    model = DummyModel()
-    declarations, constraints = component.cp_xor_differential_propagation_constraints(model)
+    state = CpBuildState()
+    result = component.cp_xor_differential_propagation_constraints(None, state)
 
-    assert declarations == []
-    assert constraints[0] == "constraint table([in0[0]]++[in1[4]]++[in2[8]]++[and_0_0[0]]++[p[0]],and3inputs_DDT);"
-    assert constraints[-1] == "constraint table([in0[3]]++[in1[7]]++[in2[11]]++[and_0_0[3]]++[p[3]],and3inputs_DDT);"
-    assert model.component_probability_index == 4
-    assert model.component_and_probability["and_0_0"] == [1, 2, 3, 4]
+    assert result.declarations == []
+    assert result.constraints[0] == "constraint table([in0[0]]++[in1[4]]++[in2[8]]++[and_0_0[0]]++[p[0]],and3inputs_DDT);"
+    assert result.constraints[-1] == "constraint table([in0[3]]++[in1[7]]++[in2[11]]++[and_0_0[3]]++[p[3]],and3inputs_DDT);"
+    assert state.next_probability_index == 4
+    assert state.component_probability_map["and_0_0"] == [1, 2, 3, 4]
 
 
 def test_cp_wordwise_deterministic_constraints_use_model_word_size():
@@ -71,7 +69,8 @@ def test_cp_wordwise_deterministic_constraints_use_model_word_size():
         word_size = 2
 
     component = make_component(number_of_inputs=2)
-    declarations, constraints = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    result = component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint if in0_active[0] == 0 /\\ in1_active[2] == 0 then and_0_0_active[0] = 0 /\\ and_0_0_value[0] = 0 else and_0_0_active[0] = 3 /\\ and_0_0_value[0] = -2 endif;"

--- a/tests/unit/components/not_component_test.py
+++ b/tests/unit/components/not_component_test.py
@@ -33,7 +33,8 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
-    declarations, constraints = not_component.cp_constraints()
+    result = not_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -43,7 +44,8 @@ def test_cp_constraints():
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
     not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
-    declarations, constraints = not_component.cp_deterministic_truncated_xor_differential_constraints()
+    result = not_component.cp_deterministic_truncated_xor_differential_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -58,7 +60,8 @@ def test_cp_xor_differential_first_step_constraints():
     not_component = NOT(0, 18, ['plaintext', 'key', 'input3', 'input4'],
                         [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                          [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]], 32)
-    declarations, constraints = not_component.cp_xor_differential_first_step_constraints(DummyModel())
+    result = not_component.cp_xor_differential_first_step_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..3] of var 0..1: not_0_18;']
 
@@ -70,7 +73,8 @@ def test_cp_xor_differential_first_step_constraints():
 
 def test_cp_xor_differential_propagation_constraints():
     not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
-    declarations, constraints = not_component.cp_xor_differential_propagation_constraints()
+    result = not_component.cp_xor_differential_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -80,7 +84,8 @@ def test_cp_xor_differential_propagation_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     not_component = NOT(0, 5, ['ascon_0_5_i'], [list(range(64))], 64)
-    declarations, constraints = not_component.cp_xor_linear_mask_propagation_constraints()
+    result = not_component.cp_xor_linear_mask_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..63] of var 0..1:not_0_5_i;', 'array[0..63] of var 0..1:not_0_5_o;']
 

--- a/tests/unit/components/or_component_test.py
+++ b/tests/unit/components/or_component_test.py
@@ -1,5 +1,7 @@
 from claasp.components.or_component import OR
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
+from claasp.cipher_modules.models.cp.cp_build_context import CpBuildContext
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.ciphers.single_component_ciphers.or_cipher import OrCipher
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
 
@@ -18,7 +20,8 @@ def test_algebraic_polynomials():
 
 def test_cp_constraints():
     or_component = OR(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
-    declarations, constraints = or_component.cp_constraints()
+    result = or_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..3] of var 0..1: or_0_0;', 'array[0..3] of var 0..1:pre_or_0_0_0;',
                             'array[0..3] of var 0..1:pre_or_0_0_1;']
@@ -32,7 +35,10 @@ def test_cp_xor_linear_mask_propagation_constraints():
     cipher = OrCipher(word_bit_size=4, number_of_inputs=2)
     or_component = cipher.get_component_from_id("or_0_0")
     cp = MznModel(cipher)
-    declarations, constraints = or_component.cp_xor_linear_mask_propagation_constraints(cp)
+    context = CpBuildContext.from_model(cp)
+    state = CpBuildState.from_model(cp)
+    result = or_component.cp_xor_linear_mask_propagation_constraints(context, state)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..3] of var 0..400: p_or_0_0;', 'array[0..7] of var 0..1:or_0_0_i;',
                             'array[0..3] of var 0..1:or_0_0_o;']

--- a/tests/unit/components/permutation_component_test.py
+++ b/tests/unit/components/permutation_component_test.py
@@ -23,7 +23,8 @@ def test_constructor_builds_permutation_matrix():
 
 def test_cp_constraints():
     permutation_component = make_permutation_component()
-    declarations, constraints = permutation_component.cp_constraints()
+    result = permutation_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints == [

--- a/tests/unit/components/reverse_component_test.py
+++ b/tests/unit/components/reverse_component_test.py
@@ -20,7 +20,8 @@ def test_constructor_builds_reverse_matrix():
 
 def test_cp_constraints():
     reverse_component = make_reverse_component()
-    declarations, constraints = reverse_component.cp_constraints()
+    result = reverse_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints == [

--- a/tests/unit/components/rotate_component_test.py
+++ b/tests/unit/components/rotate_component_test.py
@@ -16,7 +16,8 @@ def test_algebraic_polynomials():
 
 def test_cp_inverse_constraints():
     rotate_component = Rotate(0, 0, ['plaintext'], [list(range(16))], 16, 7)
-    declarations, constraints = rotate_component.cp_inverse_constraints()
+    result = rotate_component.cp_inverse_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
 
@@ -34,7 +35,8 @@ def test_cp_xor_differential_first_step_constraints():
     class DummyModel:
         word_size = 8
 
-    declarations, constraints = rotate_component.cp_xor_differential_first_step_constraints(DummyModel())
+    result = rotate_component.cp_xor_differential_first_step_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..3] of var 0..1: rot_0_18;']
 

--- a/tests/unit/components/sbox_component_test.py
+++ b/tests/unit/components/sbox_component_test.py
@@ -50,8 +50,8 @@ def test_cp_constraints():
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
     sbox_component = SBOX(0, 1, ["xor_0_0"], [[0, 1, 2, 3]], 4, [1, 2, 3, 4, 0, 7, 6, 5])
-    declarations, constraints, sbox_mant = sbox_component.cp_deterministic_truncated_xor_differential_constraints(
-        sbox_mant=[]
+    declarations, constraints, sbox_table_cache = sbox_component.cp_deterministic_truncated_xor_differential_constraints(
+        sbox_table_cache=[]
     )
 
     assert declarations[0].startswith("array [1..27, 1..6] of int: table_sbox_0_1")
@@ -59,13 +59,13 @@ def test_cp_deterministic_truncated_xor_differential_constraints():
         "constraint table([xor_0_0[0]]++[xor_0_0[1]]++[xor_0_0[2]]++[xor_0_0[3]]++[sbox_0_1[0]]++"
         "[sbox_0_1[1]]++[sbox_0_1[2]]++[sbox_0_1[3]], table_sbox_0_1);"
     ]
-    assert sbox_mant[0][1] == "sbox_0_1"
+    assert sbox_table_cache[0][1] == "sbox_0_1"
 
 
 def test_cp_xor_differential_propagation_constraints():
     sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
     cp = type("DummyModel", (), {})()
-    cp.sbox_mant = []
+    cp.sbox_table_cache = []
     cp.component_and_probability = {}
     cp.component_probability_index = 0
 
@@ -81,7 +81,7 @@ def test_cp_xor_differential_propagation_constraints():
 def test_cp_xor_linear_mask_propagation_constraints():
     sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
     cp = type("DummyModel", (), {})()
-    cp.sbox_mant = []
+    cp.sbox_table_cache = []
     cp.component_and_probability = {}
     cp.component_probability_index = 0
 

--- a/tests/unit/components/sbox_component_test.py
+++ b/tests/unit/components/sbox_component_test.py
@@ -8,6 +8,7 @@ from claasp.cipher_modules.models.milp.milp_models.milp_wordwise_deterministic_t
 )
 from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
 from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
+from claasp.cipher_modules.models.cp.cp_build_state import CpBuildState
 from claasp.cipher_modules.models.sat.sat_model import SatModel
 from claasp.cipher_modules.models.smt.smt_model import SmtModel
 from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
@@ -39,7 +40,8 @@ def test_cms_constraints():
 def test_cp_constraints():
     sbox = [12, 10, 13, 3, 14, 11, 15, 7, 8, 9, 1, 5, 0, 2, 4, 6]
     sbox_component = SBOX(0, 5, ["xor_0_1"], [[4, 5, 6, 7]], 4, sbox)
-    declarations, constraints = sbox_component.cp_constraints([])
+    result = sbox_component.cp_constraints([])
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations[0].startswith("array [1..16, 1..8] of int: table_sbox_0_5")
     assert constraints == [
@@ -50,9 +52,10 @@ def test_cp_constraints():
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
     sbox_component = SBOX(0, 1, ["xor_0_0"], [[0, 1, 2, 3]], 4, [1, 2, 3, 4, 0, 7, 6, 5])
-    declarations, constraints, sbox_table_cache = sbox_component.cp_deterministic_truncated_xor_differential_constraints(
+    result = sbox_component.cp_deterministic_truncated_xor_differential_constraints(
         sbox_table_cache=[]
     )
+    declarations, constraints, sbox_table_cache = result.declarations, result.constraints, result.metadata
 
     assert declarations[0].startswith("array [1..27, 1..6] of int: table_sbox_0_1")
     assert constraints == [
@@ -64,15 +67,12 @@ def test_cp_deterministic_truncated_xor_differential_constraints():
 
 def test_cp_xor_differential_propagation_constraints():
     sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
-    cp = type("DummyModel", (), {})()
-    cp.sbox_table_cache = []
-    cp.component_and_probability = {}
-    cp.component_probability_index = 0
+    state = CpBuildState()
 
-    declarations, constraints = sbox_component.cp_xor_differential_propagation_constraints(cp)
+    result = sbox_component.cp_xor_differential_propagation_constraints(None, state)
 
-    assert declarations[0].startswith("array [1..8, 1..7] of int: DDT_sbox_0_0")
-    assert constraints == [
+    assert result.declarations[0].startswith("array [1..8, 1..7] of int: DDT_sbox_0_0")
+    assert result.constraints == [
         "constraint table([plaintext[0]]++[plaintext[1]]++[plaintext[2]]++[sbox_0_0[0]]++[sbox_0_0[1]]++"
         "[sbox_0_0[2]]++[p[0]], DDT_sbox_0_0);"
     ]
@@ -80,16 +80,13 @@ def test_cp_xor_differential_propagation_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
-    cp = type("DummyModel", (), {})()
-    cp.sbox_table_cache = []
-    cp.component_and_probability = {}
-    cp.component_probability_index = 0
+    state = CpBuildState()
 
-    declarations, constraints = sbox_component.cp_xor_linear_mask_propagation_constraints(cp)
+    result = sbox_component.cp_xor_linear_mask_propagation_constraints(None, state)
 
-    assert declarations[-2] == "array[0..2] of var 0..1: sbox_0_0_i;"
-    assert declarations[-1] == "array[0..2] of var 0..1: sbox_0_0_o;"
-    assert constraints == [
+    assert result.declarations[-2] == "array[0..2] of var 0..1: sbox_0_0_i;"
+    assert result.declarations[-1] == "array[0..2] of var 0..1: sbox_0_0_o;"
+    assert result.constraints == [
         "constraint table([sbox_0_0_i[0]]++[sbox_0_0_i[1]]++[sbox_0_0_i[2]]++[sbox_0_0_o[0]]++"
         "[sbox_0_0_o[1]]++[sbox_0_0_o[2]]++[p[0]],LAT_sbox_0_0);"
     ]

--- a/tests/unit/components/sbox_component_test.py
+++ b/tests/unit/components/sbox_component_test.py
@@ -67,7 +67,7 @@ def test_cp_xor_differential_propagation_constraints():
     cp = type("DummyModel", (), {})()
     cp.sbox_mant = []
     cp.component_and_probability = {}
-    cp.c = 0
+    cp.component_probability_index = 0
 
     declarations, constraints = sbox_component.cp_xor_differential_propagation_constraints(cp)
 
@@ -83,7 +83,7 @@ def test_cp_xor_linear_mask_propagation_constraints():
     cp = type("DummyModel", (), {})()
     cp.sbox_mant = []
     cp.component_and_probability = {}
-    cp.c = 0
+    cp.component_probability_index = 0
 
     declarations, constraints = sbox_component.cp_xor_linear_mask_propagation_constraints(cp)
 

--- a/tests/unit/components/shift_component_test.py
+++ b/tests/unit/components/shift_component_test.py
@@ -35,7 +35,8 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     shift_component = make_shift_component(bit_size=32, parameter=4)
-    declarations, constraints = shift_component.cp_constraints()
+    result = shift_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0].startswith('constraint shift_0_0[0] = ')
@@ -44,7 +45,8 @@ def test_cp_constraints():
 
 def test_cp_inverse_constraints():
     shift_component = make_shift_component(bit_size=32, parameter=4)
-    declarations, constraints = shift_component.cp_inverse_constraints()
+    result = shift_component.cp_inverse_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0].startswith('constraint shift_0_0_inverse[0] = ')
@@ -58,7 +60,8 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
     shift_component = SHIFT(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                             [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                              [0, 1, 2, 3, 4, 5, 6, 7]], 32, -8)
-    declarations, constraints = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    result = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == 'constraint shift_0_18_active[0] = sbox_0_6_active[0];'
@@ -72,7 +75,8 @@ def test_cp_xor_differential_first_step_constraints():
     shift_component = SHIFT(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                             [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                              [0, 1, 2, 3, 4, 5, 6, 7]], 32, -8)
-    declarations, constraints = shift_component.cp_xor_differential_first_step_constraints(DummyModel())
+    result = shift_component.cp_xor_differential_first_step_constraints(DummyModel())
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..3] of var 0..1: shift_0_18;']
     assert constraints == ['constraint shift_0_18[0] = sbox_0_6[0];',
@@ -83,7 +87,8 @@ def test_cp_xor_differential_first_step_constraints():
 
 def test_cp_xor_linear_mask_propagation_constraints():
     shift_component = make_shift_component(bit_size=32, parameter=4)
-    declarations, constraints = shift_component.cp_xor_linear_mask_propagation_constraints()
+    result = shift_component.cp_xor_linear_mask_propagation_constraints(None, None)
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..31] of var 0..1: shift_0_0_i;', 'array[0..31] of var 0..1: shift_0_0_o;']
     assert len(constraints) > 0
@@ -121,7 +126,8 @@ def test_minizinc_constraints():
     cipher = ShiftCipher(bit_size=32, parameter=4)
     minizinc = MznModel(cipher)
     shift_component = cipher.get_component_from_id('shift_0_0')
-    _, shift_mzn_constraints = shift_component.minizinc_constraints(minizinc)
+    result = shift_component.minizinc_constraints(minizinc)
+    shift_mzn_constraints = result.constraints
 
     assert shift_mzn_constraints[0].startswith('constraint ')
     assert 'SHIFT(' in shift_mzn_constraints[0]

--- a/tests/unit/components/shift_rows_component_test.py
+++ b/tests/unit/components/shift_rows_component_test.py
@@ -21,7 +21,8 @@ def test_constructor_sets_shift_rows_identity():
 def test_cp_constraints():
     cipher = make_shift_rows_cipher()
     shift_rows_component = cipher.component_from(0, 0)
-    declarations, constraints = shift_rows_component.cp_constraints()
+    result = shift_rows_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint shift_rows_0_0[0] = plaintext[6];"

--- a/tests/unit/components/sigma_component_test.py
+++ b/tests/unit/components/sigma_component_test.py
@@ -16,7 +16,8 @@ def test_constructor_sets_sigma_identity():
 
 def test_cp_constraints():
     sigma_component = make_sigma_component()
-    declarations, constraints = sigma_component.cp_constraints()
+    result = sigma_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint sigma_0_0[0] = (plaintext[0] + plaintext[6] + plaintext[7]) mod 2;"

--- a/tests/unit/components/theta_keccak_component_test.py
+++ b/tests/unit/components/theta_keccak_component_test.py
@@ -16,7 +16,8 @@ def test_constructor_sets_theta_keccak_identity():
 
 def test_cp_constraints():
     theta_component = make_theta_keccak_component()
-    declarations, constraints = theta_component.cp_constraints()
+    result = theta_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0].startswith("constraint theta_keccak_0_0[0] = (")

--- a/tests/unit/components/variable_shift_component_test.py
+++ b/tests/unit/components/variable_shift_component_test.py
@@ -16,7 +16,8 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     variable_shift_component = VariableShift(0, 2, ['plaintext', 'key'], [list(range(32)), list(range(32))], 32, 1)
-    declarations, constraints = variable_shift_component.cp_constraints()
+    result = variable_shift_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..31] of var 0..1: pre_var_shift_0_2;', 'var int: shift_amount_var_shift_0_2;']
 

--- a/tests/unit/components/word_permutation_component_test.py
+++ b/tests/unit/components/word_permutation_component_test.py
@@ -22,7 +22,8 @@ def test_constructor_builds_word_permutation_description():
 
 def test_cp_constraints():
     word_permutation_component = make_word_permutation_component()
-    declarations, constraints = word_permutation_component.cp_constraints()
+    result = word_permutation_component.cp_constraints()
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == []
     assert constraints[0] == "constraint mix_column_0_0[0] = (plaintext[2]) mod 2;"

--- a/tests/unit/components/xor_component_test.py
+++ b/tests/unit/components/xor_component_test.py
@@ -56,10 +56,11 @@ def test_cp_xor_differential_propagation_first_step_constraints():
     cp = MznModel(cipher)
     cp.word_size = 8
     xor_component = cipher.get_component_from_id("xor_0_0")
-    declarations, constraints = xor_component.cp_xor_differential_propagation_first_step_constraints(
+    result = xor_component.cp_xor_differential_propagation_first_step_constraints(
         cp,
         cp._variables_list,
     )
+    declarations, constraints = result.declarations, result.constraints
 
     assert declarations == ['array[0..1, 1..2] of int: xor_truncated_table_2 = array2d(0..1, 1..2, [0,0,1,1]);']
 


### PR DESCRIPTION
Remove cp_/minizinc_ dispatch in build_generic and decouple CP model from constraint generators

- Introduce CpBuildContext (frozen), CpBuildState (mutable), and CpComponentBuildResult dataclasses to decouple CP model state from component constraint methods.
- Migrate all ~56 cp_* constraint methods across 16 component files to accept (context, state) and return CpComponentBuildResult instead of mutating the model directly.
- Update all 9 CP model files to use the new context/state/result protocol.
- Remove the if/else dispatch in build_generic_cp_model_from_dictionary that branched on model_type.startswith("cp_") vs minizinc_*; the method now exclusively calls cp_* methods with (context, state).
- Fix pre-existing bug in mzn_xor_differential_model_arx_optimized.py where weight_constraints() return value was incorrectly tuple-unpacked.
- Update all affected unit tests (component + model tests).

Below a diagram showing the interaction between classes/methods/objects involved in the generation of CP models according to the refactor

<img width="777" height="486" alt="cp_refactor_uml_sequence" src="https://github.com/user-attachments/assets/e4f9441e-fe5f-43e5-8c92-ff05eaec41d0" />


