### PR TITLE
BREAKING/Refactor: normalize component API naming

### DIFF
--- a/claasp/cipher.py
+++ b/claasp/cipher.py
@@ -396,7 +396,7 @@ class Cipher:
         EXAMPLES::
 
             sage: from claasp.ciphers.toys.fancy_block_cipher import FancyBlockCipher as fancy
-            sage: fancy(number_of_rounds=2).evaluate_using_c([0x012345,0x89ABCD], True) # random
+            sage: fancy(number_of_rounds=2).evaluate_using_c([0x012345,0x89ABCD], True) # random # doctest: +SKIP
             {'round_key_output': [3502917, 73728],
              'round_output': [9834215],
              'cipher_output': [7457252]}
@@ -602,8 +602,8 @@ class Cipher:
             True
 
             sage: from claasp.ciphers.block_ciphers.twofish_block_cipher import TwofishBlockCipher
-            sage: cipher = TwofishBlockCipher(key_length=256, number_of_rounds=2)
-            sage: key = 0xD43BB7556EA32E46F2A282B7D45B4E0D57FF739D4DC92C1BD7FC01700CC8216F
+            sage: cipher = TwofishBlockCipher(key_length=128, number_of_rounds=1)
+            sage: key = 0xD43BB7556EA32E46F2A282B7D45B4E0D
             sage: plaintext = 0x90AFE91BB288544F2C32DC239B2635E6
             sage: ciphertext = cipher.evaluate([key, plaintext])
             sage: cipher_inv = cipher.cipher_inverse()

--- a/claasp/cipher.py
+++ b/claasp/cipher.py
@@ -396,7 +396,7 @@ class Cipher:
         EXAMPLES::
 
             sage: from claasp.ciphers.toys.fancy_block_cipher import FancyBlockCipher as fancy
-            sage: fancy(number_of_rounds=2).evaluate_using_c([0x012345,0x89ABCD], True) # random # doctest: +SKIP
+            sage: fancy(number_of_rounds=2).evaluate_using_c([0x012345,0x89ABCD], True) # random
             {'round_key_output': [3502917, 73728],
              'round_output': [9834215],
              'cipher_output': [7457252]}
@@ -602,8 +602,8 @@ class Cipher:
             True
 
             sage: from claasp.ciphers.block_ciphers.twofish_block_cipher import TwofishBlockCipher
-            sage: cipher = TwofishBlockCipher(key_length=128, number_of_rounds=1)
-            sage: key = 0xD43BB7556EA32E46F2A282B7D45B4E0D
+            sage: cipher = TwofishBlockCipher(key_length=256, number_of_rounds=2)
+            sage: key = 0xD43BB7556EA32E46F2A282B7D45B4E0D57FF739D4DC92C1BD7FC01700CC8216F
             sage: plaintext = 0x90AFE91BB288544F2C32DC239B2635E6
             sage: ciphertext = cipher.evaluate([key, plaintext])
             sage: cipher_inv = cipher.cipher_inverse()

--- a/claasp/cipher.py
+++ b/claasp/cipher.py
@@ -69,12 +69,12 @@ class Cipher:
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [6], 6)
         sage: cipher.add_round()
-        sage: sbox_0_0 = cipher.add_SBOX_component(["input"], [[0,1,2]], 4, [6,7,0,1,2,3,4,5])
-        sage: sbox_0_1 = cipher.add_SBOX_component(["input"], [[3,4,5]], 4, [7,0,1,2,3,4,5,6])
+        sage: sbox_0_0 = cipher.add_sbox_component(["input"], [[0,1,2]], 4, [6,7,0,1,2,3,4,5])
+        sage: sbox_0_1 = cipher.add_sbox_component(["input"], [[3,4,5]], 4, [7,0,1,2,3,4,5,6])
         sage: rotate_0_2 = cipher.add_rotate_component([sbox_0_0.id, sbox_0_1.id], [[0,1,2],[3,4,5]], 6, 3)
         sage: cipher.add_round()
-        sage: sbox_1_0 = cipher.add_SBOX_component([rotate_0_2.id], [[0,1,2]], 4, [6,7,0,1,2,3,4,5])
-        sage: sbox_1_1 = cipher.add_SBOX_component([rotate_0_2.id], [[3,4,5]], 4, [7,0,1,2,3,4,5,6])
+        sage: sbox_1_0 = cipher.add_sbox_component([rotate_0_2.id], [[0,1,2]], 4, [6,7,0,1,2,3,4,5])
+        sage: sbox_1_1 = cipher.add_sbox_component([rotate_0_2.id], [[3,4,5]], 4, [7,0,1,2,3,4,5,6])
         sage: rotate_1_2 = cipher.add_rotate_component([sbox_1_0.id, sbox_1_1.id], [[0,1,2],[3,4,5]], 6, 3)
         sage: cipher.id == "cipher_name_i6_o6_r2"
         True
@@ -159,8 +159,8 @@ class Cipher:
     def _are_there_not_forbidden_components(self, forbidden_types, forbidden_descriptions):
         return self._rounds.are_there_not_forbidden_components(forbidden_types, forbidden_descriptions)
 
-    def add_AND_component(self, input_id_links, input_bit_positions, output_bit_size):
-        return editor.add_AND_component(self, input_id_links, input_bit_positions, output_bit_size)
+    def add_and_component(self, input_id_links, input_bit_positions, output_bit_size):
+        return editor.add_and_component(self, input_id_links, input_bit_positions, output_bit_size)
 
     def add_cipher_output_component(self, input_id_links, input_bit_positions, output_bit_size):
         return editor.add_cipher_output_component(self, input_id_links, input_bit_positions, output_bit_size)
@@ -171,8 +171,8 @@ class Cipher:
     def add_constant_component(self, output_bit_size, value):
         return editor.add_constant_component(self, output_bit_size, value)
 
-    def add_FSR_component(self, input_id_links, input_bit_positions, output_bit_size, description):
-        return editor.add_FSR_component(self, input_id_links, input_bit_positions, output_bit_size, description)
+    def add_fsr_component(self, input_id_links, input_bit_positions, output_bit_size, description):
+        return editor.add_fsr_component(self, input_id_links, input_bit_positions, output_bit_size, description)
 
     def add_intermediate_output_component(self, input_id_links, input_bit_positions, output_bit_size, output_tag):
         return editor.add_intermediate_output_component(
@@ -199,24 +199,24 @@ class Cipher:
             mix_column_description,
         )
 
-    def add_MODADD_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
-        return editor.add_MODADD_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
+    def add_modadd_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
+        return editor.add_modadd_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
 
-    def add_MODMUL_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
-        return editor.add_MODMUL_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
+    def add_modmul_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
+        return editor.add_modmul_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
 
-    def add_MODSUB_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
-        return editor.add_MODSUB_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
+    def add_modsub_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
+        return editor.add_modsub_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
 
     def add_idea_modmul_component(self, input_id_links, input_bit_positions, output_bit_size, modulus=None):
         return editor.add_idea_modmul_component(self, input_id_links, input_bit_positions, output_bit_size, modulus)
 
-    def add_NOT_component(self, input_id_links, input_bit_positions, output_bit_size):
+    def add_not_component(self, input_id_links, input_bit_positions, output_bit_size):
 
-        return editor.add_NOT_component(self, input_id_links, input_bit_positions, output_bit_size)
+        return editor.add_not_component(self, input_id_links, input_bit_positions, output_bit_size)
 
-    def add_OR_component(self, input_id_links, input_bit_positions, output_bit_size):
-        return editor.add_OR_component(self, input_id_links, input_bit_positions, output_bit_size)
+    def add_or_component(self, input_id_links, input_bit_positions, output_bit_size):
+        return editor.add_or_component(self, input_id_links, input_bit_positions, output_bit_size)
 
     def add_permutation_component(
         self,
@@ -248,11 +248,11 @@ class Cipher:
     def add_round_output_component(self, input_id_links, input_bit_positions, output_bit_size):
         return editor.add_round_output_component(self, input_id_links, input_bit_positions, output_bit_size)
 
-    def add_SBOX_component(self, input_id_links, input_bit_positions, output_bit_size, description):
-        return editor.add_SBOX_component(self, input_id_links, input_bit_positions, output_bit_size, description)
+    def add_sbox_component(self, input_id_links, input_bit_positions, output_bit_size, description):
+        return editor.add_sbox_component(self, input_id_links, input_bit_positions, output_bit_size, description)
 
-    def add_SHIFT_component(self, input_id_links, input_bit_positions, output_bit_size, parameter):
-        return editor.add_SHIFT_component(self, input_id_links, input_bit_positions, output_bit_size, parameter)
+    def add_shift_component(self, input_id_links, input_bit_positions, output_bit_size, parameter):
+        return editor.add_shift_component(self, input_id_links, input_bit_positions, output_bit_size, parameter)
 
     def add_shift_rows_component(self, input_id_links, input_bit_positions, rotation_amount=1, word_bit_size=8,
                                  number_of_words=4):
@@ -328,8 +328,8 @@ class Cipher:
             word_size,
         )
 
-    def add_XOR_component(self, input_id_links, input_bit_positions, output_bit_size):
-        return editor.add_XOR_component(self, input_id_links, input_bit_positions, output_bit_size)
+    def add_xor_component(self, input_id_links, input_bit_positions, output_bit_size):
+        return editor.add_xor_component(self, input_id_links, input_bit_positions, output_bit_size)
 
     def as_python_dictionary(self):
         return {

--- a/claasp/cipher_modules/component_analysis_tests.py
+++ b/claasp/cipher_modules/component_analysis_tests.py
@@ -756,8 +756,8 @@ class CipherComponentsAnalysis:
             sage: from claasp.cipher_modules.component_analysis_tests import CipherComponentsAnalysis
             sage: from claasp.ciphers.toys.fancy_block_cipher import FancyBlockCipher
             sage: fancy = FancyBlockCipher(number_of_rounds=3)
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2, 3]], 4, [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['plaintext'], [[0, 1, 2, 3]], 4, [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15])
             sage: operation = [sbox_component, 12, ['sbox_0_0', 'sbox_0_1', 'sbox_0_2', 'sbox_0_3', 'sbox_0_4', 'sbox_0_5',
             ....: 'sbox_1_0', 'sbox_1_1', 'sbox_1_2', 'sbox_1_3', 'sbox_1_4', 'sbox_1_5']]
             sage: d = CipherComponentsAnalysis(fancy)._sbox_properties(operation)
@@ -835,8 +835,8 @@ class CipherComponentsAnalysis:
             sage: from claasp.cipher_modules.component_analysis_tests import CipherComponentsAnalysis
             sage: from claasp.ciphers.toys.fancy_block_cipher import FancyBlockCipher
             sage: fancy = FancyBlockCipher(number_of_rounds=3)
-            sage: from claasp.components.fsr_component import FSR
-            sage: fsr_component = FSR(0,0, ["input"],[[0,1,2,3]],4,[[[4, [[1,[0]],[3,[1]],[2,[2]]]]],4])
+            sage: from claasp.components.fsr_component import Fsr
+            sage: fsr_component = Fsr(0,0, ["input"],[[0,1,2,3]],4,[[[4, [[1,[0]],[3,[1]],[2,[2]]]]],4])
             sage: operation= [fsr_component, 1, ['fsr_0_0']]
             sage: dictionary = CipherComponentsAnalysis(fancy)._fsr_properties(operation)
             sage: dictionary['fsr_word_size'] == 4

--- a/claasp/cipher_modules/inverse_cipher.py
+++ b/claasp/cipher_modules/inverse_cipher.py
@@ -951,7 +951,7 @@ def component_inverse(component, available_bits, all_equivalent_bits, key_schedu
             component.output_bit_size,
             ["MODSUB", component.description[1], component.description[2]],
         )
-        inverse_component.__class__ = modsub_component.MODSUB
+        inverse_component.__class__ = modsub_component.ModSub
         setattr(inverse_component, "round", component.round)
         update_output_bits(inverse_component, self, all_equivalent_bits, available_bits)
     elif component.type == CONSTANT:

--- a/claasp/cipher_modules/models/milp/milp_models/Gurobi/monomial_prediction.py
+++ b/claasp/cipher_modules/models/milp/milp_models/Gurobi/monomial_prediction.py
@@ -706,7 +706,7 @@ class MilpMonomialPredictionModel:
     def add_or_constraints(self, component):
         """
         The OR operation is modeled as:
-            y = OR(x1, x2, ..., xn)
+            y = Or(x1, x2, ..., xn)
         Then:
             - y >= xi  for each input xi
             - y <= sum(xi)

--- a/claasp/ciphers/block_ciphers/aes_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/aes_block_cipher.py
@@ -260,7 +260,7 @@ class AESBlockCipher(Cipher):
             # SUBWORD
             sbox_outputs = []
             for byte_idx in range(4):
-                sbox_out = self.add_SBOX_component(
+                sbox_out = self.add_sbox_component(
                     [rotated.id],
                     [[byte_idx * 8 + i for i in range(8)]],
                     8, self.SBOX_LOOKUP_TABLE)
@@ -275,7 +275,7 @@ class AESBlockCipher(Cipher):
             # Line 12: temp ← SUBWORD(temp) for AES-256
             sbox_outputs = []
             for byte_idx in range(4):
-                sbox_out = self.add_SBOX_component(
+                sbox_out = self.add_sbox_component(
                     [prev_word.id],
                     [[byte_idx * 8 + i for i in range(8)]],
                     8, self.SBOX_LOOKUP_TABLE)
@@ -290,7 +290,7 @@ class AESBlockCipher(Cipher):
         
         # Line 14: w[i] ← w[i−Nk]⊕temp
         word_minus_nk = self.get_word(word_idx - self.Nk)
-        new_word = self.add_XOR_component(
+        new_word = self.add_xor_component(
             [word_minus_nk.id] + temp_input_id_links,
             [list(range(32))] + temp_input_bit_positions,
             32)
@@ -331,7 +331,7 @@ class AESBlockCipher(Cipher):
         # Column-major byte indexing: byte_idx = c*4 + r
         byte_idx = c * self.NUM_ROWS + r
         start_bit = byte_idx * self.SBOX_BIT_SIZE
-        return self.add_SBOX_component(
+        return self.add_sbox_component(
             [s.id],
             [[start_bit + i for i in range(self.SBOX_BIT_SIZE)]],
             self.SBOX_BIT_SIZE, self.SBOX_LOOKUP_TABLE)
@@ -342,7 +342,7 @@ class AESBlockCipher(Cipher):
         Pseudocode expanding Algorithm 1 Step 05 as described in FIPS-197 Section 5.1.1:
         SUBBYTES(s)
             for 0 ≤ r < 4 and 0 ≤ c < 4
-                s[r,c] = SBOX(s[r,c]) 
+                s[r,c] = Sbox(s[r,c]) 
             return s
         """
         s_output = []
@@ -436,7 +436,7 @@ class AESBlockCipher(Cipher):
                 s_id_list = [s[i].id for i in range(self.NUM_ROWS)] + [w[i].id for i in range(self.NUM_ROWS)]
                 s_input_position_lists = [list(range(self.WORD_BIT_SIZE)) for _ in range(2 * self.NUM_ROWS)]
             
-        s = self.add_XOR_component(s_id_list, s_input_position_lists, self.CIPHER_BLOCK_SIZE)
+        s = self.add_xor_component(s_id_list, s_input_position_lists, self.CIPHER_BLOCK_SIZE)
         return s
 
     def add_round_output(self, state_component, round_number):

--- a/claasp/ciphers/block_ciphers/aradi_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/aradi_block_cipher.py
@@ -75,10 +75,10 @@ class AradiBlockCipher(Cipher):
             key = self.update_key(key, round_i)
 
         round_key = self.get_round_key_id(key, 0)
-        w = self.add_XOR_component([round_key, state], [list(range(32)), list(range(32))], 32).id
-        x = self.add_XOR_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
-        y = self.add_XOR_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
-        z = self.add_XOR_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
+        w = self.add_xor_component([round_key, state], [list(range(32)), list(range(32))], 32).id
+        x = self.add_xor_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
+        y = self.add_xor_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
+        z = self.add_xor_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
         self.add_cipher_output_component([w, x, y, z], [list(range(32)) for _ in range(4)], 128)
 
     def get_round_key_id(self, key, round_i):
@@ -94,10 +94,10 @@ class AradiBlockCipher(Cipher):
         rot_y_a = self.add_rotate_component([xy_id_links], [y_bits], 16, -self.A[j]).id
         rot_y_c = self.add_rotate_component([xy_id_links], [y_bits], 16, -self.C[j]).id
 
-        left_part = self.add_XOR_component(
+        left_part = self.add_xor_component(
             [xy_id_links] + [rot_x_a, rot_y_c], [x_bits] + [list(range(16)), list(range(16))], 16
         ).id
-        right_part = self.add_XOR_component(
+        right_part = self.add_xor_component(
             [xy_id_links] + [rot_y_a, rot_x_b], [y_bits] + [list(range(16)), list(range(16))], 16
         ).id
         return left_part, right_part
@@ -107,10 +107,10 @@ class AradiBlockCipher(Cipher):
         x_indices = xy_input_bits[:32]
         rot_i_y = self.add_rotate_component(xy_id_links, [y_indices], 32, -i).id
         rot_j_x = self.add_rotate_component(xy_id_links, [x_indices], 32, -j).id
-        left_part = self.add_XOR_component(
+        left_part = self.add_xor_component(
             xy_id_links + [rot_i_y, rot_j_x], [x_indices] + [list(range(32)), list(range(32))], 32
         ).id
-        right_part = self.add_XOR_component(xy_id_links + [rot_i_y], [x_indices] + [list(range(32))], 32).id
+        right_part = self.add_xor_component(xy_id_links + [rot_i_y], [x_indices] + [list(range(32))], 32).id
         return left_part, right_part
 
     def update_key(self, key, round_i):
@@ -119,7 +119,7 @@ class AradiBlockCipher(Cipher):
         k3, k2 = self.m_function(9, 28, [key], get_key_word_bit_indexes(3) + get_key_word_bit_indexes(2))
         k5, k4 = self.m_function(1, 3, [key], get_key_word_bit_indexes(5) + get_key_word_bit_indexes(4))
         k7, k6 = self.m_function(9, 28, [key], get_key_word_bit_indexes(7) + get_key_word_bit_indexes(6))
-        k7 = self.add_XOR_component([k7, round_constant], [list(range(32)), list(range(32))], 32).id
+        k7 = self.add_xor_component([k7, round_constant], [list(range(32)), list(range(32))], 32).id
         if round_i % 2 == 0:
             updated_key = self.add_intermediate_output_component(
                 [k7, k5, k6, k4, k3, k1, k2, k0], [list(range(32)) for _ in range(8)], 256, f"key_{round_i}"
@@ -135,22 +135,22 @@ class AradiBlockCipher(Cipher):
         x_ind = list(range(32, 64))
         y_ind = list(range(64, 96))
         z_ind = list(range(96, 128))
-        w = self.add_XOR_component([round_key, state], [w_ind, w_ind], 32).id
-        x = self.add_XOR_component([round_key, state], [x_ind, x_ind], 32).id
-        y = self.add_XOR_component([round_key, state], [y_ind, y_ind], 32).id
-        z = self.add_XOR_component([round_key, state], [z_ind, z_ind], 32).id
+        w = self.add_xor_component([round_key, state], [w_ind, w_ind], 32).id
+        x = self.add_xor_component([round_key, state], [x_ind, x_ind], 32).id
+        y = self.add_xor_component([round_key, state], [y_ind, y_ind], 32).id
+        z = self.add_xor_component([round_key, state], [z_ind, z_ind], 32).id
         # SBOX
-        wy = self.add_AND_component([w, y], [list(range(32)), list(range(32))], 32).id
-        x = self.add_XOR_component([x, wy], [list(range(32)), list(range(32))], 32).id
+        wy = self.add_and_component([w, y], [list(range(32)), list(range(32))], 32).id
+        x = self.add_xor_component([x, wy], [list(range(32)), list(range(32))], 32).id
 
-        xy = self.add_AND_component([x, y], [list(range(32)), list(range(32))], 32).id
-        z = self.add_XOR_component([z, xy], [list(range(32)), list(range(32))], 32).id
+        xy = self.add_and_component([x, y], [list(range(32)), list(range(32))], 32).id
+        z = self.add_xor_component([z, xy], [list(range(32)), list(range(32))], 32).id
 
-        wz = self.add_AND_component([w, z], [list(range(32)), list(range(32))], 32).id
-        y = self.add_XOR_component([y, wz], [list(range(32)), list(range(32))], 32).id
+        wz = self.add_and_component([w, z], [list(range(32)), list(range(32))], 32).id
+        y = self.add_xor_component([y, wz], [list(range(32)), list(range(32))], 32).id
 
-        xz = self.add_AND_component([x, z], [list(range(32)), list(range(32))], 32).id
-        w = self.add_XOR_component([w, xz], [list(range(32)), list(range(32))], 32).id
+        xz = self.add_and_component([x, z], [list(range(32)), list(range(32))], 32).id
+        w = self.add_xor_component([w, xz], [list(range(32)), list(range(32))], 32).id
 
         # L Function
         # w_id_links = [sb_id for sb_id in sb_outputs]

--- a/claasp/ciphers/block_ciphers/aradi_block_cipher_sbox.py
+++ b/claasp/ciphers/block_ciphers/aradi_block_cipher_sbox.py
@@ -76,10 +76,10 @@ class AradiBlockCipherSBox(Cipher):
             key = self.update_key(key, round_i)
 
         round_key = self.get_round_key_id(key, 0)
-        w = self.add_XOR_component([round_key, state], [list(range(32)), list(range(32))], 32).id
-        x = self.add_XOR_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
-        y = self.add_XOR_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
-        z = self.add_XOR_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
+        w = self.add_xor_component([round_key, state], [list(range(32)), list(range(32))], 32).id
+        x = self.add_xor_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
+        y = self.add_xor_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
+        z = self.add_xor_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
         self.add_cipher_output_component([w, x, y, z], [list(range(32)) for _ in range(4)], 128)
 
     def get_round_key_id(self, key, round_i):
@@ -96,10 +96,10 @@ class AradiBlockCipherSBox(Cipher):
         rot_y_a = self.add_rotate_component(xy_id_links[16:], xy_input_bits[16:], 16, -self.A[j]).id
         rot_y_c = self.add_rotate_component(xy_id_links[16:], xy_input_bits[16:], 16, -self.C[j]).id
 
-        left_part = self.add_XOR_component(
+        left_part = self.add_xor_component(
             xy_id_links[:16] + [rot_x_a, rot_y_c], xy_input_bits[:16] + [list(range(16)), list(range(16))], 16
         ).id
-        right_part = self.add_XOR_component(
+        right_part = self.add_xor_component(
             xy_id_links[16:] + [rot_y_a, rot_x_b], xy_input_bits[16:] + [list(range(16)), list(range(16))], 16
         ).id
         return left_part, right_part
@@ -109,10 +109,10 @@ class AradiBlockCipherSBox(Cipher):
         x_inds = xy_input_bits[:32]
         rot_i_y = self.add_rotate_component(xy_id_links, [y_inds], 32, -i).id
         rot_j_x = self.add_rotate_component(xy_id_links, [x_inds], 32, -j).id
-        left_part = self.add_XOR_component(
+        left_part = self.add_xor_component(
             xy_id_links + [rot_i_y, rot_j_x], [x_inds] + [list(range(32)) for _ in range(2)], 32
         ).id
-        right_part = self.add_XOR_component(xy_id_links + [rot_i_y], [x_inds] + [list(range(32))], 32).id
+        right_part = self.add_xor_component(xy_id_links + [rot_i_y], [x_inds] + [list(range(32))], 32).id
         return left_part, right_part
 
     def update_key(self, key, round_i):
@@ -121,7 +121,7 @@ class AradiBlockCipherSBox(Cipher):
         k3, k2 = self.m_function(9, 28, [key], get_key_word_bit_indexes(3) + get_key_word_bit_indexes(2))
         k5, k4 = self.m_function(1, 3, [key], get_key_word_bit_indexes(5) + get_key_word_bit_indexes(4))
         k7, k6 = self.m_function(9, 28, [key], get_key_word_bit_indexes(7) + get_key_word_bit_indexes(6))
-        k7 = self.add_XOR_component([k7, round_constant], [list(range(32)) for _ in range(2)], 32).id
+        k7 = self.add_xor_component([k7, round_constant], [list(range(32)) for _ in range(2)], 32).id
         if round_i % 2 == 0:
             updated_key = self.add_intermediate_output_component(
                 [k7, k5, k6, k4, k3, k1, k2, k0], [list(range(32)) for _ in range(8)], 256, f"key_{round_i}"
@@ -133,14 +133,14 @@ class AradiBlockCipherSBox(Cipher):
         return updated_key.id
 
     def round_function(self, state, round_key, round_i):
-        w = self.add_XOR_component([round_key, state], [list(range(32)), list(range(32))], 32).id
-        x = self.add_XOR_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
-        y = self.add_XOR_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
-        z = self.add_XOR_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
+        w = self.add_xor_component([round_key, state], [list(range(32)), list(range(32))], 32).id
+        x = self.add_xor_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
+        y = self.add_xor_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
+        z = self.add_xor_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
         # SBOX
         sb_outputs = []
         for ind in range(32):
-            sb_outputs.append(self.add_SBOX_component([w, x, y, z], [[ind], [ind], [ind], [ind]], 4, self.SBOX).id)
+            sb_outputs.append(self.add_sbox_component([w, x, y, z], [[ind], [ind], [ind], [ind]], 4, self.SBOX).id)
 
         # L Function
         wl, wr = self.l_function(sb_outputs, [[0] for _ in sb_outputs], round_i)

--- a/claasp/ciphers/block_ciphers/aradi_block_cipher_sbox_and_compact_linear_map.py
+++ b/claasp/ciphers/block_ciphers/aradi_block_cipher_sbox_and_compact_linear_map.py
@@ -115,10 +115,10 @@ class AradiBlockCipherSBoxAndCompactLinearMap(Cipher):
             key = self.update_key(key, round_i)
 
         round_key = self.get_round_key_id(key, 0)
-        w = self.add_XOR_component([round_key, state], [list(range(32)), list(range(32))], 32).id
-        x = self.add_XOR_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
-        y = self.add_XOR_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
-        z = self.add_XOR_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
+        w = self.add_xor_component([round_key, state], [list(range(32)), list(range(32))], 32).id
+        x = self.add_xor_component([round_key, state], [list(range(32, 64)), list(range(32, 64))], 32).id
+        y = self.add_xor_component([round_key, state], [list(range(64, 96)), list(range(64, 96))], 32).id
+        z = self.add_xor_component([round_key, state], [list(range(96, 128)), list(range(96, 128))], 32).id
         self.add_cipher_output_component([w, x, y, z], [list(range(32)) for _ in range(4)], 128)
 
     def get_round_key_id(self, key, round_i):
@@ -140,10 +140,10 @@ class AradiBlockCipherSBoxAndCompactLinearMap(Cipher):
         x_indices = xy_input_bits[:32]
         rot_i_y = self.add_rotate_component(xy_id_links, [y_indices], 32, -i).id
         rot_j_x = self.add_rotate_component(xy_id_links, [x_indices], 32, -j).id
-        left_part = self.add_XOR_component(
+        left_part = self.add_xor_component(
             xy_id_links + [rot_i_y, rot_j_x], [x_indices] + [list(range(32)) for _ in range(2)], 32
         ).id
-        right_part = self.add_XOR_component(xy_id_links + [rot_i_y], [x_indices] + [list(range(32))], 32).id
+        right_part = self.add_xor_component(xy_id_links + [rot_i_y], [x_indices] + [list(range(32))], 32).id
         return left_part, right_part
 
     def update_key(self, key, round_i):
@@ -155,7 +155,7 @@ class AradiBlockCipherSBoxAndCompactLinearMap(Cipher):
         k5, k4 = self.m_function(1, 3, [key], key_word_bit_indexes)
         key_word_bit_indexes = get_key_word_bit_indexes(7) + get_key_word_bit_indexes(6)
         k7, k6 = self.m_function(9, 28, [key], key_word_bit_indexes)
-        k7 = self.add_XOR_component([k7, round_constant], [list(range(32)) for _ in range(2)], 32).id
+        k7 = self.add_xor_component([k7, round_constant], [list(range(32)) for _ in range(2)], 32).id
         if round_i % 2 == 0:
             updated_key = self.add_intermediate_output_component(
                 [k7, k5, k6, k4, k3, k1, k2, k0], [list(range(32)) for _ in range(8)], 256, f"key_{round_i}"
@@ -168,14 +168,14 @@ class AradiBlockCipherSBoxAndCompactLinearMap(Cipher):
 
     def round_function(self, state, round_key, round_i):
         def create_xor_component(start_idx, length=32):
-            return self.add_XOR_component(
+            return self.add_xor_component(
                 [round_key, state],
                 [list(range(start_idx, start_idx + length)), list(range(start_idx, start_idx + length))],
                 length,
             ).id
 
         w, x, y, z = [create_xor_component(i * 32) for i in range(4)]
-        sb_outputs = [self.add_SBOX_component([w, x, y, z], [[i], [i], [i], [i]], 4, self.SBOX).id for i in range(32)]
+        sb_outputs = [self.add_sbox_component([w, x, y, z], [[i], [i], [i], [i]], 4, self.SBOX).id for i in range(32)]
 
         self.add_intermediate_output_component(
             sb_outputs * 4, [[i] for i in range(4)] * 32, 128, f"sbox_output_{round_i}"

--- a/claasp/ciphers/block_ciphers/baksheesh_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/baksheesh_block_cipher.py
@@ -62,7 +62,7 @@ class BaksheeshBlockCipher(Cipher):
 
         # 1) Whitening
         self.add_round()
-        xor = self.add_XOR_component(state[0] + key[0], state[1] + key[1], block_bit_size)
+        xor = self.add_xor_component(state[0] + key[0], state[1] + key[1], block_bit_size)
         state = ([xor.id], [list(range(block_bit_size))])
 
         # 2) Rounds
@@ -71,7 +71,7 @@ class BaksheeshBlockCipher(Cipher):
             state = self.apply_bit_permutation(state)
             state = self.apply_round_constants(state, round_number)
             key = self.update_key(key)
-            xor = self.add_XOR_component(state[0] + key[0], state[1] + key[1], block_bit_size)
+            xor = self.add_xor_component(state[0] + key[0], state[1] + key[1], block_bit_size)
             state = ([xor.id], [list(range(block_bit_size))])
             self.add_round_output_component(state[0], state[1], block_bit_size)
             self.add_round()
@@ -81,14 +81,14 @@ class BaksheeshBlockCipher(Cipher):
         state = self.apply_bit_permutation(state)
         state = self.apply_round_constants(state, number_of_rounds - 1)
         key = self.update_key(key)
-        xor = self.add_XOR_component(state[0] + key[0], state[1] + key[1], block_bit_size)
+        xor = self.add_xor_component(state[0] + key[0], state[1] + key[1], block_bit_size)
 
         self.add_cipher_output_component([xor.id], [list(range(block_bit_size))], block_bit_size)
 
     def apply_sbox_layer(self, state):
         ids, bits = [], []
         for i in range(self.number_of_nibbles):
-            sbox = self.add_SBOX_component(state[0], [state[1][0][i * 4 : (i + 1) * 4]], 4, SBOX)
+            sbox = self.add_sbox_component(state[0], [state[1][0][i * 4 : (i + 1) * 4]], 4, SBOX)
             ids.append(sbox.id)
             bits.append(list(range(4)))
         state = (ids, bits)
@@ -109,7 +109,7 @@ class BaksheeshBlockCipher(Cipher):
 
         constant = self.add_constant_component(self.block_bit_size, value)
 
-        comp = self.add_XOR_component(
+        comp = self.add_xor_component(
             state[0] + [constant.id], state[1] + [list(range(self.block_bit_size))], self.block_bit_size
         )
         state = ([comp.id], [list(range(self.block_bit_size))])

--- a/claasp/ciphers/block_ciphers/ballet_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/ballet_block_cipher.py
@@ -188,7 +188,7 @@ class BalletBlockCipher(Cipher):
 
     def round_function(self, state_0, state_1, state_2, state_3, round_key, last_round):
         # state' = state_1 xor state_2
-        self.add_XOR_component(
+        self.add_xor_component(
             state_1.id + state_2.id,
             state_1.input_bit_positions + state_2.input_bit_positions,
             self.quater_block_bit_size,
@@ -196,7 +196,7 @@ class BalletBlockCipher(Cipher):
         state_temp = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
 
         # state_0_new = state_1 xor round_key_left
-        self.add_XOR_component(
+        self.add_xor_component(
             state_1.id + round_key.id,
             state_1.input_bit_positions + [round_key.input_bit_positions[0][: self.quater_block_bit_size]],
             self.quater_block_bit_size,
@@ -208,7 +208,7 @@ class BalletBlockCipher(Cipher):
         state_temp_1 = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
         self.add_rotate_component(state_temp.id, state_temp.input_bit_positions, self.quater_block_bit_size, -9)
         state_temp_2 = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
-        self.add_MODADD_component(
+        self.add_modadd_component(
             state_temp_1.id + state_temp_2.id,
             state_temp_1.input_bit_positions + state_temp_2.input_bit_positions,
             self.quater_block_bit_size,
@@ -220,7 +220,7 @@ class BalletBlockCipher(Cipher):
         state_temp_1 = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
         self.add_rotate_component(state_temp.id, state_temp.input_bit_positions, self.quater_block_bit_size, -14)
         state_temp_2 = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
-        self.add_MODADD_component(
+        self.add_modadd_component(
             state_temp_1.id + state_temp_2.id,
             state_temp_1.input_bit_positions + state_temp_2.input_bit_positions,
             self.quater_block_bit_size,
@@ -228,7 +228,7 @@ class BalletBlockCipher(Cipher):
         state_2_new = ComponentState([self.get_current_component_id()], [list(range(self.quater_block_bit_size))])
 
         # state_3_new = state_2 xor round_key_right
-        self.add_XOR_component(
+        self.add_xor_component(
             state_2.id + round_key.id,
             state_2.input_bit_positions
             + [round_key.input_bit_positions[0][self.quater_block_bit_size : self.round_key_bit_size]],
@@ -250,7 +250,7 @@ class BalletBlockCipher(Cipher):
         key_temp_2 = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
         self.add_constant_component(self.round_key_bit_size, RC)
         round_constant = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
-        self.add_XOR_component(
+        self.add_xor_component(
             key_0.id + key_temp_1.id + key_temp_2.id + round_constant.id,
             key_0.input_bit_positions
             + key_temp_1.input_bit_positions
@@ -269,7 +269,7 @@ class BalletBlockCipher(Cipher):
         t_temp_1 = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
         self.add_rotate_component(t_1.id, t_1.input_bit_positions, self.round_key_bit_size, -17)
         t_temp_2 = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
-        self.add_XOR_component(
+        self.add_xor_component(
             t_0.id + t_temp_1.id + t_temp_2.id,
             t_0.input_bit_positions + t_temp_1.input_bit_positions + t_temp_2.input_bit_positions,
             self.round_key_bit_size,
@@ -282,7 +282,7 @@ class BalletBlockCipher(Cipher):
         key_temp_1 = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
         self.add_rotate_component(key_1.id, key_1.input_bit_positions, self.round_key_bit_size, -5)
         key_temp_2 = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
-        self.add_XOR_component(
+        self.add_xor_component(
             key_0.id + key_temp_1.id + key_temp_2.id,
             key_0.input_bit_positions + key_temp_1.input_bit_positions + key_temp_2.input_bit_positions,
             self.round_key_bit_size,
@@ -292,7 +292,7 @@ class BalletBlockCipher(Cipher):
         # key_1_new = key_1_new xor t_1_new xor RC
         self.add_constant_component(self.round_key_bit_size, RC)
         round_constant = ComponentState([self.get_current_component_id()], [list(range(self.round_key_bit_size))])
-        self.add_XOR_component(
+        self.add_xor_component(
             key_1_new.id + t_1_new.id + round_constant.id,
             key_1_new.input_bit_positions + t_1_new.input_bit_positions + round_constant.input_bit_positions,
             self.round_key_bit_size,

--- a/claasp/ciphers/block_ciphers/ballet_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/ballet_block_cipher.py
@@ -98,10 +98,7 @@ class BalletBlockCipher(Cipher):
             cipher_output_bit_size=self.block_bit_size,
         )
 
-        if self.block_bit_size == self.key_bit_size:
-            state_0, state_1, state_2, state_3, key_0, key_1 = self.round_initialization()
-        else:
-            state_0, state_1, state_2, state_3, key_0, key_1, t_0, t_1 = self.round_initialization()
+        state_0, state_1, state_2, state_3, key_0, key_1, t_0, t_1 = self.round_initialization()
 
         for round_number in range(self.r):
             self.add_round()
@@ -178,7 +175,9 @@ class BalletBlockCipher(Cipher):
         if self.block_bit_size == self.key_bit_size:
             key_0 = ComponentState([INPUT_KEY], [list(range(self.round_key_bit_size))])
             key_1 = ComponentState([INPUT_KEY], [list(range(self.round_key_bit_size, self.key_bit_size))])
-            return state_0, state_1, state_2, state_3, key_0, key_1
+            t_0 = None
+            t_1 = None
+            return state_0, state_1, state_2, state_3, key_0, key_1, t_0, t_1
 
         key_0 = ComponentState([INPUT_KEY], [list(range(self.round_key_bit_size))])
         key_1 = ComponentState([INPUT_KEY], [list(range(self.round_key_bit_size, self.round_key_bit_size * 2))])

--- a/claasp/ciphers/block_ciphers/bea1_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/bea1_block_cipher.py
@@ -371,7 +371,7 @@ class BEA1BlockCipher(Cipher):
 
         _zero = self.add_constant_component(self.sbox_bit_size, 0)
         key_state = [
-            self.add_XOR_component(
+            self.add_xor_component(
                 [INPUT_KEY if j < (self.key_block_size // self.sbox_bit_size) else _zero.id, _zero.id],
                 [
                     list(range(j * self.sbox_bit_size, (j + 1) * self.sbox_bit_size))
@@ -397,7 +397,7 @@ class BEA1BlockCipher(Cipher):
                 self.mix_columns_matrix,
             )
             x = [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [x.id],
                     [[j * self.sbox_bit_size + k for k in range(self.sbox_bit_size)]],
                     self.sbox_bit_size,
@@ -406,24 +406,24 @@ class BEA1BlockCipher(Cipher):
                 for j in range(4)
             ]
             xor_constant = self.add_constant_component(self.sbox_bit_size, pow(3, i, 2**10))
-            x[0] = self.add_XOR_component(
+            x[0] = self.add_xor_component(
                 [x[0].id, xor_constant.id], [list(range(self.sbox_bit_size))] * 2, self.sbox_bit_size
             )
 
             for j in range(4):
-                key_state[(12 * i + 12) % 24 + j] = self.add_XOR_component(
+                key_state[(12 * i + 12) % 24 + j] = self.add_xor_component(
                     [key_state[(12 * i) % 24 + j].id, x[j].id],
                     [list(range(self.sbox_bit_size))] * 2,
                     self.sbox_bit_size,
                 )
             for j in range(4):
-                key_state[(12 * i + 16) % 24 + j] = self.add_XOR_component(
+                key_state[(12 * i + 16) % 24 + j] = self.add_xor_component(
                     [key_state[(12 * i + 4) % 24 + j].id, key_state[(12 * i + 12) % 24 + j].id],
                     [list(range(self.sbox_bit_size))] * 2,
                     self.sbox_bit_size,
                 )
             for j in range(4):
-                key_state[(12 * i + 20) % 24 + j] = self.add_XOR_component(
+                key_state[(12 * i + 20) % 24 + j] = self.add_xor_component(
                     [key_state[(12 * i + 8) % 24 + j].id, key_state[(12 * i + 16) % 24 + j].id],
                     [list(range(self.sbox_bit_size))] * 2,
                     self.sbox_bit_size,
@@ -439,7 +439,7 @@ class BEA1BlockCipher(Cipher):
 
             # sbox
             cipher_state = [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [cipher_state[i].id],
                     [list(range(self.sbox_bit_size))],
                     self.sbox_bit_size,
@@ -463,7 +463,7 @@ class BEA1BlockCipher(Cipher):
                     self.mix_columns_matrix,
                 )
                 cipher_state = [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         [mx1.id, _zero.id],
                         [
                             list(range(i * self.sbox_bit_size, (i + 1) * self.sbox_bit_size)),
@@ -474,7 +474,7 @@ class BEA1BlockCipher(Cipher):
                     for i in range(4)
                 ]
                 cipher_state += [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         [mx2.id, _zero.id],
                         [
                             list(range(i * self.sbox_bit_size, (i + 1) * self.sbox_bit_size)),
@@ -521,7 +521,7 @@ class BEA1BlockCipher(Cipher):
         if isinstance(cipher_state, str):
             # cipher_state == INPUT_PLAINTEXT
             return [
-                self.add_XOR_component(
+                self.add_xor_component(
                     [cipher_state, key[i].id],
                     [
                         list(range(i * self.sbox_bit_size, (i + 1) * self.sbox_bit_size)),
@@ -533,7 +533,7 @@ class BEA1BlockCipher(Cipher):
             ]
 
         return [
-            self.add_XOR_component(
+            self.add_xor_component(
                 [cipher_state[i].id, key[i].id], [list(range(self.sbox_bit_size))] * 2, self.sbox_bit_size
             )
             for i in range(8)

--- a/claasp/ciphers/block_ciphers/des_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/des_block_cipher.py
@@ -374,7 +374,7 @@ class DESBlockCipher(Cipher):
             )
 
             # AddRoundKey to Expanded State
-            keyed_state = self.add_XOR_component(
+            keyed_state = self.add_xor_component(
                 [state.id, round_key.id],
                 [
                     [
@@ -389,7 +389,7 @@ class DESBlockCipher(Cipher):
             # Sbox
             sbox_state = []
             for i in range(number_of_sboxes):
-                sbox_output = self.add_SBOX_component(
+                sbox_output = self.add_sbox_component(
                     [keyed_state.id], [list(range(6 * i, 6 * i + 6))], 4, self.sbox[i + 1]
                 )
                 sbox_state.append(sbox_output)
@@ -403,7 +403,7 @@ class DESBlockCipher(Cipher):
             )
 
             # XOR with Left Half
-            right_state = self.add_XOR_component(
+            right_state = self.add_xor_component(
                 [state.id, right_state_to_xor.id],
                 [list(range(number_of_sboxes * 4)), list(range(number_of_sboxes * 4))],
                 number_of_sboxes * 4,

--- a/claasp/ciphers/block_ciphers/des_exact_key_length_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/des_exact_key_length_block_cipher.py
@@ -378,7 +378,7 @@ class DESExactKeyLengthBlockCipher(Cipher):
             )
 
             # AddRoundKey to Expanded State
-            keyed_state = self.add_XOR_component(
+            keyed_state = self.add_xor_component(
                 [state.id, round_key.id],
                 [
                     [
@@ -393,7 +393,7 @@ class DESExactKeyLengthBlockCipher(Cipher):
             # Sbox
             sbox_state = []
             for i in range(number_of_sboxes):
-                sbox_output = self.add_SBOX_component(
+                sbox_output = self.add_sbox_component(
                     [keyed_state.id], [list(range(6 * i, 6 * i + 6))], 4, self.sbox[i + 1]
                 )
 
@@ -408,7 +408,7 @@ class DESExactKeyLengthBlockCipher(Cipher):
             )
 
             # XOR with Left Half
-            right_state = self.add_XOR_component(
+            right_state = self.add_xor_component(
                 [state.id, right_state_to_xor.id],
                 [list(range(number_of_sboxes * 4)), list(range(number_of_sboxes * 4))],
                 number_of_sboxes * 4,

--- a/claasp/ciphers/block_ciphers/gost_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/gost_block_cipher.py
@@ -124,7 +124,7 @@ class GostBlockCipher(Cipher):
     def add_round_key(
         self, plaintext: ComponentState, key: ComponentState
     ) -> ComponentState:
-        plaintext_id = self.add_MODADD_component(
+        plaintext_id = self.add_modadd_component(
             [plaintext.id[-1], key.id],
             [plaintext.input_bit_positions[-1]] + key.input_bit_positions,
             self.half_block_size,
@@ -144,7 +144,7 @@ class GostBlockCipher(Cipher):
 
         for i, sbox in enumerate(SBOX):
             plaintext_ids += [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [plaintext.id[-1]], [list(range(4 * i, 4 * (i + 1)))], 4, sbox
                 ).id
             ]
@@ -173,7 +173,7 @@ class GostBlockCipher(Cipher):
         )
 
     def xor(self, plaintext: ComponentState) -> ComponentState:
-        plaintext_id = self.add_XOR_component(
+        plaintext_id = self.add_xor_component(
             [plaintext.id[0], plaintext.id[2]],
             [plaintext.input_bit_positions[0]] + [plaintext.input_bit_positions[2]],
             self.half_block_size,

--- a/claasp/ciphers/block_ciphers/hight_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/hight_block_cipher.py
@@ -167,7 +167,7 @@ class HightBlockCipher(Cipher):
         for sub_key_temp in sub_key_temp_list:
             delta = self.add_constant_component(8, sub_key_temp["delta_constant"])
 
-            mod_a = self.add_MODADD_component(
+            mod_a = self.add_modadd_component(
                 [sub_key_temp["master_key"].id] + [delta.id],
                 sub_key_temp["master_key"].input_bit_positions + [list(range(8))],
                 8,
@@ -178,12 +178,12 @@ class HightBlockCipher(Cipher):
 
     def final_transformation(self, plaintext_list, whitening_key_list):
         def temp_final_transformation(a, b, c, d):
-            mod_temp_1 = self.add_MODADD_component(
+            mod_temp_1 = self.add_modadd_component(
                 [plaintext_list[a].id] + [whitening_key_list[b].id],
                 [list(range(8))] + whitening_key_list[b].input_bit_positions,
                 8,
             )
-            xor_temp_1 = self.add_XOR_component(
+            xor_temp_1 = self.add_xor_component(
                 [plaintext_list[c].id] + [whitening_key_list[d].id],
                 [list(range(8))] + whitening_key_list[d].input_bit_positions,
                 8,
@@ -223,12 +223,12 @@ class HightBlockCipher(Cipher):
 
     def initial_transformation(self, plaintext_list, whitening_key_list):
         def temp_initial_transformation(a, b, c, d):
-            mod_temp_1 = self.add_MODADD_component(
+            mod_temp_1 = self.add_modadd_component(
                 [plaintext_list[a].id] + [whitening_key_list[b].id],
                 plaintext_list[a].input_bit_positions + whitening_key_list[b].input_bit_positions,
                 8,
             )
-            xor_temp_1 = self.add_XOR_component(
+            xor_temp_1 = self.add_xor_component(
                 [plaintext_list[c].id] + [whitening_key_list[d].id],
                 plaintext_list[c].input_bit_positions + whitening_key_list[d].input_bit_positions,
                 8,
@@ -266,14 +266,14 @@ class HightBlockCipher(Cipher):
                 [x.id], [get_ith_word(self.word_size, 0, x.id, x.input_bit_positions)], self.word_size, -7
             )
 
-            xor_1 = self.add_XOR_component(
+            xor_1 = self.add_xor_component(
                 [rot_1.id] + [rot_2.id],
                 [get_ith_word(self.word_size, 0, rot_1.id, rot_1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, rot_2.id, rot_2.input_bit_positions)],
                 self.word_size,
             )
 
-            xor_2 = self.add_XOR_component(
+            xor_2 = self.add_xor_component(
                 [xor_1.id] + [rot_7.id],
                 [get_ith_word(self.word_size, 0, xor_1.id, xor_1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, rot_7.id, rot_7.input_bit_positions)],
@@ -295,14 +295,14 @@ class HightBlockCipher(Cipher):
                 [x.id], [get_ith_word(self.word_size, 0, x.id, x.input_bit_positions)], self.word_size, -6
             )
 
-            xor_1 = self.add_XOR_component(
+            xor_1 = self.add_xor_component(
                 [rot_1.id] + [rot_2.id],
                 [get_ith_word(self.word_size, 0, rot_1.id, rot_1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, rot_2.id, rot_2.input_bit_positions)],
                 self.word_size,
             )
 
-            xor_2 = self.add_XOR_component(
+            xor_2 = self.add_xor_component(
                 [xor_1.id] + [rot_7.id],
                 [get_ith_word(self.word_size, 0, xor_1.id, xor_1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, rot_7.id, rot_7.input_bit_positions)],
@@ -313,14 +313,14 @@ class HightBlockCipher(Cipher):
 
         def f3_xor(x1, x2, x3, f):
             x2p = f(x2)
-            mod_1 = self.add_MODADD_component(
+            mod_1 = self.add_modadd_component(
                 [x2p.id] + [x3.id],
                 [get_ith_word(self.word_size, 0, x2p.id, x2p.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, x3.id, x3.input_bit_positions)],
                 self.word_size,
             )
 
-            xor_1 = self.add_XOR_component(
+            xor_1 = self.add_xor_component(
                 [x1.id] + [mod_1.id],
                 [get_ith_word(self.word_size, 0, x1.id, x1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, mod_1.id, mod_1.input_bit_positions)],
@@ -331,14 +331,14 @@ class HightBlockCipher(Cipher):
 
         def f3_mod(x1, x2, x3, f):
             x2p = f(x2)
-            xor_1 = self.add_XOR_component(
+            xor_1 = self.add_xor_component(
                 [x2p.id] + [x3.id],
                 [get_ith_word(self.word_size, 0, x2p.id, x2p.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, x3.id, x3.input_bit_positions)],
                 self.word_size,
             )
 
-            mod_1 = self.add_MODADD_component(
+            mod_1 = self.add_modadd_component(
                 [x1.id] + [xor_1.id],
                 [get_ith_word(self.word_size, 0, x1.id, x1.input_bit_positions)]
                 + [get_ith_word(self.word_size, 0, xor_1.id, xor_1.input_bit_positions)],

--- a/claasp/ciphers/block_ciphers/idea_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/idea_block_cipher.py
@@ -181,7 +181,7 @@ class IdeaBlockCipher(Cipher):
         return ComponentState([self.get_current_component_id()], [list(range(self.WORD_SIZE))])
 
     def _add_modadd_component(self, s1, s2):
-        self.add_MODADD_component(
+        self.add_modadd_component(
             [s1.id[0], s2.id[0]],
             [s1.input_bit_positions[0], s2.input_bit_positions[0]],
             self.WORD_SIZE,
@@ -190,7 +190,7 @@ class IdeaBlockCipher(Cipher):
         return ComponentState([self.get_current_component_id()], [list(range(self.WORD_SIZE))])
 
     def _add_xor_component(self, s1, s2):
-        self.add_XOR_component(
+        self.add_xor_component(
             [s1.id[0], s2.id[0]],
             [s1.input_bit_positions[0], s2.input_bit_positions[0]],
             self.WORD_SIZE,

--- a/claasp/ciphers/block_ciphers/kalyna_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/kalyna_block_cipher.py
@@ -159,7 +159,7 @@ class KalynaBlockCipher(Cipher):
         S0 = self.add_constant_component(
             self.CIPHER_BLOCK_SIZE, 0x00000000000000000000000000000005
         )
-        g1_first = self.add_MODADD_component(
+        g1_first = self.add_modadd_component(
             [INPUT_KEY, S0.id],
             [
                 [i for i in range(self.CIPHER_BLOCK_SIZE // 2, self.CIPHER_BLOCK_SIZE)],
@@ -167,7 +167,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE // 2,
         )
-        g1_second = self.add_MODADD_component(
+        g1_second = self.add_modadd_component(
             [INPUT_KEY, S0.id],
             [
                 [i for i in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -178,7 +178,7 @@ class KalynaBlockCipher(Cipher):
         sboxes_components = []
         for i in range(self.CIPHER_BLOCK_SIZE // 16):
             sboxes_components.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g1_first.id],
                     [list(range((8 * i), (8 * i + 8)))],
                     self.SBOX_BIT_SIZE,
@@ -187,7 +187,7 @@ class KalynaBlockCipher(Cipher):
             )
         for i in range(self.CIPHER_BLOCK_SIZE // 16, self.CIPHER_BLOCK_SIZE // 8):
             sboxes_components.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g1_second.id],
                     [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                     self.SBOX_BIT_SIZE,
@@ -211,7 +211,7 @@ class KalynaBlockCipher(Cipher):
             self.CIPHER_BLOCK_SIZE // 2,
             self.kalyna_matrix_description,
         )
-        g2_first = self.add_XOR_component(
+        g2_first = self.add_xor_component(
             [g1_first.id, INPUT_KEY],
             [
                 [i for i in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -219,7 +219,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE // 2,
         )
-        g2_second = self.add_XOR_component(
+        g2_second = self.add_xor_component(
             [g1_second.id, INPUT_KEY],
             [
                 [i for i in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -230,7 +230,7 @@ class KalynaBlockCipher(Cipher):
         sboxes_components_2 = []
         for i in range(self.CIPHER_BLOCK_SIZE // 16):
             sboxes_components_2.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g2_first.id],
                     [list(range((8 * i), (8 * i + 8)))],
                     self.SBOX_BIT_SIZE,
@@ -239,7 +239,7 @@ class KalynaBlockCipher(Cipher):
             )
         for i in range(self.CIPHER_BLOCK_SIZE // 16, self.CIPHER_BLOCK_SIZE // 8):
             sboxes_components_2.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g2_second.id],
                     [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                     self.SBOX_BIT_SIZE,
@@ -264,7 +264,7 @@ class KalynaBlockCipher(Cipher):
             self.CIPHER_BLOCK_SIZE // 2,
             self.kalyna_matrix_description,
         )
-        g2_first_modadd = self.add_MODADD_component(
+        g2_first_modadd = self.add_modadd_component(
             [INPUT_KEY, g2_first.id],
             [
                 [i for i in range(self.KEY_BLOCK_SIZE // 2, self.KEY_BLOCK_SIZE)],
@@ -272,7 +272,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE // 2,
         )
-        g2_second_modadd = self.add_MODADD_component(
+        g2_second_modadd = self.add_modadd_component(
             [INPUT_KEY, g2_second.id],
             [
                 [i for i in range(self.KEY_BLOCK_SIZE // 2)],
@@ -283,7 +283,7 @@ class KalynaBlockCipher(Cipher):
         sboxes_components_3 = []
         for i in range(self.CIPHER_BLOCK_SIZE // 16):
             sboxes_components_3.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g2_second_modadd.id],
                     [list(range((8 * i), (8 * i + 8)))],
                     self.SBOX_BIT_SIZE,
@@ -292,7 +292,7 @@ class KalynaBlockCipher(Cipher):
             )
         for i in range(self.CIPHER_BLOCK_SIZE // 16, self.CIPHER_BLOCK_SIZE // 8):
             sboxes_components_3.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [g2_first_modadd.id],
                     [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                     self.SBOX_BIT_SIZE,
@@ -319,7 +319,7 @@ class KalynaBlockCipher(Cipher):
         )
 
         const = self.add_constant_component(self.CIPHER_BLOCK_SIZE, 0x0)
-        g3_second_128 = self.add_XOR_component(
+        g3_second_128 = self.add_xor_component(
             [g3_second.id, const.id],
             [
                 [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -327,7 +327,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE,
         )
-        g3_first_128 = self.add_XOR_component(
+        g3_first_128 = self.add_xor_component(
             [const.id, g3_first.id],
             [
                 [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -335,7 +335,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE,
         )
-        k_T = self.add_XOR_component(
+        k_T = self.add_xor_component(
             [g3_second_128.id, g3_first_128.id],
             [
                 [j for j in range(self.CIPHER_BLOCK_SIZE)],
@@ -360,7 +360,7 @@ class KalynaBlockCipher(Cipher):
                 self.KEY_BLOCK_SIZE,
                 32 * k,
             )
-            k_i_prime = self.add_MODADD_component(
+            k_i_prime = self.add_modadd_component(
                 [tmv.id, k_T.id],
                 [
                     [j for j in range(self.KEY_BLOCK_SIZE)],
@@ -368,7 +368,7 @@ class KalynaBlockCipher(Cipher):
                 ],
                 self.CIPHER_BLOCK_SIZE,
             )
-            k_i_prime_int = self.add_MODADD_component(
+            k_i_prime_int = self.add_modadd_component(
                 [k_i_prime.id, rotated_key.id],
                 [
                     [j for j in range(self.KEY_BLOCK_SIZE)],
@@ -379,7 +379,7 @@ class KalynaBlockCipher(Cipher):
             sboxes_components_E = []
             for i in range(self.KEY_BLOCK_SIZE // 8):
                 sboxes_components_E.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [k_i_prime_int.id],
                         [list(range((8 * i), (8 * i + 8)))],
                         self.SBOX_BIT_SIZE,
@@ -410,7 +410,7 @@ class KalynaBlockCipher(Cipher):
                 self.CIPHER_BLOCK_SIZE // 2,
                 self.kalyna_matrix_description,
             )
-            k_i_prime_first_half = self.add_XOR_component(
+            k_i_prime_first_half = self.add_xor_component(
                 [gE_second.id, k_i_prime.id],
                 [
                     [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -418,7 +418,7 @@ class KalynaBlockCipher(Cipher):
                 ],
                 self.KEY_BLOCK_SIZE // 2,
             )
-            k_i_prime_second_half = self.add_XOR_component(
+            k_i_prime_second_half = self.add_xor_component(
                 [gE_first.id, k_i_prime.id],
                 [
                     [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -429,7 +429,7 @@ class KalynaBlockCipher(Cipher):
             sboxes_components_E2 = []
             for i in range(self.KEY_BLOCK_SIZE // 16):
                 sboxes_components_E2.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [k_i_prime_first_half.id],
                         [list(range((8 * i), (8 * i + 8)))],
                         self.SBOX_BIT_SIZE,
@@ -438,7 +438,7 @@ class KalynaBlockCipher(Cipher):
                 )
             for i in range(self.KEY_BLOCK_SIZE // 16, self.KEY_BLOCK_SIZE // 8):
                 sboxes_components_E2.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [k_i_prime_second_half.id],
                         [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                         self.SBOX_BIT_SIZE,
@@ -470,7 +470,7 @@ class KalynaBlockCipher(Cipher):
                 self.CIPHER_BLOCK_SIZE // 2,
                 self.kalyna_matrix_description,
             )
-            k_2i_prime_first_half = self.add_MODADD_component(
+            k_2i_prime_first_half = self.add_modadd_component(
                 [gE2_second.id, k_i_prime.id],
                 [
                     [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -478,7 +478,7 @@ class KalynaBlockCipher(Cipher):
                 ],
                 self.KEY_BLOCK_SIZE // 2,
             )
-            k_2i_prime_second_half = self.add_MODADD_component(
+            k_2i_prime_second_half = self.add_modadd_component(
                 [gE2_first.id, k_i_prime.id],
                 [
                     [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -523,7 +523,7 @@ class KalynaBlockCipher(Cipher):
         k0_second = even_round_keys[0]["second_half"]
 
         # self.add_round()
-        first_half = self.add_MODADD_component(
+        first_half = self.add_modadd_component(
             [k0_first.id, INPUT_PLAINTEXT],
             [
                 [i for i in range(self.KEY_BLOCK_SIZE // 2)],
@@ -532,7 +532,7 @@ class KalynaBlockCipher(Cipher):
             self.CIPHER_BLOCK_SIZE // 2,
         )
 
-        second_half = self.add_MODADD_component(
+        second_half = self.add_modadd_component(
             [k0_second.id, INPUT_PLAINTEXT],
             [
                 [i for i in range(self.KEY_BLOCK_SIZE // 2)],
@@ -545,7 +545,7 @@ class KalynaBlockCipher(Cipher):
             sboxes_components = []
             for i in range(self.CIPHER_BLOCK_SIZE // 16):
                 sboxes_components.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [first_half.id],
                         [list(range((8 * i), (8 * i + 8)))],
                         self.SBOX_BIT_SIZE,
@@ -554,7 +554,7 @@ class KalynaBlockCipher(Cipher):
                 )
             for i in range(self.CIPHER_BLOCK_SIZE // 16, self.CIPHER_BLOCK_SIZE // 8):
                 sboxes_components.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [second_half.id],
                         [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                         self.SBOX_BIT_SIZE,
@@ -588,7 +588,7 @@ class KalynaBlockCipher(Cipher):
             )
             if k % 2 == 1:
                 k_round = odd_round_keys[k]
-                first_half = self.add_XOR_component(
+                first_half = self.add_xor_component(
                     [g_second.id, k_round.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -596,7 +596,7 @@ class KalynaBlockCipher(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 2,
                 )
-                second_half = self.add_XOR_component(
+                second_half = self.add_xor_component(
                     [g_first.id, k_round.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -612,7 +612,7 @@ class KalynaBlockCipher(Cipher):
             else:
                 k_round_first_half = even_round_keys[k]["first_half"]
                 k_round_second_half = even_round_keys[k]["second_half"]
-                first_half = self.add_XOR_component(
+                first_half = self.add_xor_component(
                     [g_second.id, k_round_first_half.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -620,7 +620,7 @@ class KalynaBlockCipher(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 2,
                 )
-                second_half = self.add_XOR_component(
+                second_half = self.add_xor_component(
                     [g_first.id, k_round_second_half.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -642,7 +642,7 @@ class KalynaBlockCipher(Cipher):
         sboxes_components = []
         for i in range(self.CIPHER_BLOCK_SIZE // 16):
             sboxes_components.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [first_half.id],
                     [list(range((8 * i), (8 * i + 8)))],
                     self.SBOX_BIT_SIZE,
@@ -651,7 +651,7 @@ class KalynaBlockCipher(Cipher):
             )
         for i in range(self.CIPHER_BLOCK_SIZE // 16, self.CIPHER_BLOCK_SIZE // 8):
             sboxes_components.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [second_half.id],
                     [list(range((8 * i) - 64, (8 * i + 8) - 64))],
                     self.SBOX_BIT_SIZE,
@@ -679,7 +679,7 @@ class KalynaBlockCipher(Cipher):
 
         k_round_first_half = even_round_keys[self.NROUNDS]["first_half"]
         k_round_second_half = even_round_keys[self.NROUNDS]["second_half"]
-        first_half = self.add_MODADD_component(
+        first_half = self.add_modadd_component(
             [g_second.id, k_round_first_half.id],
             [
                 [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],
@@ -687,7 +687,7 @@ class KalynaBlockCipher(Cipher):
             ],
             self.CIPHER_BLOCK_SIZE // 2,
         )
-        second_half = self.add_MODADD_component(
+        second_half = self.add_modadd_component(
             [g_first.id, k_round_second_half.id],
             [
                 [j for j in range(self.CIPHER_BLOCK_SIZE // 2)],

--- a/claasp/ciphers/block_ciphers/kasumi_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/kasumi_block_cipher.py
@@ -161,7 +161,7 @@ class KasumiBlockCipher(Cipher):
 
         new_right_half_ids = []
         for i in range(6):
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [fos[i], right_half_ids[i]],
                 [list(range(half_word_distribution[i])), right_positions[i]],
                 half_word_distribution[i],
@@ -181,7 +181,7 @@ class KasumiBlockCipher(Cipher):
 
         new_left_half_ids = []
         for i in range(6):
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [fls[i], left_half_ids[i]],
                 [list(range(half_word_distribution[i])), left_positions[i]],
                 half_word_distribution[i],
@@ -204,30 +204,30 @@ class KasumiBlockCipher(Cipher):
         return configuration_number_of_rounds
 
     def fi_function1(self, ids, ki_id, ki_positions):
-        s9_1 = self.add_SBOX_component([ids[0], ids[1]], [list(range(7)), list(range(2))], 9, SBox9).id
+        s9_1 = self.add_sbox_component([ids[0], ids[1]], [list(range(7)), list(range(2))], 9, SBox9).id
 
         cst1 = self.add_constant_component(2, 0b00).id
 
-        xor1_1 = self.add_XOR_component([s9_1, cst1], [list(range(2)), list(range(2))], 2).id
-        xor1_2 = self.add_XOR_component([s9_1, ids[2]], [list(range(2, 9)), list(range(7))], 7).id
+        xor1_1 = self.add_xor_component([s9_1, cst1], [list(range(2)), list(range(2))], 2).id
+        xor1_2 = self.add_xor_component([s9_1, ids[2]], [list(range(2, 9)), list(range(7))], 7).id
 
-        s7_1 = self.add_SBOX_component([ids[2]], [list(range(7))], 7, SBox7).id
+        s7_1 = self.add_sbox_component([ids[2]], [list(range(7))], 7, SBox7).id
 
-        xor2 = self.add_XOR_component([s7_1, xor1_2], [list(range(7)), list(range(7))], 7).id
+        xor2 = self.add_xor_component([s7_1, xor1_2], [list(range(7)), list(range(7))], 7).id
 
-        xor3_1 = self.add_XOR_component([xor1_1, ki_id], [list(range(2)), ki_positions[7:9]], 2).id
-        xor3_2 = self.add_XOR_component([xor1_2, ki_id], [list(range(7)), ki_positions[9:16]], 7).id
+        xor3_1 = self.add_xor_component([xor1_1, ki_id], [list(range(2)), ki_positions[7:9]], 2).id
+        xor3_2 = self.add_xor_component([xor1_2, ki_id], [list(range(7)), ki_positions[9:16]], 7).id
 
-        xor4 = self.add_XOR_component([xor2, ki_id], [list(range(7)), ki_positions[:7]], 7).id
+        xor4 = self.add_xor_component([xor2, ki_id], [list(range(7)), ki_positions[:7]], 7).id
 
-        s9_2 = self.add_SBOX_component([xor3_1, xor3_2], [list(range(2)), list(range(7))], 9, SBox9).id
+        s9_2 = self.add_sbox_component([xor3_1, xor3_2], [list(range(2)), list(range(7))], 9, SBox9).id
 
-        xor5_1 = self.add_XOR_component([s9_2, cst1], [list(range(2)), list(range(2))], 2)
-        xor5_2 = self.add_XOR_component([s9_2, xor4], [list(range(2, 9)), list(range(7))], 7)
+        xor5_1 = self.add_xor_component([s9_2, cst1], [list(range(2)), list(range(2))], 2)
+        xor5_2 = self.add_xor_component([s9_2, xor4], [list(range(2, 9)), list(range(7))], 7)
         xor5_2_id = xor5_2.id
 
-        s7_2 = self.add_SBOX_component([xor4], [list(range(7))], 7, SBox7).id
-        xor6 = self.add_XOR_component([s7_2, xor5_2_id], [list(range(7)), list(range(7))], 7)
+        s7_2 = self.add_sbox_component([xor4], [list(range(7))], 7, SBox7).id
+        xor6 = self.add_xor_component([s7_2, xor5_2_id], [list(range(7)), list(range(7))], 7)
 
         return [xor6, xor5_1, xor5_2]
 
@@ -236,7 +236,7 @@ class KasumiBlockCipher(Cipher):
         xor1s = []
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            xor1_temp = self.add_XOR_component([ids[i], sub_key], [positions[i], list(range(start, end))], length)
+            xor1_temp = self.add_xor_component([ids[i], sub_key], [positions[i], list(range(start, end))], length)
             xor1s.append(xor1_temp.id)
             start = end
 
@@ -248,7 +248,7 @@ class KasumiBlockCipher(Cipher):
 
         xor2s = []
         for i, length in enumerate(half_half_word_distribution):
-            xor2_temp = self.add_XOR_component(
+            xor2_temp = self.add_xor_component(
                 [fis1[i].id, ids[i + 3]], [list(range(length)), positions[i + 3]], length
             )
             xor2s.append(xor2_temp.id)
@@ -259,7 +259,7 @@ class KasumiBlockCipher(Cipher):
         xor3s = []
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            xor3_temp = self.add_XOR_component(
+            xor3_temp = self.add_xor_component(
                 [ids[i + 3], sub_key], [positions[i + 3], subkey_size[start:end]], length
             )
             xor3s.append(xor3_temp.id)
@@ -273,7 +273,7 @@ class KasumiBlockCipher(Cipher):
 
         xor4s = []
         for i, length in enumerate(half_half_word_distribution):
-            xor4_temp = self.add_XOR_component(
+            xor4_temp = self.add_xor_component(
                 [fis2[i].id, xor2s[i]], [list(range(length)), list(range(length))], length
             )
             xor4s.append(xor4_temp.id)
@@ -284,7 +284,7 @@ class KasumiBlockCipher(Cipher):
         start = 0
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            xor5_temp = self.add_XOR_component(
+            xor5_temp = self.add_xor_component(
                 [xor2s[i], sub_key], [list(range(length)), sub_key_positions[start:end]], length
             )
             xor5s.append(xor5_temp.id)
@@ -297,7 +297,7 @@ class KasumiBlockCipher(Cipher):
 
         xor6s = []
         for i, length in enumerate(half_half_word_distribution):
-            xor6_temp = self.add_XOR_component(
+            xor6_temp = self.add_xor_component(
                 [fis3[i].id, xor4s[i]], [list(range(length)), list(range(length))], length
             )
             xor6s.append(xor6_temp.id)
@@ -310,7 +310,7 @@ class KasumiBlockCipher(Cipher):
         start = 0
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            and1_temp = self.add_AND_component([ids[i], sub_key], [positions[i], word_size[start:end]], length)
+            and1_temp = self.add_and_component([ids[i], sub_key], [positions[i], word_size[start:end]], length)
             and1s.append(and1_temp.id)
             start = end
 
@@ -324,7 +324,7 @@ class KasumiBlockCipher(Cipher):
         start = 0
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            xor1_temp = self.add_XOR_component([rot1, ids[i + 3]], [rot_size[start:end], positions[i + 3]], length)
+            xor1_temp = self.add_xor_component([rot1, ids[i + 3]], [rot_size[start:end], positions[i + 3]], length)
             xor1s.append(xor1_temp.id)
             start = end
 
@@ -334,7 +334,7 @@ class KasumiBlockCipher(Cipher):
         start = 0
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            or1_temp = self.add_OR_component([xor1s[i], sub_key], [list(range(length)), subkey_size[start:end]], length)
+            or1_temp = self.add_or_component([xor1s[i], sub_key], [list(range(length)), subkey_size[start:end]], length)
             or1s.append(or1_temp.id)
             start = end
 
@@ -345,7 +345,7 @@ class KasumiBlockCipher(Cipher):
         start = 0
         for i, length in enumerate(half_half_word_distribution):
             end = start + length
-            xor2_temp = self.add_XOR_component([rot2, ids[i]], [rot_size[start:end], positions[i]], length)
+            xor2_temp = self.add_xor_component([rot2, ids[i]], [rot_size[start:end], positions[i]], length)
             xor2s.append(xor2_temp.id)
             start = end
 
@@ -353,7 +353,7 @@ class KasumiBlockCipher(Cipher):
 
     def derived_key(self, key):
         cst = self.add_constant_component(128, 0x123456789ABCDEFFEDCBA9876543210).id
-        key_der = self.add_XOR_component(
+        key_der = self.add_xor_component(
             key[0] + [cst], [list(range(self.key_bit_size))] + [list(range(self.key_bit_size))], self.key_bit_size
         )
         return key_der.id

--- a/claasp/ciphers/block_ciphers/lblock_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/lblock_block_cipher.py
@@ -83,10 +83,10 @@ class LBlockBlockCipher(Cipher):
 
     def update_key(self, k, i):
         rot_k = self.add_rotate_component([k], [list(range(80))], 80, -29).id  #
-        s0 = self.add_SBOX_component([rot_k], [list(range(4))], 4, self.sboxes[9]).id  #
-        s1 = self.add_SBOX_component([rot_k], [list(range(4, 8))], 4, self.sboxes[8]).id  #
+        s0 = self.add_sbox_component([rot_k], [list(range(4))], 4, self.sboxes[9]).id  #
+        s1 = self.add_sbox_component([rot_k], [list(range(4, 8))], 4, self.sboxes[8]).id  #
         c0 = self.add_constant_component(5, i).id
-        xor0 = self.add_XOR_component([rot_k, c0], [[29, 30, 31, 32, 33], list(range(5))], 5).id  #
+        xor0 = self.add_xor_component([rot_k, c0], [[29, 30, 31, 32, 33], list(range(5))], 5).id  #
         updated_key = self.add_intermediate_output_component(
             [s0, s1, rot_k, xor0, rot_k],
             [list(range(4)), list(range(4)), list(range(8, 29)), list(range(5)), list(range(34, 80))],
@@ -98,15 +98,15 @@ class LBlockBlockCipher(Cipher):
     def round_function(self, x, k):
         word_pos = [1, 3, 0, 2, 5, 7, 4, 6]
         sb_order = [6, 4, 7, 5, 2, 0, 3, 1]
-        after_key_add = self.add_XOR_component([x, k], [list(range(32))] + [list(range(32))], 32).id
+        after_key_add = self.add_xor_component([x, k], [list(range(32))] + [list(range(32))], 32).id
         sb_outputs = [
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 [after_key_add], [list(range(word_pos[i] * 4, (word_pos[i] + 1) * 4))], 4, self.sboxes[sb_order[i]]
             ).id
             for i in range(8)
         ]
         right_word_rotated = self.add_rotate_component([x], [list(range(32, 64))], 32, -8).id
-        new_left_word = self.add_XOR_component(
+        new_left_word = self.add_xor_component(
             sb_outputs + [right_word_rotated], [list(range(4)) for i in range(8)] + [list(range(32))], 32
         ).id
         round_output = self.add_round_output_component([new_left_word, x], [list(range(32)), list(range(32))], 64).id

--- a/claasp/ciphers/block_ciphers/lea_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/lea_block_cipher.py
@@ -175,7 +175,7 @@ class LeaBlockCipher(Cipher):
             rot_j = self.add_rotate_component(
                 [delta_j.id], [get_ith_word(self.word_size, 0)], self.word_size, -(round_i + operation)
             )
-            mod_j = self.add_MODADD_component(
+            mod_j = self.add_modadd_component(
                 [key[operation].id] + [rot_j.id],
                 key[operation].input_bit_positions + rot_j.input_bit_positions,
                 self.word_size,
@@ -194,7 +194,7 @@ class LeaBlockCipher(Cipher):
             rot_j = self.add_rotate_component(
                 [delta_j.id], [get_ith_word(self.word_size, 0)], self.word_size, -(round_i + operation)
             )
-            mod_j = self.add_MODADD_component(
+            mod_j = self.add_modadd_component(
                 [key[operation].id] + [rot_j.id],
                 key[operation].input_bit_positions + rot_j.input_bit_positions,
                 self.word_size,
@@ -213,7 +213,7 @@ class LeaBlockCipher(Cipher):
             rot_j = self.add_rotate_component(
                 [delta_j.id], [get_ith_word(self.word_size, 0)], self.word_size, -(round_i + operation)
             )
-            mod_j = self.add_MODADD_component(
+            mod_j = self.add_modadd_component(
                 [key[new_j].id] + [rot_j.id], key[new_j].input_bit_positions + rot_j.input_bit_positions, self.word_size
             )
             rot_c = self.add_rotate_component(
@@ -244,18 +244,18 @@ class LeaBlockCipher(Cipher):
 
     def round_function(self, internal_state, round_key):
         def word_function(i0, i1, i2, i3, rot_value):
-            xor_w3_1 = self.add_XOR_component(
+            xor_w3_1 = self.add_xor_component(
                 [internal_state[i0].id] + [round_key[i1].id],
                 internal_state[i0].input_bit_positions + round_key[i1].input_bit_positions,
                 self.word_size,
             )
-            xor_w1_2 = self.add_XOR_component(
+            xor_w1_2 = self.add_xor_component(
                 [internal_state[i2].id] + [round_key[i3].id],
                 internal_state[i2].input_bit_positions + round_key[i3].input_bit_positions,
                 self.word_size,
             )
 
-            mod_1 = self.add_MODADD_component(
+            mod_1 = self.add_modadd_component(
                 [xor_w3_1.id] + [xor_w1_2.id],
                 [get_ith_word(self.word_size, 0)] + [get_ith_word(self.word_size, 0)],
                 self.word_size,

--- a/claasp/ciphers/block_ciphers/led_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/led_block_cipher.py
@@ -120,7 +120,7 @@ class LedBlockCipher(Cipher):
         constant = self.get_round_constant(round_number)
         const_id = self.add_constant_component(self.block_bit_size, constant).id
 
-        xor_id = self.add_XOR_component(
+        xor_id = self.add_xor_component(
             [*state.id, const_id],
             [*state.input_bit_positions, list(range(self.block_bit_size))],
             self.block_bit_size,
@@ -130,7 +130,7 @@ class LedBlockCipher(Cipher):
     def sub_cells(self, state):
         sbox_out_ids = []
         for i in range(16):
-            id_sbox = self.add_SBOX_component(state.id, [state.input_bit_positions[0][i * 4 : (i + 1) * 4]], 4, SBOX).id
+            id_sbox = self.add_sbox_component(state.id, [state.input_bit_positions[0][i * 4 : (i + 1) * 4]], 4, SBOX).id
             sbox_out_ids.append(id_sbox)
         return ComponentState(sbox_out_ids, [list(range(4))] * 16)
 
@@ -166,7 +166,7 @@ class LedBlockCipher(Cipher):
         return ComponentState(new_state, new_positions)
 
     def add_round_key(self, state, key):
-        xor_id = self.add_XOR_component(
+        xor_id = self.add_xor_component(
             [*state.id, *key.id], [*state.input_bit_positions, *key.input_bit_positions], self.block_bit_size
         ).id
 

--- a/claasp/ciphers/block_ciphers/lowmc_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/lowmc_block_cipher.py
@@ -277,12 +277,12 @@ class LowMCBlockCipher(Cipher):
     def add_round_constant(self, plaintext_id, round_number):
         constant_id = self.add_constant_component(self.block_bit_size, self.round_constants[round_number]).id
 
-        return self.add_XOR_component(
+        return self.add_xor_component(
             [plaintext_id, constant_id], [list(range(self.block_bit_size))] * 2, self.block_bit_size
         ).id
 
     def add_round_key(self, plaintext_id, rk_id):
-        return self.add_XOR_component(
+        return self.add_xor_component(
             [plaintext_id, rk_id], [list(range(self.block_bit_size))] * 2, self.block_bit_size
         ).id
 
@@ -419,7 +419,7 @@ class LowMCBlockCipher(Cipher):
         # m computations of 3 - bit sbox
         # remaining n - 3m bits remain the same
         for i in range(self.n_sbox):
-            sbox_output[i] = self.add_SBOX_component([plaintext_id], [list(range(3 * i, 3 * (i + 1)))], 3, self.sbox).id
+            sbox_output[i] = self.add_sbox_component([plaintext_id], [list(range(3 * i, 3 * (i + 1)))], 3, self.sbox).id
 
         return (
             sbox_output + [plaintext_id],

--- a/claasp/ciphers/block_ciphers/mantis_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/mantis_block_cipher.py
@@ -101,13 +101,13 @@ class MantisBlockCipher(Cipher):
         for i in range(16):
             data_id_list, data_bit_positions = extract_inputs(
                 [current_state], [list(range(64))], list(range(i * 4, (i + 1) * 4)))
-            sbox_output = self.add_SBOX_component(
+            sbox_output = self.add_sbox_component(
                 data_id_list, data_bit_positions, 4, MANTIS_SBOX)
             sbox_id_list.append(sbox_output.id)
             sbox_bit_positions.append(list(range(4)))
 
         zero_constant = self.add_constant_component(64, 0)
-        concatenated_state = self.add_XOR_component(
+        concatenated_state = self.add_xor_component(
             sbox_id_list + [zero_constant.id],
             sbox_bit_positions + [list(range(64))],
             64
@@ -117,7 +117,7 @@ class MantisBlockCipher(Cipher):
     def add_round_constant(self, sbox_id_list, sbox_bit_positions, round_idx):
         constant = self.add_constant_component(
             64, MANTIS_ROUND_CONSTANTS[round_idx])
-        constant_xor = self.add_XOR_component(
+        constant_xor = self.add_xor_component(
             sbox_id_list + [constant.id],
             sbox_bit_positions + [list(range(64))],
             64
@@ -129,7 +129,7 @@ class MantisBlockCipher(Cipher):
             [current_tweak], [list(range(64))], 64, TWEAK_PERMUTATION, 4
         ).id
 
-        tweakey = self.add_XOR_component(
+        tweakey = self.add_xor_component(
             [permuted_tweak, INPUT_KEY],
             [list(range(64)), list(range(64, 128))], 64
         )
@@ -166,7 +166,7 @@ class MantisBlockCipher(Cipher):
             mix_column_ids.append(mix_output.id)
 
         zero_constant = self.add_constant_component(64, 0)
-        concatenated_state = self.add_XOR_component(
+        concatenated_state = self.add_xor_component(
             mix_column_ids + [zero_constant.id],
             [list(range(column_size))
              for _ in range(num_columns)] + [list(range(64))],
@@ -199,17 +199,17 @@ class MantisBlockCipher(Cipher):
                 4
             ).id
         alpha_component = self.add_constant_component(64, MANTIS_ALPHA)
-        k1_xor_alpha = self.add_XOR_component(
+        k1_xor_alpha = self.add_xor_component(
             [INPUT_KEY, alpha_component.id],
             [list(range(64, 128)), list(range(64))],
             64
         )
-        tweakey = self.add_XOR_component(
+        tweakey = self.add_xor_component(
             [current_tweak, k1_xor_alpha.id],
             [list(range(64)), list(range(64))],
             64
         )
-        result = self.add_XOR_component(
+        result = self.add_xor_component(
             [current_state, tweakey.id],
             [list(range(64)), list(range(64))],
             64
@@ -219,7 +219,7 @@ class MantisBlockCipher(Cipher):
     def add_round_constant_direct(self, current_state, round_idx):
         constant = self.add_constant_component(
             64, MANTIS_ROUND_CONSTANTS[round_idx])
-        constant_xor = self.add_XOR_component(
+        constant_xor = self.add_xor_component(
             [current_state, constant.id],
             [list(range(64)), list(range(64))],
             64
@@ -227,11 +227,11 @@ class MantisBlockCipher(Cipher):
         return constant_xor.id
 
     def add_pre_whitening(self):
-        k1_xor_tweak = self.add_XOR_component(
+        k1_xor_tweak = self.add_xor_component(
             [INPUT_KEY, INPUT_TWEAK], [list(range(64, 128)), list(range(64))], 64)
-        m_xor_k0 = self.add_XOR_component([INPUT_PLAINTEXT, INPUT_KEY], [
+        m_xor_k0 = self.add_xor_component([INPUT_PLAINTEXT, INPUT_KEY], [
                                           list(range(64)), list(range(64))], 64)
-        pre_whitening = self.add_XOR_component([m_xor_k0.id, k1_xor_tweak.id], [
+        pre_whitening = self.add_xor_component([m_xor_k0.id, k1_xor_tweak.id], [
                                                list(range(64)), list(range(64))], 64)
         return pre_whitening.id
 
@@ -244,7 +244,7 @@ class MantisBlockCipher(Cipher):
             for i in range(16):
                 data_id_list, data_bit_positions = extract_inputs(
                     [current_state], [list(range(64))], list(range(i * 4, (i + 1) * 4)))
-                sbox_output = self.add_SBOX_component(
+                sbox_output = self.add_sbox_component(
                     data_id_list, data_bit_positions, 4, MANTIS_SBOX)
                 sbox_id_list.append(sbox_output.id)
                 sbox_bit_positions.append(list(range(4)))
@@ -253,7 +253,7 @@ class MantisBlockCipher(Cipher):
                 sbox_id_list, sbox_bit_positions, round_idx)
 
             tweakey_id, current_tweak = self.add_tweakey(current_tweak)
-            current_state = self.add_XOR_component(
+            current_state = self.add_xor_component(
                 [current_state, tweakey_id],
                 [list(range(64)), list(range(64))], 64
             ).id
@@ -311,32 +311,32 @@ class MantisBlockCipher(Cipher):
         k0_rot1 = self.add_rotate_component(
             [INPUT_KEY], [list(range(64))], 64, 1
         )
-        k0_sh63 = self.add_SHIFT_component(
+        k0_sh63 = self.add_shift_component(
             [INPUT_KEY], [list(range(64))], 64, 63
         )
-        k0_prime = self.add_XOR_component(
+        k0_prime = self.add_xor_component(
             [k0_rot1.id, k0_sh63.id],
             [list(range(64)), list(range(64))],
             64
         )
         alpha_component = self.add_constant_component(64, MANTIS_ALPHA)
-        k1_xor_alpha = self.add_XOR_component(
+        k1_xor_alpha = self.add_xor_component(
             [INPUT_KEY, alpha_component.id],
             [list(range(64, 128)), list(range(64))],
             64
         )
 
-        k1_alpha_xor_tweak = self.add_XOR_component(
+        k1_alpha_xor_tweak = self.add_xor_component(
             [k1_xor_alpha.id, current_tweak],
             [list(range(64)), list(range(64))],
             64
         )
-        state_xor_tweakey = self.add_XOR_component(
+        state_xor_tweakey = self.add_xor_component(
             [current_state, k1_alpha_xor_tweak.id],
             [list(range(64)), list(range(64))],
             64
         )
-        post_whitening = self.add_XOR_component(
+        post_whitening = self.add_xor_component(
             [state_xor_tweakey.id, k0_prime.id],
             [list(range(64)), list(range(64))],
             64

--- a/claasp/ciphers/block_ciphers/midori_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/midori_block_cipher.py
@@ -241,7 +241,7 @@ class MidoriBlockCipher(Cipher):
         self.add_round()
 
         if self.block_bit_size == 64:
-            WK_id = self.add_XOR_component([key_id], [list(range(key_bit_size))], 64).id
+            WK_id = self.add_xor_component([key_id], [list(range(key_bit_size))], 64).id
         else:
             WK_id = key_id
 
@@ -268,7 +268,7 @@ class MidoriBlockCipher(Cipher):
         self.add_cipher_output_component(data[0], data[1], self.block_bit_size)
 
     def key_add(self, data, round_key_id):
-        new_data_id = self.add_XOR_component(
+        new_data_id = self.add_xor_component(
             data[0] + [round_key_id], data[1] + [list(range(self.block_bit_size))], self.block_bit_size
         ).id
 
@@ -294,12 +294,12 @@ class MidoriBlockCipher(Cipher):
         round_constant_id = self.add_constant_component(self.block_bit_size, round_constant_value).id
 
         if self.block_bit_size == 64:
-            xor_id = self.add_XOR_component(
+            xor_id = self.add_xor_component(
                 [key_id, round_constant_id], [list(range((i % 2) * 64, ((i % 2) + 1) * 64)), list(range(64))], 64
             ).id
 
         else:
-            xor_id = self.add_XOR_component([key_id, round_constant_id], [list(range(128))] * 2, 128).id
+            xor_id = self.add_xor_component([key_id, round_constant_id], [list(range(128))] * 2, 128).id
 
         return xor_id
 
@@ -316,7 +316,7 @@ class MidoriBlockCipher(Cipher):
         if self.block_bit_size == 64:
             for i in range(16):
                 data_id_list, data_bit_positions = extract_inputs(*data, list(range(i * 4, (i + 1) * 4)))
-                new_data_id_list[i] = self.add_SBOX_component(data_id_list, data_bit_positions, 4, sbox[0]).id
+                new_data_id_list[i] = self.add_sbox_component(data_id_list, data_bit_positions, 4, sbox[0]).id
 
         else:
             for i in range(16):
@@ -328,8 +328,8 @@ class MidoriBlockCipher(Cipher):
                     data_id_list, data_bit_positions, self.word_size, p
                 ).id
 
-                sbox_high_output = self.add_SBOX_component([permutated_data_word_id], [list(range(4))], 4, sbox[1]).id
-                sbox_low_output = self.add_SBOX_component([permutated_data_word_id], [list(range(4, 8))], 4, sbox[1]).id
+                sbox_high_output = self.add_sbox_component([permutated_data_word_id], [list(range(4))], 4, sbox[1]).id
+                sbox_low_output = self.add_sbox_component([permutated_data_word_id], [list(range(4, 8))], 4, sbox[1]).id
 
                 perm = [inverse_sub_permutation[i % 4].index(j) for j in range(8)]
                 new_data_id_list[i] = self.add_permutation_component(

--- a/claasp/ciphers/block_ciphers/msx_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/msx_block_cipher.py
@@ -136,11 +136,11 @@ class MSXBlockCipher(Cipher):
         ]
         Cc = [self._const32(v) for v in C]
 
-        self.add_MODADD_component(k[1].id + k[0].id, k[1].input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
+        self.add_modadd_component(k[1].id + k[0].id, k[1].input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
         t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-        self.add_MODADD_component(t.id + k[3].id, t.input_bit_positions + k[3].input_bit_positions, self.word_size, self.mod32)
+        self.add_modadd_component(t.id + k[3].id, t.input_bit_positions + k[3].input_bit_positions, self.word_size, self.mod32)
         t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-        self.add_XOR_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
+        self.add_xor_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
         st0 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         st = [None] * 12
@@ -150,7 +150,7 @@ class MSXBlockCipher(Cipher):
             (7, k[0], 7), (8, k[2], 8), (9, k[1], 9), (10, k[2], 10), (11, k[3], 11)
         ]
         for idx, kw, ci in assign:
-            self.add_XOR_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
+            self.add_xor_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
             st[idx] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
         return st
 
@@ -172,7 +172,7 @@ class MSXBlockCipher(Cipher):
         for rot, dst in zip([1, 2, 3, 4, 5], dsts):
             self.add_rotate_component(new_st[dst].id, new_st[dst].input_bit_positions, self.word_size, -rot)
             r = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(r.id + tmp.id, r.input_bit_positions + tmp.input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(r.id + tmp.id, r.input_bit_positions + tmp.input_bit_positions, self.word_size, self.mod32)
             new_st[dst] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
         return new_st
 
@@ -188,11 +188,11 @@ class MSXBlockCipher(Cipher):
 
         if self.key_bit_size == 128:
             k = self._key_words_from_input(4)
-            self.add_MODADD_component(k[2].id + k[3].id, k[2].input_bit_positions + k[3].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(k[2].id + k[3].id, k[2].input_bit_positions + k[3].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(t.id + k[0].id, t.input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(t.id + k[0].id, t.input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_XOR_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
+            self.add_xor_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
             st[0] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
             assign = [
                 (1, k[1], 1), (2, k[0], 2), (3, k[3], 3), (4, k[0], 4), (5, k[2], 5), (6, k[3], 6),
@@ -202,25 +202,25 @@ class MSXBlockCipher(Cipher):
                 (22, k[3], 22), (23, k[1], 23),
             ]
             for idx, kw, ci in assign:
-                self.add_XOR_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
+                self.add_xor_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
                 st[idx] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
         elif self.key_bit_size == 256:
             k = self._key_words_from_input(8)
-            self.add_MODADD_component(k[2].id + k[1].id, k[2].input_bit_positions + k[1].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(k[2].id + k[1].id, k[2].input_bit_positions + k[1].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(t.id + k[5].id, t.input_bit_positions + k[5].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(t.id + k[5].id, t.input_bit_positions + k[5].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(t.id + k[4].id, t.input_bit_positions + k[4].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(t.id + k[4].id, t.input_bit_positions + k[4].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_XOR_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
+            self.add_xor_component(t.id + Cc[0].id, t.input_bit_positions + Cc[0].input_bit_positions, self.word_size)
             st[0] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(k[3].id + k[7].id, k[3].input_bit_positions + k[7].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(k[3].id + k[7].id, k[3].input_bit_positions + k[7].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(t.id + k[6].id, t.input_bit_positions + k[6].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(t.id + k[6].id, t.input_bit_positions + k[6].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(t.id + k[0].id, t.input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(t.id + k[0].id, t.input_bit_positions + k[0].input_bit_positions, self.word_size, self.mod32)
             t = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_XOR_component(t.id + Cc[1].id, t.input_bit_positions + Cc[1].input_bit_positions, self.word_size)
+            self.add_xor_component(t.id + Cc[1].id, t.input_bit_positions + Cc[1].input_bit_positions, self.word_size)
             st[1] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
             assign = [
                 (2, k[0], 2), (3, k[6], 3), (4, k[7], 4), (5, k[4], 5), (6, k[2], 6), (7, k[3], 7),
@@ -229,7 +229,7 @@ class MSXBlockCipher(Cipher):
                 (20, k[3], 20), (21, k[4], 21), (22, k[5], 22), (23, k[7], 23),
             ]
             for idx, kw, ci in assign:
-                self.add_XOR_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
+                self.add_xor_component(kw.id + Cc[ci].id, kw.input_bit_positions + Cc[ci].input_bit_positions, self.word_size)
                 st[idx] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
         else:
             raise AssertionError("Unsupported key size for MSX-128")
@@ -255,7 +255,7 @@ class MSXBlockCipher(Cipher):
         for rot, dst in zip(range(1, 10), dsts):
             self.add_rotate_component(new_st[dst].id, new_st[dst].input_bit_positions, self.word_size, -rot)
             r = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
-            self.add_MODADD_component(r.id + tmp.id, r.input_bit_positions + tmp.input_bit_positions, self.word_size, self.mod32)
+            self.add_modadd_component(r.id + tmp.id, r.input_bit_positions + tmp.input_bit_positions, self.word_size, self.mod32)
             new_st[dst] = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
         return new_st
 
@@ -286,7 +286,7 @@ class MSXBlockCipher(Cipher):
             rk_group = next_rk_group()
             # MSX-64 Feistel applies F to W1 (offset 32) exactly as the original code applied F to L.
             F_out = self.round_function(W1, rk_group, c_i)
-            self.add_XOR_component(W0.id + F_out.id, W0.input_bit_positions + F_out.input_bit_positions, self.word_size)
+            self.add_xor_component(W0.id + F_out.id, W0.input_bit_positions + F_out.input_bit_positions, self.word_size)
             W0_next = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
             
             W0_new = W1
@@ -342,11 +342,11 @@ class MSXBlockCipher(Cipher):
 
             # F takes W1 XORs into W0, and then F takes W3 XORs into W2
             F1 = self.round_function(W1, rk_group1, c_i)
-            self.add_XOR_component(W0.id + F1.id, W0.input_bit_positions + F1.input_bit_positions, self.word_size)
+            self.add_xor_component(W0.id + F1.id, W0.input_bit_positions + F1.input_bit_positions, self.word_size)
             W0_next = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
             
             F2 = self.round_function(W3, rk_group2, c_i)
-            self.add_XOR_component(W2.id + F2.id, W2.input_bit_positions + F2.input_bit_positions, self.word_size)
+            self.add_xor_component(W2.id + F2.id, W2.input_bit_positions + F2.input_bit_positions, self.word_size)
             W2_next = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
             W0_new = W3
@@ -399,25 +399,25 @@ class MSXBlockCipher(Cipher):
             zero16.input_bit_positions + x_high16.input_bit_positions,
         )
 
-        self.add_MODADD_component(x0_32.id + rk_group[0].id, x0_32.input_bit_positions + rk_group[0].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(x0_32.id + rk_group[0].id, x0_32.input_bit_positions + rk_group[0].input_bit_positions, n, self.mod32)
         t0 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_MODADD_component(x1_32.id + rk_group[1].id, x1_32.input_bit_positions + rk_group[1].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(x1_32.id + rk_group[1].id, x1_32.input_bit_positions + rk_group[1].input_bit_positions, n, self.mod32)
         t1 = ComponentState([self.get_current_component_id()], [list(range(n))])
 
-        self.add_MODMUL_component(t0.id + t1.id, t0.input_bit_positions + t1.input_bit_positions, n, self.mod32)
+        self.add_modmul_component(t0.id + t1.id, t0.input_bit_positions + t1.input_bit_positions, n, self.mod32)
         w0 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_MODADD_component(w0.id + rk_group[2].id, w0.input_bit_positions + rk_group[2].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(w0.id + rk_group[2].id, w0.input_bit_positions + rk_group[2].input_bit_positions, n, self.mod32)
         w0 = ComponentState([self.get_current_component_id()], [list(range(n))])
 
-        self.add_MODADD_component(x0_32.id + rk_group[3].id, x0_32.input_bit_positions + rk_group[3].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(x0_32.id + rk_group[3].id, x0_32.input_bit_positions + rk_group[3].input_bit_positions, n, self.mod32)
         u0 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_MODADD_component(x1_32.id + rk_group[4].id, x1_32.input_bit_positions + rk_group[4].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(x1_32.id + rk_group[4].id, x1_32.input_bit_positions + rk_group[4].input_bit_positions, n, self.mod32)
         u1 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_MODMUL_component(u0.id + u1.id, u0.input_bit_positions + u1.input_bit_positions, n, self.mod32)
+        self.add_modmul_component(u0.id + u1.id, u0.input_bit_positions + u1.input_bit_positions, n, self.mod32)
         w1 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_MODADD_component(w1.id + rk_group[5].id, w1.input_bit_positions + rk_group[5].input_bit_positions, n, self.mod32)
+        self.add_modadd_component(w1.id + rk_group[5].id, w1.input_bit_positions + rk_group[5].input_bit_positions, n, self.mod32)
         w1 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_XOR_component(w1.id + c.id, w1.input_bit_positions + c.input_bit_positions, n)
+        self.add_xor_component(w1.id + c.id, w1.input_bit_positions + c.input_bit_positions, n)
         w1 = ComponentState([self.get_current_component_id()], [list(range(n))])
 
         hi16_w0 = ComponentState(w0.id, [[i for i in range(0, 16)]])
@@ -433,9 +433,9 @@ class MSXBlockCipher(Cipher):
         self.add_rotate_component(y_orig.id, y_orig.input_bit_positions, n, -21)
         ry21 = ComponentState([self.get_current_component_id()], [list(range(n))])
 
-        self.add_XOR_component(y_orig.id + ry13.id, y_orig.input_bit_positions + ry13.input_bit_positions, n)
+        self.add_xor_component(y_orig.id + ry13.id, y_orig.input_bit_positions + ry13.input_bit_positions, n)
         y_step1 = ComponentState([self.get_current_component_id()], [list(range(n))])
-        self.add_XOR_component(y_step1.id + ry21.id, y_step1.input_bit_positions + ry21.input_bit_positions, n)
+        self.add_xor_component(y_step1.id + ry21.id, y_step1.input_bit_positions + ry21.input_bit_positions, n)
         y = ComponentState([self.get_current_component_id()], [list(range(n))])
         return y
 

--- a/claasp/ciphers/block_ciphers/present_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/present_block_cipher.py
@@ -176,7 +176,7 @@ class PresentBlockCipher(Cipher):
 
     def add_round_key(self, data, key):
         key_id_list, key_bit_positions = extract_inputs(*key, list(range(self.block_bit_size)))
-        new_data_id = self.add_XOR_component(data[0] + key_id_list, data[1] + key_bit_positions, self.block_bit_size).id
+        new_data_id = self.add_xor_component(data[0] + key_id_list, data[1] + key_bit_positions, self.block_bit_size).id
 
         return [new_data_id], [list(range(self.block_bit_size))]
 
@@ -189,24 +189,24 @@ class PresentBlockCipher(Cipher):
         sbox_output = [""] * 16
 
         for i in range(16):
-            sbox_output[i] = self.add_SBOX_component(data[0], [data[1][0][i * 4 : (i + 1) * 4]], 4, sbox).id
+            sbox_output[i] = self.add_sbox_component(data[0], [data[1][0][i * 4 : (i + 1) * 4]], 4, sbox).id
 
         return sbox_output, [list(range(4))] * 16
 
     def update_key_register(self, key, r):
         rot = self.add_rotate_component(key[0], key[1], self.key_bit_size, -61).id
 
-        sbox_1 = self.add_SBOX_component([rot], [list(range(4))], 4, sbox).id
+        sbox_1 = self.add_sbox_component([rot], [list(range(4))], 4, sbox).id
 
         constant_id = self.add_constant_component(8, r).id
 
         if self.key_bit_size == 80:
-            xor = self.add_XOR_component([rot, constant_id], [list(range(60, 65)), list(range(3, 8))], 5).id
+            xor = self.add_xor_component([rot, constant_id], [list(range(60, 65)), list(range(3, 8))], 5).id
             return [sbox_1, rot, xor, rot], [list(range(4)), list(range(4, 60)), list(range(5)), list(range(65, 80))]
 
         if self.key_bit_size == 128:
-            xor = self.add_XOR_component([rot, constant_id], [list(range(61, 66)), list(range(3, 8))], 5).id
-            sbox_2 = self.add_SBOX_component([rot], [list(range(4, 8))], 4, sbox).id
+            xor = self.add_xor_component([rot, constant_id], [list(range(61, 66)), list(range(3, 8))], 5).id
+            sbox_2 = self.add_sbox_component([rot], [list(range(4, 8))], 4, sbox).id
             return [sbox_1, sbox_2, rot, xor, rot], [
                 list(range(4)),
                 list(range(4)),

--- a/claasp/ciphers/block_ciphers/prince_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/prince_block_cipher.py
@@ -116,7 +116,7 @@ class PrinceBlockCipher(Cipher):
 
             for i in range(16):
                 sbox_layer.append(
-                    self.add_SBOX_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox)
+                    self.add_sbox_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox)
                 )
 
             input_ids = [c.id for c in sbox_layer]
@@ -127,11 +127,11 @@ class PrinceBlockCipher(Cipher):
             )
             current_state = after_shift_row.id
             round_constant = self.add_constant_component(64, round_constants[round_idx])
-            current_state = self.add_XOR_component(
+            current_state = self.add_xor_component(
                 [current_state, round_constant.id], [list(range(64)), list(range(64))], 64
             ).id
 
-            round_key_xor = self.add_XOR_component(
+            round_key_xor = self.add_xor_component(
                 [current_state, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
             )
             current_state = round_key_xor.id
@@ -141,11 +141,11 @@ class PrinceBlockCipher(Cipher):
 
     def prince_core(self, xor_initial, number_of_rounds):
         round_constant_0 = self.add_constant_component(64, round_constants[0])
-        round_constant_xor_key_1 = self.add_XOR_component(
+        round_constant_xor_key_1 = self.add_xor_component(
             [round_constant_0.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
         ).id
 
-        current_state = self.add_XOR_component(
+        current_state = self.add_xor_component(
             [xor_initial, round_constant_xor_key_1], [list(range(64)), list(range(64))], 64
         )
 
@@ -154,7 +154,7 @@ class PrinceBlockCipher(Cipher):
 
         sboxes = []
         for i in range(16):
-            sboxes.append(self.add_SBOX_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox))
+            sboxes.append(self.add_sbox_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox))
         input_ids = [sbox_layer.id for sbox_layer in sboxes]
         input_bit_positions = [list(range(4)) for i in range(16)]
         current_state = self.add_linear_layer_component(input_ids, input_bit_positions, 64, get_m_prime())
@@ -162,7 +162,7 @@ class PrinceBlockCipher(Cipher):
         sboxes = []
         for i in range(16):
             sboxes.append(
-                self.add_SBOX_component([current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox)
+                self.add_sbox_component([current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox)
             )
 
         input_ids = [sbox_layer.id for sbox_layer in sboxes]
@@ -172,11 +172,11 @@ class PrinceBlockCipher(Cipher):
 
         round_constant_11 = self.add_constant_component(64, round_constants[11])
 
-        constant_xor_key1 = self.add_XOR_component(
+        constant_xor_key1 = self.add_xor_component(
             [round_constant_11.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
         )
 
-        final_xor = self.add_XOR_component(
+        final_xor = self.add_xor_component(
             input_ids + [constant_xor_key1.id], input_bit_positions + [list(range(64))], 64
         )
 
@@ -184,28 +184,28 @@ class PrinceBlockCipher(Cipher):
 
     def pre_whitening(self):
         self.add_round()
-        return self.add_XOR_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(64)), list(range(64))], 64).id
+        return self.add_xor_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(64)), list(range(64))], 64).id
 
     def get_k0_prime(self, key_component_id):
         k0_rot = self.add_rotate_component([key_component_id], [list(range(64))], 64, 1).id
-        k0_shift = self.add_SHIFT_component([key_component_id], [list(range(64))], 64, 63).id
+        k0_shift = self.add_shift_component([key_component_id], [list(range(64))], 64, 63).id
 
-        k0_prime = self.add_XOR_component([k0_rot, k0_shift], [list(range(64)), list(range(64))], 64).id
+        k0_prime = self.add_xor_component([k0_rot, k0_shift], [list(range(64)), list(range(64))], 64).id
 
         return k0_prime
 
     def pos_whitening(self, final_xor):
         k0_prime = self.get_k0_prime(INPUT_KEY)
-        return self.add_XOR_component([final_xor.id, k0_prime], [list(range(64)), list(range(64))], 64)
+        return self.add_xor_component([final_xor.id, k0_prime], [list(range(64)), list(range(64))], 64)
 
     def get_last_rounds(self, number_of_rounds, input_ids, input_bit_positions):
         for round_idx in range(number_of_rounds // 2, (number_of_rounds // 2 - 1) + number_of_rounds // 2):
             self.add_round()
             round_constant_0 = self.add_constant_component(64, round_constants[round_idx])
-            constant_xor_key1 = self.add_XOR_component(
+            constant_xor_key1 = self.add_xor_component(
                 [round_constant_0.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
             )
-            current_state = self.add_XOR_component(
+            current_state = self.add_xor_component(
                 input_ids + [constant_xor_key1.id], input_bit_positions + [list(range(64))], 64
             )
 
@@ -218,7 +218,7 @@ class PrinceBlockCipher(Cipher):
             sbox_layer = []
             for i in range(16):
                 sbox_layer.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox
                     )
                 )

--- a/claasp/ciphers/block_ciphers/prince_v2_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/prince_v2_block_cipher.py
@@ -117,7 +117,7 @@ class PrinceV2BlockCipher(Cipher):
 
             for i in range(16):
                 sbox_layer.append(
-                    self.add_SBOX_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox)
+                    self.add_sbox_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox)
                 )
 
             input_ids = [c.id for c in sbox_layer]
@@ -128,16 +128,16 @@ class PrinceV2BlockCipher(Cipher):
             )
             current_state = after_shift_row.id
             round_constant = self.add_constant_component(64, round_constants[round_idx])
-            current_state = self.add_XOR_component(
+            current_state = self.add_xor_component(
                 [current_state, round_constant.id], [list(range(64)), list(range(64))], 64
             ).id
 
             if round_idx % 2 == 1:
-                round_key_xor = self.add_XOR_component(
+                round_key_xor = self.add_xor_component(
                     [current_state, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
                 )
             else:
-                round_key_xor = self.add_XOR_component(
+                round_key_xor = self.add_xor_component(
                     [current_state, INPUT_KEY], [list(range(64)), list(range(64))], 64
                 )
             current_state = round_key_xor.id
@@ -147,11 +147,11 @@ class PrinceV2BlockCipher(Cipher):
 
     def prince_core(self, xor_initial, number_of_rounds):
         round_constant_0 = self.add_constant_component(64, round_constants[0])
-        round_constant_xor_key_1 = self.add_XOR_component(
+        round_constant_xor_key_1 = self.add_xor_component(
             [round_constant_0.id, INPUT_KEY], [list(range(64)), list(range(64))], 64
         ).id
 
-        current_state = self.add_XOR_component(
+        current_state = self.add_xor_component(
             [INPUT_PLAINTEXT, round_constant_xor_key_1], [list(range(64)), list(range(64))], 64
         )
 
@@ -160,35 +160,35 @@ class PrinceV2BlockCipher(Cipher):
 
         sboxes = []
         for i in range(16):
-            sboxes.append(self.add_SBOX_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox))
+            sboxes.append(self.add_sbox_component([current_state], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, sbox))
         input_ids = [sbox_layer.id for sbox_layer in sboxes]
         input_ids2 = input_ids + [INPUT_KEY]
         input_bit_positions = [list(range(4)) for i in range(16)]
         input_bit_positions2 = input_bit_positions + [list(range(64))]
-        current_state = self.add_XOR_component(input_ids2, input_bit_positions2, 64)
+        current_state = self.add_xor_component(input_ids2, input_bit_positions2, 64)
         current_state = self.add_linear_layer_component([current_state.id], [list(range(64))], 64, get_m_prime())
-        current_state = self.add_XOR_component(
+        current_state = self.add_xor_component(
             [current_state.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
         )
         round_constant_11 = self.add_constant_component(64, round_constants[11])
-        current_state = self.add_XOR_component(
+        current_state = self.add_xor_component(
             [current_state.id, round_constant_11.id], [list(range(64)), list(range(64))], 64
         )
         sboxes = []
         for i in range(16):
             sboxes.append(
-                self.add_SBOX_component([current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox)
+                self.add_sbox_component([current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox)
             )
         input_ids = [sbox_layer.id for sbox_layer in sboxes]
         input_bit_positions = [list(range(4)) for i in range(16)]
         input_ids, input_bit_positions = self.get_last_rounds(number_of_rounds, input_ids, input_bit_positions)
         round_constant_11 = self.add_constant_component(64, round_constants[11])
 
-        constant_xor_key1 = self.add_XOR_component(
+        constant_xor_key1 = self.add_xor_component(
             [round_constant_11.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
         )
 
-        final_xor = self.add_XOR_component(
+        final_xor = self.add_xor_component(
             input_ids + [constant_xor_key1.id], input_bit_positions + [list(range(64))], 64
         )
 
@@ -196,24 +196,24 @@ class PrinceV2BlockCipher(Cipher):
 
     def pre_whitening(self):
         self.add_round()
-        return self.add_XOR_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(64)), list(range(64))], 64).id
+        return self.add_xor_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(64)), list(range(64))], 64).id
 
     def pos_whitening(self, final_xor):
-        return self.add_XOR_component([final_xor.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64)
+        return self.add_xor_component([final_xor.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64)
 
     def get_last_rounds(self, number_of_rounds, input_ids, input_bit_positions):
         for round_idx in range(number_of_rounds // 2, (number_of_rounds // 2 - 1) + number_of_rounds // 2):
             self.add_round()
             round_constant_0 = self.add_constant_component(64, round_constants[round_idx])
             if round_idx % 2 == 1:  # Check if the round index is odd
-                constant_xor_key1 = self.add_XOR_component(
+                constant_xor_key1 = self.add_xor_component(
                     [round_constant_0.id, INPUT_KEY], [list(range(64)), list(range(64, 128))], 64
                 )
             else:  # If the round index is even
-                constant_xor_key1 = self.add_XOR_component(
+                constant_xor_key1 = self.add_xor_component(
                     [round_constant_0.id, INPUT_KEY], [list(range(64)), list(range(64))], 64
                 )
-            current_state = self.add_XOR_component(
+            current_state = self.add_xor_component(
                 input_ids + [constant_xor_key1.id], input_bit_positions + [list(range(64))], 64
             )
 
@@ -226,7 +226,7 @@ class PrinceV2BlockCipher(Cipher):
             sbox_layer = []
             for i in range(16):
                 sbox_layer.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [current_state.id], [[i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]], 4, inverse_sbox
                     )
                 )

--- a/claasp/ciphers/block_ciphers/qarmav2_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/qarmav2_block_cipher.py
@@ -531,14 +531,14 @@ class QARMAv2BlockCipher(Cipher):
     def state_masking(self, id_links, bit_positions):
         masked_state = []
         for id_link, bit_position in zip(id_links, bit_positions):
-            masked_state.append(self.add_XOR_component(id_link, bit_position, len(bit_position[0])).id)
+            masked_state.append(self.add_xor_component(id_link, bit_position, len(bit_position[0])).id)
 
         return masked_state
 
     def state_sboxing(self, id_links, bit_positions, sbox):
         sboxed_state = []
         for id_link, bit_position in zip(id_links, bit_positions):
-            sboxed_state.append(self.add_SBOX_component(id_link, bit_position, self.word_size, sbox).id)
+            sboxed_state.append(self.add_sbox_component(id_link, bit_position, self.word_size, sbox).id)
 
         return sboxed_state
 
@@ -565,7 +565,7 @@ class QARMAv2BlockCipher(Cipher):
         if self.number_of_layers == 2:
             key_state[0] = [
                 [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         key_state[0][0] + [alpha[0], alpha[1]],
                         key_state[0][1] + [list(range(self.layer_block_size)), list(range(self.layer_block_size))],
                         self.key_block_size,
@@ -575,7 +575,7 @@ class QARMAv2BlockCipher(Cipher):
             ]
             key_state[1] = [
                 [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         key_state[1][0] + [beta[0], beta[1]],
                         key_state[1][1] + [list(range(self.layer_block_size)), list(range(self.layer_block_size))],
                         self.key_block_size,
@@ -586,7 +586,7 @@ class QARMAv2BlockCipher(Cipher):
         else:
             key_state[0] = [
                 [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         key_state[0][0] + [alpha[0]],
                         key_state[0][1] + [list(range(self.layer_block_size))],
                         self.key_block_size,
@@ -596,7 +596,7 @@ class QARMAv2BlockCipher(Cipher):
             ]
             key_state[1] = [
                 [
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         key_state[1][0] + [beta[0]],
                         key_state[1][1] + [list(range(self.layer_block_size))],
                         self.key_block_size,
@@ -624,42 +624,42 @@ class QARMAv2BlockCipher(Cipher):
     # --------------------------------------------------------------------------------#
 
     def update_single_constant(self, constant):
-        spill = self.add_SHIFT_component(
+        spill = self.add_shift_component(
             [constant], [list(range(self.layer_block_size))], self.layer_block_size, 51
         )
-        tmp_0 = self.add_SHIFT_component(
+        tmp_0 = self.add_shift_component(
             [constant], [list(range(self.layer_block_size))], self.layer_block_size, -13
         )
-        tmp_1 = self.add_SHIFT_component(
+        tmp_1 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -50
         )
-        tmp_2 = self.add_SHIFT_component(
+        tmp_2 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -33
         )
-        tmp_3 = self.add_SHIFT_component(
+        tmp_3 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -19
         )
-        tmp = self.add_XOR_component(
+        tmp = self.add_xor_component(
             [tmp_0.id, tmp_1.id, tmp_2.id, tmp_3.id, spill.id],
             [list(range(self.layer_block_size)) for j in range(5)],
             self.layer_block_size,
         )
-        spill = self.add_SHIFT_component(
+        spill = self.add_shift_component(
             [tmp.id], [list(range(self.layer_block_size))], self.layer_block_size, 54
         )
-        tmp_0 = self.add_SHIFT_component(
+        tmp_0 = self.add_shift_component(
             [tmp.id], [list(range(self.layer_block_size))], self.layer_block_size, -10
         )
-        tmp_1 = self.add_SHIFT_component(
+        tmp_1 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -50
         )
-        tmp_2 = self.add_SHIFT_component(
+        tmp_2 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -33
         )
-        tmp_3 = self.add_SHIFT_component(
+        tmp_3 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -19
         )
-        tmp = self.add_XOR_component(
+        tmp = self.add_xor_component(
             [tmp_0.id, tmp_1.id, tmp_2.id, tmp_3.id, spill.id],
             [list(range(self.layer_block_size)) for j in range(5)],
             self.layer_block_size,
@@ -668,10 +668,10 @@ class QARMAv2BlockCipher(Cipher):
 
     def o_function(self, key):
         key_rot_0 = self.add_rotate_component(key[0][0], key[0][1], self.key_block_size, 1)
-        key_shift_0 = self.add_SHIFT_component(key[0][0], key[0][1], self.key_block_size, self.key_block_size - 1)
+        key_shift_0 = self.add_shift_component(key[0][0], key[0][1], self.key_block_size, self.key_block_size - 1)
         key_1 = [
             [
-                self.add_XOR_component(
+                self.add_xor_component(
                     [key_rot_0.id, key_shift_0.id],
                     [list(range(self.key_block_size)), list(range(self.key_block_size))],
                     self.key_block_size,
@@ -680,11 +680,11 @@ class QARMAv2BlockCipher(Cipher):
             [list(range(self.key_block_size))],
         ]
 
-        key_lshift_1 = self.add_SHIFT_component(key[1][0], key[1][1], self.key_block_size, -1)
-        key_rshift_1 = self.add_SHIFT_component(
+        key_lshift_1 = self.add_shift_component(key[1][0], key[1][1], self.key_block_size, -1)
+        key_rshift_1 = self.add_shift_component(
             [key_lshift_1.id], [list(range(self.key_block_size))], self.key_block_size, self.key_block_size - 1
         )
-        key_rotated_1 = self.add_XOR_component(
+        key_rotated_1 = self.add_xor_component(
             key[1][0] + [key_rshift_1.id], key[1][1] + [list(range(self.key_block_size))], self.key_block_size
         )
         key_2 = [
@@ -702,7 +702,7 @@ class QARMAv2BlockCipher(Cipher):
         output = []
         for c in range(4):
             output.append(
-                self.add_XOR_component(
+                self.add_xor_component(
                     [input_ids[(c + r + 1) % 4] for r in range(3)],
                     [input_pos[(c + r + 1) % 4][r + 1 :] + input_pos[(c + r + 1) % 4][: r + 1] for r in range(3)],
                     4,
@@ -712,17 +712,17 @@ class QARMAv2BlockCipher(Cipher):
 
     def majority_function(self, key):
         maj_key_size = self.key_block_size / 2
-        and_0_1 = self.add_AND_component(
+        and_0_1 = self.add_and_component(
             [key, key],
             [list(range(maj_key_size)), list(range(maj_key_size, 2 * maj_key_size))],
             maj_key_size,
         )
-        and_0_2 = self.add_AND_component(
+        and_0_2 = self.add_and_component(
             [key, key],
             [list(range(maj_key_size)), list(range(2 * maj_key_size, 3 * maj_key_size))],
             maj_key_size,
         )
-        and_1_2 = self.add_AND_component(
+        and_1_2 = self.add_and_component(
             [key, key],
             [
                 list(range(maj_key_size, 2 * maj_key_size)),
@@ -730,7 +730,7 @@ class QARMAv2BlockCipher(Cipher):
             ],
             maj_key_size,
         )
-        maj_key_rotated = self.add_OR_component(
+        maj_key_rotated = self.add_or_component(
             [and_0_1, and_0_2, and_1_2], [list(range(maj_key_size)) for j in range(3)], maj_key_size
         )
         maj_key = self.add_rotate_component([maj_key_rotated], [list(range(maj_key_size))], maj_key_size, 17)

--- a/claasp/ciphers/block_ciphers/qarmav2_with_mixcolumn_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/qarmav2_with_mixcolumn_block_cipher.py
@@ -253,7 +253,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
 
     def first_round_start(self, key_state):
         # First round different from others
-        first_round_add_round_key = self.add_XOR_component(
+        first_round_add_round_key = self.add_xor_component(
             [key_state[0].id, INPUT_PLAINTEXT],
             [list(range(self.key_block_size)), list(range(self.cipher_block_size))[::-1]],
             self.cipher_block_size,
@@ -261,7 +261,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
 
         first_round_sboxes = []
         for sb in range(self.num_sboxes):
-            sbox = self.add_SBOX_component(
+            sbox = self.add_sbox_component(
                 [first_round_add_round_key.id], [list(range(4 * sb, 4 * sb + 4))], self.sbox_bit_size, self.sbox
             )
             first_round_sboxes.append(sbox)
@@ -279,7 +279,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         # Direct encryption
         round_key_shuffle = [None] * self.number_of_layers
         for l in range(self.number_of_layers):
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [
                     round_output.id,
                     key_state[round_number % 2].id,
@@ -332,7 +332,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         round_sboxes = [None] * self.number_of_layers * self.layer_sboxes
         for l in range(self.number_of_layers):
             for sb in range(self.layer_sboxes):
-                sbox = self.add_SBOX_component(
+                sbox = self.add_sbox_component(
                     [round_state_rotate[sb % 4 + 4 * l].id],
                     [list(range(4 * int(sb / 4), 4 * int(sb / 4) + 4))],
                     self.sbox_bit_size,
@@ -378,7 +378,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
                 self.layer_block_size,
                 self.state_permutation,
             )
-            mixed_shuffled_state = self.add_XOR_component(
+            mixed_shuffled_state = self.add_xor_component(
                 [shuffled_state.id, W[(self.nrounds + 1) % 2].id],
                 [list(range(self.layer_block_size)), list(range(64 * l, 64 * l + 64))],
                 self.layer_block_size,
@@ -404,7 +404,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         central_keyed_state = [None] * self.number_of_layers * 16
         for l in range(self.number_of_layers):
             for w in range(16):
-                central_xor = self.add_XOR_component(
+                central_xor = self.add_xor_component(
                     [round_state_rotate[w % 4 + 4 * l].id, W[(self.nrounds) % 2].id],
                     [
                         list(range(self.word_size * int(w / 4), self.word_size * int(w / 4) + 4)),
@@ -446,7 +446,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
 
         round_sboxes = []
         for sb in range(self.num_sboxes):
-            sbox = self.add_SBOX_component(
+            sbox = self.add_sbox_component(
                 [exchanging_rows.id], [list(range(4 * sb, 4 * sb + 4))], self.sbox_bit_size, self.inverse_sbox
             )
             round_sboxes.append(sbox)
@@ -475,7 +475,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         round_key_shuffle = []
         if round_number == 1:
             for l in range(self.number_of_layers):
-                xor = self.add_XOR_component(
+                xor = self.add_xor_component(
                     [
                         round_state_shuffle[l].id,
                         key_state[(round_number + 1) % 2].id,
@@ -493,7 +493,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
                 round_key_shuffle.append(xor)
         else:
             for l in range(self.number_of_layers):
-                xor = self.add_XOR_component(
+                xor = self.add_xor_component(
                     [
                         round_state_shuffle[l].id,
                         key_state[(round_number + 1) % 2].id,
@@ -537,14 +537,14 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         # Last round different from others
         last_round_sboxes = []
         for sb in range(self.num_sboxes):
-            sbox = self.add_SBOX_component(
+            sbox = self.add_sbox_component(
                 [round_output.id], [list(range(4 * sb, 4 * sb + 4))], self.sbox_bit_size, self.inverse_sbox
             )
             last_round_sboxes.append(sbox)
 
         last_round_add_round_key = []
         for sb in range(self.num_sboxes):
-            add_round_key = self.add_XOR_component(
+            add_round_key = self.add_xor_component(
                 [key_state[1].id, last_round_sboxes[sb].id],
                 [list(range(4 * sb, 4 * sb + 4)), list(range(self.sbox_bit_size))],
                 self.sbox_bit_size,
@@ -568,7 +568,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         alpha, beta = self.constants_update()
 
         if self.number_of_layers == 2:
-            key_state[0] = self.add_XOR_component(
+            key_state[0] = self.add_xor_component(
                 [key_state[0].id, alpha[0], alpha[1]],
                 [
                     list(range(self.key_block_size)),
@@ -577,7 +577,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
                 ],
                 self.key_block_size,
             )
-            key_state[1] = self.add_XOR_component(
+            key_state[1] = self.add_xor_component(
                 [key_state[1].id, beta[0], beta[1]],
                 [
                     list(range(self.key_block_size)),
@@ -587,12 +587,12 @@ class QARMAv2MixColumnBlockCipher(Cipher):
                 self.key_block_size,
             )
         else:
-            key_state[0] = self.add_XOR_component(
+            key_state[0] = self.add_xor_component(
                 [key_state[0].id, alpha[0]],
                 [list(range(self.key_block_size)), list(range(self.layer_block_size))],
                 self.key_block_size,
             )
-            key_state[1] = self.add_XOR_component(
+            key_state[1] = self.add_xor_component(
                 [key_state[1].id, beta[0]],
                 [list(range(self.key_block_size)), list(range(self.layer_block_size))],
                 self.key_block_size,
@@ -617,42 +617,42 @@ class QARMAv2MixColumnBlockCipher(Cipher):
     # --------------------------------------------------------------------------------#
 
     def update_single_constant(self, constant):
-        spill = self.add_SHIFT_component(
+        spill = self.add_shift_component(
             [constant], [list(range(self.layer_block_size))], self.layer_block_size, 51
         )
-        tmp_0 = self.add_SHIFT_component(
+        tmp_0 = self.add_shift_component(
             [constant], [list(range(self.layer_block_size))], self.layer_block_size, -13
         )
-        tmp_1 = self.add_SHIFT_component(
+        tmp_1 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -50
         )
-        tmp_2 = self.add_SHIFT_component(
+        tmp_2 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -33
         )
-        tmp_3 = self.add_SHIFT_component(
+        tmp_3 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -19
         )
-        tmp = self.add_XOR_component(
+        tmp = self.add_xor_component(
             [tmp_0.id, tmp_1.id, tmp_2.id, tmp_3.id, spill.id],
             [list(range(self.layer_block_size)) for j in range(5)],
             self.layer_block_size,
         )
-        spill = self.add_SHIFT_component(
+        spill = self.add_shift_component(
             [tmp.id], [list(range(self.layer_block_size))], self.layer_block_size, 54
         )
-        tmp_0 = self.add_SHIFT_component(
+        tmp_0 = self.add_shift_component(
             [tmp.id], [list(range(self.layer_block_size))], self.layer_block_size, -10
         )
-        tmp_1 = self.add_SHIFT_component(
+        tmp_1 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -50
         )
-        tmp_2 = self.add_SHIFT_component(
+        tmp_2 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -33
         )
-        tmp_3 = self.add_SHIFT_component(
+        tmp_3 = self.add_shift_component(
             [spill.id], [list(range(self.layer_block_size))], self.layer_block_size, -19
         )
-        tmp = self.add_XOR_component(
+        tmp = self.add_xor_component(
             [tmp_0.id, tmp_1.id, tmp_2.id, tmp_3.id, spill.id],
             [list(range(self.layer_block_size)) for j in range(5)],
             self.layer_block_size,
@@ -663,22 +663,22 @@ class QARMAv2MixColumnBlockCipher(Cipher):
         key_rot_0 = self.add_rotate_component(
             [key[0].id], [list(range(self.key_block_size))], self.key_block_size, 1
         )
-        key_shift_0 = self.add_SHIFT_component(
+        key_shift_0 = self.add_shift_component(
             [key[0].id], [list(range(self.key_block_size))], self.key_block_size, self.key_block_size - 1
         )
-        key_1 = self.add_XOR_component(
+        key_1 = self.add_xor_component(
             [key_rot_0.id, key_shift_0.id],
             [list(range(self.key_block_size)), list(range(self.key_block_size))],
             self.key_block_size,
         )
 
-        key_lshift_1 = self.add_SHIFT_component(
+        key_lshift_1 = self.add_shift_component(
             [key[1].id], [list(range(self.key_block_size))], self.key_block_size, -1
         )
-        key_rshift_1 = self.add_SHIFT_component(
+        key_rshift_1 = self.add_shift_component(
             [key_lshift_1.id], [list(range(self.key_block_size))], self.key_block_size, self.key_block_size - 1
         )
-        key_rotated_1 = self.add_XOR_component(
+        key_rotated_1 = self.add_xor_component(
             [key[1].id, key_rshift_1.id],
             [list(range(self.key_block_size)), list(range(self.key_block_size))],
             self.key_block_size,
@@ -691,17 +691,17 @@ class QARMAv2MixColumnBlockCipher(Cipher):
 
     def majority_function(self, key):
         maj_key_size = self.key_block_size / 2
-        and_0_1 = self.add_AND_component(
+        and_0_1 = self.add_and_component(
             [key, key],
             [list(range(maj_key_size)), list(range(maj_key_size, 2 * maj_key_size))],
             maj_key_size,
         )
-        and_0_2 = self.add_AND_component(
+        and_0_2 = self.add_and_component(
             [key, key],
             [list(range(maj_key_size)), list(range(2 * maj_key_size, 3 * maj_key_size))],
             maj_key_size,
         )
-        and_1_2 = self.add_AND_component(
+        and_1_2 = self.add_and_component(
             [key, key],
             [
                 list(range(maj_key_size, 2 * maj_key_size)),
@@ -709,7 +709,7 @@ class QARMAv2MixColumnBlockCipher(Cipher):
             ],
             maj_key_size,
         )
-        maj_key_rotated = self.add_OR_component(
+        maj_key_rotated = self.add_or_component(
             [and_0_1, and_0_2, and_1_2], [list(range(maj_key_size)) for _ in range(3)], maj_key_size
         )
         maj_key = self.add_rotate_component([maj_key_rotated], [list(range(maj_key_size))], maj_key_size, 17)

--- a/claasp/ciphers/block_ciphers/raiden_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/raiden_block_cipher.py
@@ -116,10 +116,10 @@ class RaidenBlockCipher(Cipher):
 
             # OPERATION 1
             # k0 + k1
-            sum1_id = self.add_MODADD_component([key[0][0], key[1][0]], [key[0][1], key[1][1]], self.word_size).id
+            sum1_id = self.add_modadd_component([key[0][0], key[1][0]], [key[0][1], key[1][1]], self.word_size).id
 
             # k2 + k3
-            sum2_id = self.add_MODADD_component([key[2][0], key[3][0]], [key[2][1], key[3][1]], self.word_size).id
+            sum2_id = self.add_modadd_component([key[2][0], key[3][0]], [key[2][1], key[3][1]], self.word_size).id
 
             # k0 << k2
             ls1_id = self.add_variable_shift_component(
@@ -127,52 +127,52 @@ class RaidenBlockCipher(Cipher):
             ).id
 
             # (k2 + k3) ^ (k0 << k2)
-            xor1_id = self.add_XOR_component([sum2_id, ls1_id], [word_bit_positions] * 2, self.word_size).id
+            xor1_id = self.add_xor_component([sum2_id, ls1_id], [word_bit_positions] * 2, self.word_size).id
 
             # (k0 + k1) + ((k2 + k3) ^ (k0 << k2))
-            sk_id = self.add_MODADD_component([sum1_id, xor1_id], [word_bit_positions] * 2, self.word_size).id
+            sk_id = self.add_modadd_component([sum1_id, xor1_id], [word_bit_positions] * 2, self.word_size).id
 
             # OPERATION 2
             # sk + v1
-            sum3_id = self.add_MODADD_component(
+            sum3_id = self.add_modadd_component(
                 [sk_id, data[1][0]], [word_bit_positions, data[1][1]], self.word_size
             ).id
 
             # (sk + v1) << ls
-            ls2_id = self.add_SHIFT_component([sum3_id], [word_bit_positions], self.word_size, -left_shift_amount).id
+            ls2_id = self.add_shift_component([sum3_id], [word_bit_positions], self.word_size, -left_shift_amount).id
 
             # sk - v1
-            sub1_id = self.add_MODSUB_component(
+            sub1_id = self.add_modsub_component(
                 [sk_id, data[1][0]], [word_bit_positions, data[1][1]], self.word_size
             ).id
 
             # (sk + v1) >> rs
-            rs1_id = self.add_SHIFT_component([sum3_id], [word_bit_positions], self.word_size, right_shift_amount).id
+            rs1_id = self.add_shift_component([sum3_id], [word_bit_positions], self.word_size, right_shift_amount).id
 
             # ((sk + v1) << ls) ^ ((sk - v1) ^ ((sk + v1) >> rs))
-            xor2_id = self.add_XOR_component([ls2_id, sub1_id, rs1_id], [word_bit_positions] * 3, self.word_size).id
+            xor2_id = self.add_xor_component([ls2_id, sub1_id, rs1_id], [word_bit_positions] * 3, self.word_size).id
 
             # v0 = v0 + ((sk + v1) << ls) ^ ((sk - v1) ^ ((sk + v1) >> rs))
-            v0 = self.add_MODADD_component([data[0][0], xor2_id], [data[0][1], word_bit_positions], self.word_size).id
+            v0 = self.add_modadd_component([data[0][0], xor2_id], [data[0][1], word_bit_positions], self.word_size).id
 
             # OPERATION 3
             # sk + v0
-            sum4_id = self.add_MODADD_component([sk_id, v0], [word_bit_positions] * 2, self.word_size).id
+            sum4_id = self.add_modadd_component([sk_id, v0], [word_bit_positions] * 2, self.word_size).id
 
             # (sk + v0) << ls
-            ls3_id = self.add_SHIFT_component([sum4_id], [word_bit_positions], self.word_size, -left_shift_amount).id
+            ls3_id = self.add_shift_component([sum4_id], [word_bit_positions], self.word_size, -left_shift_amount).id
 
             # sk - v0
-            sub2_id = self.add_MODSUB_component([sk_id, v0], [word_bit_positions] * 2, self.word_size).id
+            sub2_id = self.add_modsub_component([sk_id, v0], [word_bit_positions] * 2, self.word_size).id
 
             # (sk + v0) >> rs
-            rs2_id = self.add_SHIFT_component([sum4_id], [word_bit_positions], self.word_size, right_shift_amount).id
+            rs2_id = self.add_shift_component([sum4_id], [word_bit_positions], self.word_size, right_shift_amount).id
 
             # ((sk + v0) << ls) ^ (sk - v0) ^ ((sk + v0) >> rs)
-            xor3_id = self.add_XOR_component([ls3_id, sub2_id, rs2_id], [word_bit_positions] * 3, self.word_size).id
+            xor3_id = self.add_xor_component([ls3_id, sub2_id, rs2_id], [word_bit_positions] * 3, self.word_size).id
 
             # v1 = v1 + (((sk + v0) << ls) ^ (sk - v0) ^ ((sk + v0) >> rs))
-            v1 = self.add_MODADD_component([data[1][0], xor3_id], [data[1][1], word_bit_positions], self.word_size).id
+            v1 = self.add_modadd_component([data[1][0], xor3_id], [data[1][1], word_bit_positions], self.word_size).id
 
             # ROUND KEY OUTPUT
             key[round_number % 4] = sk_id, word_bit_positions

--- a/claasp/ciphers/block_ciphers/rc5_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/rc5_block_cipher.py
@@ -138,7 +138,7 @@ class RC5BlockCipher(Cipher):
                     block = self.u
 
                 L.append(
-                    self.add_XOR_component(
+                    self.add_xor_component(
                         [dummy_component.id]
                         + [INPUT_KEY for _ in range(min(self.u, len(little_endian_order) - i * self.u))],
                         [list(range(block * 8))]
@@ -170,11 +170,11 @@ class RC5BlockCipher(Cipher):
         for _ in range(3 * max(self.t, self.c)):
             # A = (S[i] + A + B) shift 3
 
-            Si_modadd_A = self.add_MODADD_component(
+            Si_modadd_A = self.add_modadd_component(
                 [S[i].id, A.id], [list(range(word_size)), list(range(word_size))], word_size
             )
 
-            Si_modadd_A_modadd_B = self.add_MODADD_component(
+            Si_modadd_A_modadd_B = self.add_modadd_component(
                 [Si_modadd_A.id, B.id], [list(range(word_size)), list(range(word_size))], word_size
             )
 
@@ -184,21 +184,21 @@ class RC5BlockCipher(Cipher):
 
             # B = (key_array[j] + A + B) shift (A + B)
 
-            A_modadd_B = self.add_MODADD_component(
+            A_modadd_B = self.add_modadd_component(
                 [A.id, B.id], [list(range(word_size)), list(range(word_size))], word_size
             )
 
-            shift_amount = self.add_XOR_component(
+            shift_amount = self.add_xor_component(
                 [A_modadd_B.id, dummy_component.id],
                 [[word_size - 1 - i for i in range(self.Lgw)][::-1], list(range(word_size))],
                 self.Lgw,
             )
 
-            Lj_modadd_A = self.add_MODADD_component(
+            Lj_modadd_A = self.add_modadd_component(
                 [L[j].id, A.id], [list(range(word_size)), list(range(word_size))], word_size
             )
 
-            Lj_modadd_A_modadd_B = self.add_MODADD_component(
+            Lj_modadd_A_modadd_B = self.add_modadd_component(
                 [Lj_modadd_A.id, B.id], [list(range(word_size)), list(range(word_size))], word_size
             )
 
@@ -223,24 +223,24 @@ class RC5BlockCipher(Cipher):
 
         little_endian_order_pt = [list(range(2 * word_size))[x : x + 8] for x in range(0, 2 * word_size, 8)][::-1]
 
-        A = self.add_XOR_component(
+        A = self.add_xor_component(
             [INPUT_PLAINTEXT for _ in range(int(word_size / 8))] + [dummy_component.id],
             [little_endian_order_pt[j] for j in range(int(word_size / 8), int(word_size / 4))]
             + [list(range(word_size))],
             word_size,
         )
 
-        B = self.add_XOR_component(
+        B = self.add_xor_component(
             [INPUT_PLAINTEXT for _ in range(int(word_size / 8))] + [dummy_component.id],
             [little_endian_order_pt[i] for i in range(int(word_size / 8))] + [list(range(word_size))],
             word_size,
         )
 
-        S0_modadd = self.add_MODADD_component(
+        S0_modadd = self.add_modadd_component(
             [A.id, S[0].id], [list(range(word_size)), list(range(word_size))], word_size
         )
 
-        S1_modadd = self.add_MODADD_component(
+        S1_modadd = self.add_modadd_component(
             [B.id, S[1].id], [list(range(word_size)), list(range(word_size))], word_size
         )
 
@@ -252,9 +252,9 @@ class RC5BlockCipher(Cipher):
     def round_function(self, k, A, B, S, word_size):
         dummy_component = self.add_constant_component(word_size, 0x0)
 
-        A_xor_B = self.add_XOR_component([A.id, B.id], [list(range(word_size)), list(range(word_size))], word_size)
+        A_xor_B = self.add_xor_component([A.id, B.id], [list(range(word_size)), list(range(word_size))], word_size)
 
-        shift_amount_B = self.add_XOR_component(
+        shift_amount_B = self.add_xor_component(
             [B.id, dummy_component.id],
             [[word_size - 1 - i for i in range(self.Lgw)][::-1], list(range(word_size))],
             self.Lgw,
@@ -267,15 +267,15 @@ class RC5BlockCipher(Cipher):
             -1,
         )
 
-        S_2i_modadd = self.add_MODADD_component(
+        S_2i_modadd = self.add_modadd_component(
             [B_shift.id, S[2 * (k + 1)].id], [list(range(word_size)), list(range(word_size))], word_size
         )
 
         A = S_2i_modadd
 
-        B_xor_A = self.add_XOR_component([B.id, A.id], [list(range(word_size)), list(range(word_size))], word_size)
+        B_xor_A = self.add_xor_component([B.id, A.id], [list(range(word_size)), list(range(word_size))], word_size)
 
-        shift_amount_A = self.add_XOR_component(
+        shift_amount_A = self.add_xor_component(
             [A.id, dummy_component.id],
             [[word_size - 1 - i for i in range(self.Lgw)][::-1], list(range(word_size))],
             self.Lgw,
@@ -288,7 +288,7 @@ class RC5BlockCipher(Cipher):
             -1,
         )
 
-        S_2i_1_modadd = self.add_MODADD_component(
+        S_2i_1_modadd = self.add_modadd_component(
             [A_shift.id, S[2 * (k + 1) + 1].id], [list(range(word_size)), list(range(word_size))], word_size
         )
 

--- a/claasp/ciphers/block_ciphers/rijndael_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/rijndael_block_cipher.py
@@ -239,7 +239,7 @@ class RijndaelBlockCipher(Cipher):
         for byte_index in range(4):
             byte_start = byte_index * self.byte_bit_size
             substituted_bytes.append(
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     word_state.id,
                     [list(range(byte_start, byte_start + self.byte_bit_size))],
                     self.byte_bit_size,
@@ -257,7 +257,7 @@ class RijndaelBlockCipher(Cipher):
 
     def _xor_word_with_constant(self, word_state, constant_value):
         constant_component = self.add_constant_component(self.word_bit_size, constant_value)
-        xor_component = self.add_XOR_component(
+        xor_component = self.add_xor_component(
             word_state.id + [constant_component.id],
             word_state.input_bit_positions + [list(range(self.word_bit_size))],
             self.word_bit_size,
@@ -265,7 +265,7 @@ class RijndaelBlockCipher(Cipher):
         return ComponentState([xor_component.id], [list(range(self.word_bit_size))])
 
     def _xor_words(self, left_word, right_word):
-        xor_component = self.add_XOR_component(
+        xor_component = self.add_xor_component(
             left_word.id + right_word.id,
             left_word.input_bit_positions + right_word.input_bit_positions,
             self.word_bit_size,
@@ -279,7 +279,7 @@ class RijndaelBlockCipher(Cipher):
                 byte_index = column_index * self.state_rows + row_index
                 byte_start = byte_index * self.byte_bit_size
                 substituted_bytes.append(
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         state.id,
                         [list(range(byte_start, byte_start + self.byte_bit_size))],
                         self.byte_bit_size,
@@ -334,7 +334,7 @@ class RijndaelBlockCipher(Cipher):
         return ComponentState([mixed_state.id], [list(range(self.block_bit_size))])
 
     def _add_round_key(self, state, round_key):
-        round_state = self.add_XOR_component(
+        round_state = self.add_xor_component(
             state.id + round_key.id,
             state.input_bit_positions + round_key.input_bit_positions,
             self.block_bit_size,

--- a/claasp/ciphers/block_ciphers/scarf_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/scarf_block_cipher.py
@@ -81,17 +81,17 @@ class SCARFBlockCipher(Cipher):
         for r in range(number_of_rounds - 1):
             F_component = self.F_function(data, Ti[r], r)
             xor_component = self.add_subkey(data, Ti[r], r)
-            sbox_component = self.add_SBOX_component([xor_component.id], [[0, 1, 2, 3, 4]], 5, scarf_sbox)
-            F_component_xored = self.add_XOR_component([F_component.id, data.id[1]], [[0, 1, 2, 3, 4]] * 2, 5)
+            sbox_component = self.add_sbox_component([xor_component.id], [[0, 1, 2, 3, 4]], 5, scarf_sbox)
+            F_component_xored = self.add_xor_component([F_component.id, data.id[1]], [[0, 1, 2, 3, 4]] * 2, 5)
             data = ComponentState([F_component_xored.id, sbox_component.id], [[0, 1, 2, 3, 4]] * 2)
             self.add_round_output_component(data.id, data.input_bit_positions, self.block_bit_size)
             self.add_round()
 
         # Last round is different:
         F_component = self.F_function(data, Ti[7], 7)
-        F_component_xored = self.add_XOR_component([F_component.id, data.id[1]], [[0, 1, 2, 3, 4]] * 2, 5)
-        sbox_component = self.add_SBOX_component([data.id[0]], [[0, 1, 2, 3, 4]], 5, scarf_sbox)
-        last_xor = self.add_XOR_component([sbox_component.id, Ti[7].id], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5)
+        F_component_xored = self.add_xor_component([F_component.id, data.id[1]], [[0, 1, 2, 3, 4]] * 2, 5)
+        sbox_component = self.add_sbox_component([data.id[0]], [[0, 1, 2, 3, 4]], 5, scarf_sbox)
+        last_xor = self.add_xor_component([sbox_component.id, Ti[7].id], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5)
 
         self.add_cipher_output_component(
             [last_xor.id, F_component_xored.id], [[0, 1, 2, 3, 4]] * 2, self.block_bit_size
@@ -99,9 +99,9 @@ class SCARFBlockCipher(Cipher):
 
     def add_subkey(self, data, Ti, current_round):
         if current_round % 2 == 0:
-            xor = self.add_XOR_component([data.id[0], Ti.id], [[0, 1, 2, 3, 4], [30, 31, 32, 33, 34]], 5)
+            xor = self.add_xor_component([data.id[0], Ti.id], [[0, 1, 2, 3, 4], [30, 31, 32, 33, 34]], 5)
         else:
-            xor = self.add_XOR_component([data.id[0], Ti.id], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5)
+            xor = self.add_xor_component([data.id[0], Ti.id], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5)
         return xor
 
     def F_function(self, data, Ti, current_round):
@@ -109,12 +109,12 @@ class SCARFBlockCipher(Cipher):
         self.create_rot_components(data, rot_components)
         and_components = []
         self.create_and_components(rot_components, and_components, Ti, current_round)
-        extra_and_component = self.add_AND_component(
+        extra_and_component = self.add_and_component(
             [rot_components[1].id, rot_components[2].id], [[0, 1, 2, 3, 4]] * 2, 5
         )
         input_ids = [xor.id for xor in and_components] + [extra_and_component.id]
         input_bit_pos = [[0, 1, 2, 3, 4]] * 6
-        xor_component = self.add_XOR_component(input_ids, input_bit_pos, 5)
+        xor_component = self.add_xor_component(input_ids, input_bit_pos, 5)
         return xor_component
 
     def create_rot_components(self, data, rot_components):
@@ -126,30 +126,30 @@ class SCARFBlockCipher(Cipher):
         for i in range(5):
             if current_round % 2 == 0:
                 l = [list(range(30 + 5 * j, 30 + 5 * j + 5)) for j in range(6)]
-                and_comp = self.add_AND_component([rot_components[i].id] + [Ti.id], [[0, 1, 2, 3, 4]] + [l[5 - i]], 5)
+                and_comp = self.add_and_component([rot_components[i].id] + [Ti.id], [[0, 1, 2, 3, 4]] + [l[5 - i]], 5)
             else:
                 l = [list(range(5 * j, 5 * j + 5)) for j in range(6)]
-                and_comp = self.add_AND_component([rot_components[i].id] + [Ti.id], [[0, 1, 2, 3, 4]] + [l[5 - i]], 5)
+                and_comp = self.add_and_component([rot_components[i].id] + [Ti.id], [[0, 1, 2, 3, 4]] + [l[5 - i]], 5)
             and_components.append(and_comp)
 
     def tweakey_schedule(self, tweak, key, constant):
         expansion = [list(range(j, j + 4)) for j in range(0, 48, 4)]
         for i in range(0, 24, 2):
             expansion.insert(i, [0])
-        T1 = self.add_XOR_component([constant.id, tweak[0][0]] * 12 + key[0], expansion + [list(range(180, 240))], 60)
+        T1 = self.add_xor_component([constant.id, tweak[0][0]] * 12 + key[0], expansion + [list(range(180, 240))], 60)
         self.add_round_key_output_component([T1.id], [list(range(60))], 60)
 
         sboxes_components = []
         self.create_sbox_components(T1, sboxes_components)
         sigma = self.create_sigma_components(sboxes_components)
-        T2 = self.add_XOR_component([sigma.id] + key[0], [list(range(60)), list(range(120, 180))], 60)
+        T2 = self.add_xor_component([sigma.id] + key[0], [list(range(60)), list(range(120, 180))], 60)
         self.add_round_key_output_component([T2.id], [list(range(60))], 60)
 
         sboxes_components = []
         self.create_sbox_components(T2, sboxes_components)
         input_ids = [sbox_component.id for sbox_component in sboxes_components]
         input_bit_pos = [list(range(5)) for _ in range(12)]
-        Sl_xored = self.add_XOR_component(input_ids + key[0], input_bit_pos + [list(range(60, 120))], 60)
+        Sl_xored = self.add_xor_component(input_ids + key[0], input_bit_pos + [list(range(60, 120))], 60)
 
         Pi = self.add_permutation_component([Sl_xored.id], [list(range(60))], 60, permutation)
         sboxes_components = []
@@ -159,7 +159,7 @@ class SCARFBlockCipher(Cipher):
         T3 = self.add_round_key_output_component(input_ids, input_bit_pos, 60)
 
         sigma = self.create_sigma_components(sboxes_components)
-        sigma_xored = self.add_XOR_component([sigma.id] + key[0], [list(range(60)), list(range(60))], 60)
+        sigma_xored = self.add_xor_component([sigma.id] + key[0], [list(range(60)), list(range(60))], 60)
         sboxes_components = []
         self.create_sbox_components(sigma_xored, sboxes_components)
         input_ids = [sbox_component.id for sbox_component in sboxes_components]
@@ -170,7 +170,7 @@ class SCARFBlockCipher(Cipher):
 
     def create_sbox_components(self, Ti, sboxes_components):
         for j in range(12):
-            sbox = self.add_SBOX_component([Ti.id], [list(range(j * 5, (j + 1) * 5))], 5, scarf_sbox)
+            sbox = self.add_sbox_component([Ti.id], [list(range(j * 5, (j + 1) * 5))], 5, scarf_sbox)
             sboxes_components.append(sbox)
 
     def create_sigma_components(self, sboxes_components):
@@ -182,7 +182,7 @@ class SCARFBlockCipher(Cipher):
         rot29 = self.add_rotate_component(input_ids, input_bit_pos, 60, -29).id
         rot43 = self.add_rotate_component(input_ids, input_bit_pos, 60, -43).id
         rot51 = self.add_rotate_component(input_ids, input_bit_pos, 60, -51).id
-        sigma_xor = self.add_XOR_component(
+        sigma_xor = self.add_xor_component(
             [rot6, rot12, rot19, rot29, rot43, rot51] + input_ids,
             [list(range(60)) for _ in range(6)] + input_bit_pos,
             60,

--- a/claasp/ciphers/block_ciphers/simeck_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/simeck_block_cipher.py
@@ -100,11 +100,11 @@ class SimeckBlockCipher(Cipher):
     def feistel_function(self, left, right, round_key):
         # f(x) = (x & x <<< 5) ⊕ x <<< 1
         s5x_id = self.add_rotate_component([left[0]], [left[1]], self.word_size, self.rotation_amounts[0]).id
-        x_and_s5x_id = self.add_AND_component([left[0], s5x_id], [list(range(self.word_size))] * 2, self.word_size).id
+        x_and_s5x_id = self.add_and_component([left[0], s5x_id], [list(range(self.word_size))] * 2, self.word_size).id
         s1x_id = self.add_rotate_component([left[0]], [left[1]], self.word_size, self.rotation_amounts[1]).id
         # Rk(x, y) = (y ⊕ f(x) ⊕ k, x)
-        f_id = self.add_XOR_component([x_and_s5x_id, s1x_id], [list(range(self.word_size))] * 2, self.word_size).id
-        new_left_id = self.add_XOR_component(
+        f_id = self.add_xor_component([x_and_s5x_id, s1x_id], [list(range(self.word_size))] * 2, self.word_size).id
+        new_left_id = self.add_xor_component(
             [right[0], f_id, round_key[0]], [right[1], list(range(self.word_size)), round_key[1]], self.word_size
         ).id
 

--- a/claasp/ciphers/block_ciphers/simeck_sbox_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/simeck_sbox_block_cipher.py
@@ -143,7 +143,7 @@ class SimeckSboxBlockCipher(Cipher):
         output_positions = [0] * self.word_size
         for i in range(self.number_of_sboxes):
             sbox_input_positions = [left[1][(position + 8 * i) % self.word_size] for position in positions_pattern]
-            sbox_id = self.add_SBOX_component([left[0]], [sbox_input_positions], 8, SBOX).id
+            sbox_id = self.add_sbox_component([left[0]], [sbox_input_positions], 8, SBOX).id
             sbox_output_positions = [(position + 8 * i) % self.word_size for position in positions_pattern[:-1]]
             for j, sbox_output_position in enumerate(sbox_output_positions):
                 output_ids[sbox_output_position] = sbox_id
@@ -157,11 +157,11 @@ class SimeckSboxBlockCipher(Cipher):
             else:
                 sboxes_positions[-1].append(output_positions[i])
         s1_left_input_positions = left[1][1:] + [left[1][0]]
-        f_id = self.add_XOR_component(
+        f_id = self.add_xor_component(
             [*sboxes_ids, left[0]], [*sboxes_positions, s1_left_input_positions], self.word_size
         ).id
         # Rk(x, y) = (y ⊕ f(x) ⊕ k, x)
-        new_left_id = self.add_XOR_component(
+        new_left_id = self.add_xor_component(
             [right[0], f_id, round_key[0]], [right[1], list(range(self.word_size)), round_key[1]], self.word_size
         ).id
 

--- a/claasp/ciphers/block_ciphers/simon_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/simon_block_cipher.py
@@ -176,14 +176,14 @@ class SimonBlockCipher(Cipher):
         s8_x = self.add_rotate_component([x[0]], [x[1]], self.word_size, self.rotation_amounts[1]).id
         s2_x = self.add_rotate_component([x[0]], [x[1]], self.word_size, self.rotation_amounts[2]).id
 
-        s1_and_s8 = self.add_AND_component([s1_x, s8_x], [list(range(self.word_size))] * 2, self.word_size).id
+        s1_and_s8 = self.add_and_component([s1_x, s8_x], [list(range(self.word_size))] * 2, self.word_size).id
 
-        return self.add_XOR_component([s1_and_s8, s2_x], [list(range(self.word_size))] * 2, self.word_size).id
+        return self.add_xor_component([s1_and_s8, s2_x], [list(range(self.word_size))] * 2, self.word_size).id
 
     def feistel_function(self, data, round_key):
         # Rk(x, y) = (y ⊕ f(x) ⊕ k, x)
         f_id = self.f((data[0][0], data[1][0]))
-        new_x_id = self.add_XOR_component(
+        new_x_id = self.add_xor_component(
             [data[0][1], f_id, round_key[0]], [data[1][1], list(range(self.word_size)), round_key[1]], self.word_size
         ).id
 
@@ -219,13 +219,13 @@ class SimonBlockCipher(Cipher):
             ).id
 
             if self.key_size_in_words == 4:
-                op = self.add_XOR_component(
+                op = self.add_xor_component(
                     [op, round_keys[i + 1][0]], [list(range(self.word_size)), round_keys[i + 1][1]], self.word_size
                 ).id
 
             rot_id = self.add_rotate_component([op], [list(range(self.word_size))], self.word_size, 1).id
 
-            xor_id = self.add_XOR_component(
+            xor_id = self.add_xor_component(
                 [round_constant, round_keys[i][0], op, rot_id],
                 [list(range(self.word_size)), round_keys[i][1]] + [list(range(self.word_size))] * 2,
                 self.word_size,

--- a/claasp/ciphers/block_ciphers/simon_sbox_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/simon_sbox_block_cipher.py
@@ -152,7 +152,7 @@ class SimonSboxBlockCipher(Cipher):
         output_positions = [0] * self.word_size
         for i in range(self.number_of_sboxes):
             sbox_input_positions = [(position + 8 * i) % self.word_size for position in input_positions_pattern]
-            sbox_id = self.add_SBOX_component([x[0]], [sbox_input_positions], 8, SBOX).id
+            sbox_id = self.add_sbox_component([x[0]], [sbox_input_positions], 8, SBOX).id
             sbox_output_positions = [(position + 8 * i) % self.word_size for position in output_positions_pattern]
             for j, sbox_output_position in enumerate(sbox_output_positions):
                 output_ids[sbox_output_position] = sbox_id
@@ -167,7 +167,7 @@ class SimonSboxBlockCipher(Cipher):
                 sboxes_positions[-1].append(output_positions[i])
 
         s2_x_input_positions = list(map(int(self.word_size).__rmod__, range(2, 2 + self.word_size)))
-        feistel_id = self.add_XOR_component(
+        feistel_id = self.add_xor_component(
             [*sboxes_ids, x[0]], [*sboxes_positions, s2_x_input_positions], self.word_size
         ).id
 
@@ -176,7 +176,7 @@ class SimonSboxBlockCipher(Cipher):
     def feistel_function(self, x, y, k):
         # Rk(x, y) = (y ⊕ f(x) ⊕ k, x)
         feistel_id, feistel_positions = self.f(x)
-        new_x_id = self.add_XOR_component([y[0], feistel_id, k[0]], [y[1], feistel_positions, k[1]], self.word_size).id
+        new_x_id = self.add_xor_component([y[0], feistel_id, k[0]], [y[1], feistel_positions, k[1]], self.word_size).id
 
         self.add_round_output_component([new_x_id, x[0]], [list(range(self.word_size)), x[1]], self.block_bit_size).id
 
@@ -207,22 +207,22 @@ class SimonSboxBlockCipher(Cipher):
             s4_x_input_positions = [(i - 4) % self.word_size for i in range(self.word_size)]
 
             if self.number_of_key_words == 4:
-                op = self.add_XOR_component(
+                op = self.add_xor_component(
                     [round_keys[round_number - 1][0], round_keys[round_number - 3][0]],
                     [s3_x_input_positions, round_keys[round_number - 3][1]],
                     self.word_size,
                 ).id
-                op = self.add_XOR_component(
+                op = self.add_xor_component(
                     [op, op], [s1_x_input_positions, list(range(self.word_size))], self.word_size
                 ).id
             else:
-                op = self.add_XOR_component(
+                op = self.add_xor_component(
                     [round_keys[round_number - 1][0], round_keys[round_number - 1][0]],
                     [s4_x_input_positions, s3_x_input_positions],
                     self.word_size,
                 ).id
 
-            xor_id = self.add_XOR_component(
+            xor_id = self.add_xor_component(
                 [round_constant, op, round_keys[constant_index][0]],
                 [list(range(self.word_size))] * 2 + [round_keys[constant_index][1]],
                 self.word_size,

--- a/claasp/ciphers/block_ciphers/skinny_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/skinny_block_cipher.py
@@ -191,7 +191,7 @@ class SkinnyBlockCipher(Cipher):
     def round_function(self, state, key, round_number, rc2):
         # SubCells
         for cell_number in range(NUMBER_OF_CELLS):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 state[cell_number].id, state[cell_number].input_bit_positions, self.cell_size, self.sbox
             )
             state[cell_number] = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
@@ -200,26 +200,26 @@ class SkinnyBlockCipher(Cipher):
         self.add_constant_component(self.cell_size, ROUND_CONSTANTS_0[round_number])
         rc0 = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
         inputs_id, inputs_positions = get_inputs_parameter([state[0], rc0])
-        self.add_XOR_component(inputs_id, inputs_positions, self.cell_size)
+        self.add_xor_component(inputs_id, inputs_positions, self.cell_size)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
 
         # AddConstants c1
         self.add_constant_component(self.cell_size, ROUND_CONSTANTS_1[round_number])
         rc1 = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
         inputs_id, inputs_pos = get_inputs_parameter([state[4], rc1])
-        self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
         state[4] = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
 
         # AddConstants c2
         inputs_id, inputs_pos = get_inputs_parameter([state[8], rc2])
-        self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
         state[8] = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
 
         # AddRoundTweakey
         for key_arrays_number in range(self.number_of_key_arrays):
             for cell_number in range(2 * NUMBER_OF_ROWS):
                 inputs_id, inputs_pos = get_inputs_parameter([state[cell_number], key[key_arrays_number][cell_number]])
-                self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+                self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
                 state[cell_number] = ComponentState([self.get_current_component_id()], [list(range(self.cell_size))])
 
         # ShiftRows
@@ -231,17 +231,17 @@ class SkinnyBlockCipher(Cipher):
         mix_column_state = []
         for i in range(4):
             inputs_id, inputs_pos = get_inputs_parameter([state[i], state[i + 8], state[i + 12]])
-            self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
             mix_column_state.append(ComponentState([self.get_current_component_id()], [list(range(self.cell_size))]))
         for i in range(4):
             mix_column_state.append(state[i])
         for i in range(4):
             inputs_id, inputs_pos = get_inputs_parameter([state[i + 4], state[i + 8]])
-            self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
             mix_column_state.append(ComponentState([self.get_current_component_id()], [list(range(self.cell_size))]))
         for i in range(4):
             inputs_id, inputs_pos = get_inputs_parameter([state[i], state[i + 8]])
-            self.add_XOR_component(inputs_id, inputs_pos, self.cell_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.cell_size)
             mix_column_state.append(ComponentState([self.get_current_component_id()], [list(range(self.cell_size))]))
 
         return mix_column_state

--- a/claasp/ciphers/block_ciphers/skipjack_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/skipjack_block_cipher.py
@@ -170,7 +170,7 @@ class SkipjackBlockCipher(Cipher):
             key_byte = ComponentState([INPUT_KEY], [list(range(bit_start, bit_end))])
 
             # XOR: g_out XOR key_byte
-            self.add_XOR_component(
+            self.add_xor_component(
                 [g_out.id[0], key_byte.id[0]],
                 [g_out.input_bit_positions[0], key_byte.input_bit_positions[0]],
                 8
@@ -178,7 +178,7 @@ class SkipjackBlockCipher(Cipher):
             xor_result = ComponentState([self.get_current_component_id()], [list(range(8))])
 
             # SBOX: F[xor_result]
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 [xor_result.id[0]],
                 [xor_result.input_bit_positions[0]],
                 8,
@@ -187,7 +187,7 @@ class SkipjackBlockCipher(Cipher):
             sbox_result = ComponentState([self.get_current_component_id()], [list(range(8))])
 
             # XOR: sbox_result XOR g_prev
-            self.add_XOR_component(
+            self.add_xor_component(
                 [sbox_result.id[0], g_prev.id[0]],
                 [sbox_result.input_bit_positions[0], g_prev.input_bit_positions[0]],
                 8
@@ -210,7 +210,7 @@ class SkipjackBlockCipher(Cipher):
         counter_comp = ComponentState([self.get_current_component_id()], [list(range(16))])
 
         # Both g_output and w4 can be multi-ID (2x8-bit), so flatten both.
-        self.add_XOR_component(
+        self.add_xor_component(
             g_output.id + w4.id + [counter_comp.id[0]],
             g_output.input_bit_positions + w4.input_bit_positions + [counter_comp.input_bit_positions[0]],
             16
@@ -228,14 +228,14 @@ class SkipjackBlockCipher(Cipher):
         counter_comp = ComponentState([self.get_current_component_id()], [list(range(16))])
 
         # w1 and w2 can be multi-ID, so flatten both for a full 16-bit XOR each.
-        self.add_XOR_component(
+        self.add_xor_component(
             w1.id + w2.id,
             w1.input_bit_positions + w2.input_bit_positions,
             16
         )
         temp = ComponentState([self.get_current_component_id()], [list(range(16))])
 
-        self.add_XOR_component(
+        self.add_xor_component(
             [temp.id[0], counter_comp.id[0]],
             [temp.input_bit_positions[0], counter_comp.input_bit_positions[0]],
             16

--- a/claasp/ciphers/block_ciphers/sm4_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/sm4_block_cipher.py
@@ -92,7 +92,7 @@ class SM4(Cipher):
             K = []
             for idx in range(4):
                 FK_const = self.add_constant_component(word_bits, self.FK[idx])
-                Ki = self.add_XOR_component(
+                Ki = self.add_xor_component(
                     [INPUT_KEY, FK_const.id],
                     [
                         [i for i in range(idx * 32, (idx + 1) * 32)],
@@ -112,7 +112,7 @@ class SM4(Cipher):
             for i in range(self.NROUNDS):
                 CK_const = self.add_constant_component(word_bits, self.CK[i])
 
-                t1 = self.add_XOR_component(
+                t1 = self.add_xor_component(
                     [K[i + 3].id, CK_const.id],
                     [
                         [j for j in range(self.KEY_BLOCK_SIZE // 4)],
@@ -120,7 +120,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                t2 = self.add_XOR_component(
+                t2 = self.add_xor_component(
                     [t1.id, K[i + 2].id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -128,7 +128,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                temp_k = self.add_XOR_component(
+                temp_k = self.add_xor_component(
                     [t2.id, K[i + 1].id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -138,7 +138,7 @@ class SM4(Cipher):
                 )
 
                 sboxes_k = [
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [temp_k.id], [[b * 8 + k for k in range(8)]], 8, self.sbox
                     )
                     for b in range(4)
@@ -148,7 +148,7 @@ class SM4(Cipher):
 
                 rot13 = self.add_rotate_component(ids_k, pos_k, word_bits, -13)
                 rot23 = self.add_rotate_component(ids_k, pos_k, word_bits, -23)
-                xor_rot = self.add_XOR_component(
+                xor_rot = self.add_xor_component(
                     [rot13.id, rot23.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -157,13 +157,13 @@ class SM4(Cipher):
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
 
-                L_prime = self.add_XOR_component(
+                L_prime = self.add_xor_component(
                     [sboxes_k[b].id for b in range(4)] + [xor_rot.id],
                     [list(range(8)) for _ in range(4)] + [list(range(32))],
                     32,
                 )
 
-                Ki4 = self.add_XOR_component(
+                Ki4 = self.add_xor_component(
                     [L_prime.id, K[i].id],
                     [
                         [j for j in range(self.KEY_BLOCK_SIZE // 4)],
@@ -174,7 +174,7 @@ class SM4(Cipher):
                 K.append(Ki4)
                 rk_i = Ki4
 
-                t1 = self.add_XOR_component(
+                t1 = self.add_xor_component(
                     [X[i + 3]["id"], rk_i.id],
                     [
                         X[i + 3]["bit_position"],
@@ -182,7 +182,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                t2 = self.add_XOR_component(
+                t2 = self.add_xor_component(
                     [t1.id, X[i + 2]["id"]],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -190,7 +190,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                temp_x = self.add_XOR_component(
+                temp_x = self.add_xor_component(
                     [t2.id, X[i + 1]["id"]],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -200,7 +200,7 @@ class SM4(Cipher):
                 )
 
                 sboxes_x = [
-                    self.add_SBOX_component(
+                    self.add_sbox_component(
                         [temp_x.id], [[b * 8 + k for k in range(8)]], 8, self.sbox
                     )
                     for b in range(4)
@@ -213,7 +213,7 @@ class SM4(Cipher):
                 rot18 = self.add_rotate_component(ids_x, pos_x, word_bits, -18)
                 rot24 = self.add_rotate_component(ids_x, pos_x, word_bits, -24)
 
-                xor_rot2_10 = self.add_XOR_component(
+                xor_rot2_10 = self.add_xor_component(
                     [rot2.id, rot10.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -221,7 +221,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                xor_rot18_24 = self.add_XOR_component(
+                xor_rot18_24 = self.add_xor_component(
                     [rot18.id, rot24.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -229,7 +229,7 @@ class SM4(Cipher):
                     ],
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
-                xor_all = self.add_XOR_component(
+                xor_all = self.add_xor_component(
                     [xor_rot2_10.id, xor_rot18_24.id],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],
@@ -238,14 +238,14 @@ class SM4(Cipher):
                     self.CIPHER_BLOCK_SIZE // 4,
                 )
 
-                L_out = self.add_XOR_component(
+                L_out = self.add_xor_component(
                     [sboxes_x[b].id for b in range(4)] + [xor_all.id],
                     [list(range(8)) for _ in range(4)]
                     + [list(range(self.CIPHER_BLOCK_SIZE // 4))],
                     32,
                 )
 
-                Xi4 = self.add_XOR_component(
+                Xi4 = self.add_xor_component(
                     [L_out.id, X[i]["id"]],
                     [
                         [j for j in range(self.CIPHER_BLOCK_SIZE // 4)],

--- a/claasp/ciphers/block_ciphers/sparx_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/sparx_block_cipher.py
@@ -236,7 +236,7 @@ class SparxBlockCipher(Cipher):
                 for t in range(s):
                     # c[i] ^ k[r]
                     key_id_list, key_bit_positions = extract_inputs(*key, list(range(t * 32, (t + 1) * 32)))
-                    xor_id = self.add_XOR_component(
+                    xor_id = self.add_xor_component(
                         new_data_words[i][0] + key_id_list, new_data_words[i][1] + key_bit_positions, 32
                     ).id
                     # c[i] = arx_box(c[i] ^ k[r])
@@ -258,7 +258,7 @@ class SparxBlockCipher(Cipher):
                 for i in range(self.word_number):
                     data_id_list, data_bit_positions = extract_inputs(*data, list(range(i * 32, (i + 1) * 32)))
                     key_id_list, key_bit_positions = extract_inputs(*key, list(range(i * 32, (i + 1) * 32)))
-                    new_data_id_list[i] = self.add_XOR_component(
+                    new_data_id_list[i] = self.add_xor_component(
                         data_id_list + key_id_list, data_bit_positions + key_bit_positions, 32
                     ).id
                 data = new_data_id_list, [list(range(32))] * self.word_number
@@ -288,16 +288,16 @@ class SparxBlockCipher(Cipher):
 
         # k2 = key[1]_h + k1_h || k[1]_l + k1_l
         k1_high = extract_inputs(*key, list(range(32, 48)))
-        new_k2_high_id = self.add_MODADD_component(k1_high[0] + new_k1_high[0], k1_high[1] + new_k1_high[1], 16).id
+        new_k2_high_id = self.add_modadd_component(k1_high[0] + new_k1_high[0], k1_high[1] + new_k1_high[1], 16).id
 
         k1_low = extract_inputs(*key, list(range(48, 64)))
-        new_k2_low_id = self.add_MODADD_component(k1_low[0] + new_k1_low[0], k1_low[1] + new_k1_low[1], 16).id
+        new_k2_low_id = self.add_modadd_component(k1_low[0] + new_k1_low[0], k1_low[1] + new_k1_low[1], 16).id
 
         # k[3] = (k[3] // 2**16) * 2**16 + (k[3] + r) % 2**16 #can be changed?
         r_id = self.add_constant_component(16, r).id
 
         k3_low = extract_inputs(*key, list(range(112, 128)))
-        new_k0_low_id = self.add_MODADD_component(k3_low[0] + [r_id], k3_low[1] + [list(range(16))], 16).id
+        new_k0_low_id = self.add_modadd_component(k3_low[0] + [r_id], k3_low[1] + [list(range(16))], 16).id
 
         # Concatenate parts
         k3_high = extract_inputs(*key, list(range(96, 112)))
@@ -317,10 +317,10 @@ class SparxBlockCipher(Cipher):
 
         # k[2] = k1_h + k1_h || k1_l + k1_l
         k1_high = extract_inputs(*key, list(range(32, 48)))
-        new_k2_high_id = self.add_MODADD_component(k1_high[0] + new_k1_high[0], k1_high[1] + new_k1_high[1], 16).id
+        new_k2_high_id = self.add_modadd_component(k1_high[0] + new_k1_high[0], k1_high[1] + new_k1_high[1], 16).id
 
         k1_low = extract_inputs(*key, list(range(48, 64)))
-        new_k2_low_id = self.add_MODADD_component(k1_low[0] + new_k1_low[0], k1_low[1] + new_k1_low[1], 16).id
+        new_k2_low_id = self.add_modadd_component(k1_low[0] + new_k1_low[0], k1_low[1] + new_k1_low[1], 16).id
 
         # k[3] = arx_box(k[2])
         new_k3 = self.arx_box(key, 2)
@@ -331,10 +331,10 @@ class SparxBlockCipher(Cipher):
         r_id = self.add_constant_component(16, r).id
 
         k3_high = extract_inputs(*key, list(range(96, 112)))
-        new_k0_high_id = self.add_MODADD_component(k3_high[0] + new_k3_high[0], k3_high[1] + new_k3_high[1], 16).id
+        new_k0_high_id = self.add_modadd_component(k3_high[0] + new_k3_high[0], k3_high[1] + new_k3_high[1], 16).id
 
         k3_low = extract_inputs(*key, list(range(112, 128)))
-        new_k0_low_id = self.add_MODADD_component(
+        new_k0_low_id = self.add_modadd_component(
             k3_low[0] + new_k3_low[0] + [r_id], k3_low[1] + new_k3_low[1] + [list(range(16))], 16
         ).id
 
@@ -354,10 +354,10 @@ class SparxBlockCipher(Cipher):
 
         # k1_low = (k3_low + key[1]) % 2**16
         k1_high = extract_inputs(*key, list(range(32, 48)))
-        new_k4_high_id = self.add_MODADD_component(new_k3_high[0] + k1_high[0], new_k3_high[1] + k1_high[1], 16).id
+        new_k4_high_id = self.add_modadd_component(new_k3_high[0] + k1_high[0], new_k3_high[1] + k1_high[1], 16).id
 
         k1_low = extract_inputs(*key, list(range(48, 64)))
-        new_k4_low_id = self.add_MODADD_component(new_k3_low[0] + k1_low[0], new_k3_low[1] + k1_low[1], 16).id
+        new_k4_low_id = self.add_modadd_component(new_k3_low[0] + k1_low[0], new_k3_low[1] + k1_low[1], 16).id
 
         # k7
         new_k7 = self.arx_box(key, 4)
@@ -368,10 +368,10 @@ class SparxBlockCipher(Cipher):
         r_id = self.add_constant_component(16, r).id
 
         k5_low = extract_inputs(*key, list(range(160, 176)))
-        new_k0_high_id = self.add_MODADD_component(new_k7_high[0] + k5_low[0], new_k7_high[1] + k5_low[1], 16).id
+        new_k0_high_id = self.add_modadd_component(new_k7_high[0] + k5_low[0], new_k7_high[1] + k5_low[1], 16).id
 
         k5_high = extract_inputs(*key, list(range(176, 192)))
-        new_k0_low_id = self.add_MODADD_component(
+        new_k0_low_id = self.add_modadd_component(
             new_k7_low[0] + k5_high[0] + [r_id], new_k7_low[1] + k5_high[1] + [list(range(16))], 16
         ).id
 
@@ -401,13 +401,13 @@ class SparxBlockCipher(Cipher):
 
         # new_a = (a >>> 7) + b
         low_i_word = extract_inputs(*arx_input, list(range((i * 32) + 16, (i + 1) * 32)))
-        new_a = self.add_MODADD_component([rrot_id] + low_i_word[0], [list(range(16))] + low_i_word[1], 16).id
+        new_a = self.add_modadd_component([rrot_id] + low_i_word[0], [list(range(16))] + low_i_word[1], 16).id
 
         # b <<< 2
         lrot_id = self.add_rotate_component(*low_i_word, 16, -2).id
 
         # new_b = (b <<< 2) ^ new_a
-        new_b = self.add_XOR_component([lrot_id, new_a], [list(range(16))] * 2, 16).id
+        new_b = self.add_xor_component([lrot_id, new_a], [list(range(16))] * 2, 16).id
 
         return [new_a, new_b], [list(range(16))] * 2
 
@@ -421,7 +421,7 @@ class SparxBlockCipher(Cipher):
         rrot = self.add_rotate_component(high_data_id_list, high_data_bit_positions, 32, 8).id
 
         # x ^ y ^ (x <<< 8) ^ (x >>> 8)
-        xor_id = self.add_XOR_component(data[0] + [lrot, rrot], data[1] + [list(range(32))] * 2, 32).id
+        xor_id = self.add_xor_component(data[0] + [lrot, rrot], data[1] + [list(range(32))] * 2, 32).id
 
         return [xor_id] + high_data_id_list, [list(range(32))] + high_data_bit_positions
 
@@ -429,28 +429,28 @@ class SparxBlockCipher(Cipher):
         high_data_id_list, high_data_bit_positions = extract_inputs(*data, list(range(64)))
 
         # t = ror(x ^ y, 8, 32) ^ lor(x ^ y, 8, 32)
-        xor1 = self.add_XOR_component(high_data_id_list, high_data_bit_positions, 32).id
+        xor1 = self.add_xor_component(high_data_id_list, high_data_bit_positions, 32).id
         rrot = self.add_rotate_component([xor1], [list(range(32))], 32, 8).id
         lrot = self.add_rotate_component([xor1], [list(range(32))], 32, -8).id
-        t = self.add_XOR_component([rrot, lrot], [list(range(32))] * 2, 32).id
+        t = self.add_xor_component([rrot, lrot], [list(range(32))] * 2, 32).id
 
         data_0_id_list, data_0_bit_positions = extract_inputs(*data, list(range(32)))
         data_1_id_list, data_1_bit_positions = extract_inputs(*data, list(range(32, 64)))
 
         # x ^ t
-        xor_a = self.add_XOR_component(data_0_id_list + [t], data_0_bit_positions + [list(range(32))], 32).id
+        xor_a = self.add_xor_component(data_0_id_list + [t], data_0_bit_positions + [list(range(32))], 32).id
 
         # y ^ t
-        xor_b = self.add_XOR_component(data_1_id_list + [t], data_1_bit_positions + [list(range(32))], 32).id
+        xor_b = self.add_xor_component(data_1_id_list + [t], data_1_bit_positions + [list(range(32))], 32).id
 
         data_2_id_list, data_2_bit_positions = extract_inputs(*data, list(range(64, 96)))
         data_3_id_list, data_3_bit_positions = extract_inputs(*data, list(range(96, 128)))
 
         # c[2] ^
-        c0 = self.add_XOR_component(
+        c0 = self.add_xor_component(
             data_2_id_list + [xor_b, xor_a], data_2_bit_positions + [list(range(16)), list(range(16, 32))], 32
         ).id
-        c1 = self.add_XOR_component(
+        c1 = self.add_xor_component(
             data_3_id_list + [xor_a, xor_b], data_3_bit_positions + [list(range(16)), list(range(16, 32))], 32
         ).id
 

--- a/claasp/ciphers/block_ciphers/speck_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/speck_block_cipher.py
@@ -133,11 +133,11 @@ class SpeckBlockCipher(Cipher):
         p1 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         # p1 = modadd(p1, p2)
-        self.add_MODADD_component(p1.id + p2.id, p1.input_bit_positions + p2.input_bit_positions, self.word_size)
+        self.add_modadd_component(p1.id + p2.id, p1.input_bit_positions + p2.input_bit_positions, self.word_size)
         p1 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         # p1 = p1 ^ round_key
-        self.add_XOR_component(p1.id + key.id, p1.input_bit_positions + key.input_bit_positions, self.word_size)
+        self.add_xor_component(p1.id + key.id, p1.input_bit_positions + key.input_bit_positions, self.word_size)
         p1 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         # p2 <<< beta
@@ -145,7 +145,7 @@ class SpeckBlockCipher(Cipher):
         p2 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         # p2 = p1 ^ p2
-        self.add_XOR_component(p1.id + p2.id, p1.input_bit_positions + p2.input_bit_positions, self.word_size)
+        self.add_xor_component(p1.id + p2.id, p1.input_bit_positions + p2.input_bit_positions, self.word_size)
         p2 = ComponentState([self.get_current_component_id()], [list(range(self.word_size))])
 
         return p1, p2

--- a/claasp/ciphers/block_ciphers/speedy_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/speedy_block_cipher.py
@@ -140,12 +140,12 @@ class SpeedyBlockCipher(Cipher):
 
             # the comments describe the point of view of the state
             # state is a whole of 6*l bits
-            block = self.add_XOR_component(
+            block = self.add_xor_component(
                 [block.id, key.id], block.input_bit_positions + key.input_bit_positions, block_bit_size
             )
             # state is l components corresponding to the l sboxes
             block = [
-                self.add_SBOX_component([block.id], [list(range(6 * i, 6 * (i + 1)))], 6, SBOX) for i in range(self.l)
+                self.add_sbox_component([block.id], [list(range(6 * i, 6 * (i + 1)))], 6, SBOX) for i in range(self.l)
             ]
             # state is 6 columns
             new_block = []
@@ -159,7 +159,7 @@ class SpeedyBlockCipher(Cipher):
             input_ids = [block[_].id for _ in range(6)]
             for i in range(self.l):
                 input_bit_positions = [[i] for _ in range(6)]
-                new_block.append(self.add_SBOX_component(input_ids, input_bit_positions, 6, SBOX))
+                new_block.append(self.add_sbox_component(input_ids, input_bit_positions, 6, SBOX))
             block = new_block
             # state is 6 columns
             new_block = []
@@ -173,7 +173,7 @@ class SpeedyBlockCipher(Cipher):
             input_ids = [block[_].id for _ in range(6)] * len(alpha)
             for i in range(self.l):
                 input_bit_positions = [[(i + a) % self.l] for a in alpha for _ in range(6)]
-                new_block.append(self.add_XOR_component(input_ids, input_bit_positions, 6))
+                new_block.append(self.add_xor_component(input_ids, input_bit_positions, 6))
             block = new_block
             # state is a whole of 6*l bits
             constant = 0
@@ -183,7 +183,7 @@ class SpeedyBlockCipher(Cipher):
             constant_component = self.add_constant_component(192, constant)
             input_ids = [nb.id for nb in block] + [constant_component.id]
             input_bit_positions = [list(range(6)) for _ in range(self.l)] + [list(range(6 * self.l))]
-            block = self.add_XOR_component(input_ids, input_bit_positions, block_bit_size)
+            block = self.add_xor_component(input_ids, input_bit_positions, block_bit_size)
             block = ComponentState(block.id, [list(range(block_bit_size))])
             # key schedule
             key = self.add_permutation_component([key.id], [list(range(6 * self.l))], 6 * self.l, self.permutation)
@@ -195,11 +195,11 @@ class SpeedyBlockCipher(Cipher):
         self.add_round()
 
         # state is a whole of 6*l bits
-        block = self.add_XOR_component(
+        block = self.add_xor_component(
             [block.id, key.id], block.input_bit_positions + key.input_bit_positions, block_bit_size
         )
         # state is l components corresponding to the l sboxes
-        block = [self.add_SBOX_component([block.id], [list(range(6 * i, 6 * (i + 1)))], 6, SBOX) for i in range(self.l)]
+        block = [self.add_sbox_component([block.id], [list(range(6 * i, 6 * (i + 1)))], 6, SBOX) for i in range(self.l)]
         # state is 6 columns
         new_block = []
         input_ids = [block[_].id for _ in range(self.l)]
@@ -212,14 +212,14 @@ class SpeedyBlockCipher(Cipher):
         input_ids = [block[_].id for _ in range(6)]
         for i in range(self.l):
             input_bit_positions = [[i] for _ in range(6)]
-            new_block.append(self.add_SBOX_component(input_ids, input_bit_positions, 6, SBOX))
+            new_block.append(self.add_sbox_component(input_ids, input_bit_positions, 6, SBOX))
         block = new_block
         # key schedule
         key = self.add_permutation_component([key.id], [list(range(6 * self.l))], 6 * self.l, self.permutation)
         # state is a whole of 6*l bits
         input_ids = [nb.id for nb in new_block] + [key.id]
         input_bit_positions = [list(range(6)) for _ in range(self.l)] + [list(range(6 * self.l))]
-        block = self.add_XOR_component(input_ids, input_bit_positions, block_bit_size)
+        block = self.add_xor_component(input_ids, input_bit_positions, block_bit_size)
 
         self.add_round_key_output_component([key.id], [list(range(6 * self.l))], 6 * self.l)
         self.add_cipher_output_component([block.id], [list(range(6 * self.l))], 6 * self.l)

--- a/claasp/ciphers/block_ciphers/tea_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/tea_block_cipher.py
@@ -116,10 +116,10 @@ class TeaBlockCipher(Cipher):
             # UPDATE OF V0
             # OPERAND 1
             # v1 << l
-            ls1_id = self.add_SHIFT_component([data[1][0]], [data[1][1]], self.word_size, -left_shift_amount).id
+            ls1_id = self.add_shift_component([data[1][0]], [data[1][1]], self.word_size, -left_shift_amount).id
 
             # (v1 << l) + k0
-            sum1_id = self.add_MODADD_component([ls1_id, key[0][0]], [word_bit_positions, key[0][1]], self.word_size).id
+            sum1_id = self.add_modadd_component([ls1_id, key[0][0]], [word_bit_positions, key[0][1]], self.word_size).id
 
             # sum = delta * (round+1)
             round_constant_id = self.add_constant_component(
@@ -128,49 +128,49 @@ class TeaBlockCipher(Cipher):
 
             # OPERAND 2
             # v1 + sum
-            sum2_id = self.add_MODADD_component(
+            sum2_id = self.add_modadd_component(
                 [data[1][0], round_constant_id], [data[1][1], word_bit_positions], self.word_size
             ).id
 
             # OPERAND 3
             # v1 >> r
-            rs1_id = self.add_SHIFT_component([data[1][0]], [data[1][1]], self.word_size, right_shift_amount).id
+            rs1_id = self.add_shift_component([data[1][0]], [data[1][1]], self.word_size, right_shift_amount).id
 
             # (v1 >> r) + k1
-            sum3_id = self.add_MODADD_component([rs1_id, key[1][0]], [word_bit_positions, key[1][1]], self.word_size).id
+            sum3_id = self.add_modadd_component([rs1_id, key[1][0]], [word_bit_positions, key[1][1]], self.word_size).id
 
             # FINAL
             # ((v1 << l) + k0) XOR (v1 + sum) XOR ((v1 >> r) + k1)
-            xor1_id = self.add_XOR_component([sum1_id, sum2_id, sum3_id], [word_bit_positions] * 3, self.word_size).id
+            xor1_id = self.add_xor_component([sum1_id, sum2_id, sum3_id], [word_bit_positions] * 3, self.word_size).id
 
             # v0 + (((v1 << l) + k0) XOR (v1 + sum) XOR ((v1 >> r) + k1))
-            v0 = self.add_MODADD_component([data[0][0], xor1_id], [data[0][1], word_bit_positions], self.word_size).id
+            v0 = self.add_modadd_component([data[0][0], xor1_id], [data[0][1], word_bit_positions], self.word_size).id
 
             # UPDATE OF V1
             # OPERAND 1
             # v0 << l
-            ls2_id = self.add_SHIFT_component([v0], [word_bit_positions], self.word_size, -left_shift_amount).id
+            ls2_id = self.add_shift_component([v0], [word_bit_positions], self.word_size, -left_shift_amount).id
 
             # (v0 << l) + k2
-            sum4_id = self.add_MODADD_component([ls2_id, key[2][0]], [word_bit_positions, key[2][1]], self.word_size).id
+            sum4_id = self.add_modadd_component([ls2_id, key[2][0]], [word_bit_positions, key[2][1]], self.word_size).id
 
             # OPERAND 2
             # v0 + sum
-            sum5_id = self.add_MODADD_component([v0, round_constant_id], [word_bit_positions] * 2, self.word_size).id
+            sum5_id = self.add_modadd_component([v0, round_constant_id], [word_bit_positions] * 2, self.word_size).id
 
             # OPERAND 3
             # v0 >> r
-            rs2_id = self.add_SHIFT_component([v0], [word_bit_positions], self.word_size, right_shift_amount).id
+            rs2_id = self.add_shift_component([v0], [word_bit_positions], self.word_size, right_shift_amount).id
 
             # (v0 >> r) + k3
-            sum6_id = self.add_MODADD_component([rs2_id, key[3][0]], [word_bit_positions, key[3][1]], self.word_size).id
+            sum6_id = self.add_modadd_component([rs2_id, key[3][0]], [word_bit_positions, key[3][1]], self.word_size).id
 
             # FINAL
             # ((v0 << l) + k2) XOR (v0 + sum) XOR ((v0 >> r) + k3)
-            xor2_id = self.add_XOR_component([sum4_id, sum5_id, sum6_id], [word_bit_positions] * 3, self.word_size).id
+            xor2_id = self.add_xor_component([sum4_id, sum5_id, sum6_id], [word_bit_positions] * 3, self.word_size).id
 
             # v1 + (((v0 << l) + k2) XOR (v0 + sum) XOR ((v0 >> r) + k3))
-            v1 = self.add_MODADD_component([data[1][0], xor2_id], [data[1][1], word_bit_positions], self.word_size).id
+            v1 = self.add_modadd_component([data[1][0], xor2_id], [data[1][1], word_bit_positions], self.word_size).id
 
             # ROUND OUTPUT
             data[0] = v0, word_bit_positions

--- a/claasp/ciphers/block_ciphers/threefish_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/threefish_block_cipher.py
@@ -184,10 +184,10 @@ class ThreefishBlockCipher(Cipher):
         constant = self.add_constant_component(64, 0x1BD11BDAA9FC1A22).id
 
         key_id_list, key_bit_positions = extract_inputs(*key, list(range(self.block_bit_size)))
-        xor_1 = self.add_XOR_component([constant] + key_id_list, [list(range(64))] + key_bit_positions, 64).id
+        xor_1 = self.add_xor_component([constant] + key_id_list, [list(range(64))] + key_bit_positions, 64).id
         key = key_id_list + [xor_1], key_bit_positions + [list(range(64))]
 
-        xor_2 = self.add_XOR_component(*tweak, 64).id
+        xor_2 = self.add_xor_component(*tweak, 64).id
         tweak = tweak[0] + [xor_2], tweak[1] + [list(range(64))]
 
         for round_number in range(n):
@@ -218,7 +218,7 @@ class ThreefishBlockCipher(Cipher):
         for i in range(self.nw):
             data_id_list, data_bit_positions = extract_inputs(*data, list(range(i * 64, (i + 1) * 64)))
             subkey_id_list, subkey_bit_positions = extract_inputs(*subkey, list(range(i * 64, (i + 1) * 64)))
-            new_data[i] = self.add_MODADD_component(
+            new_data[i] = self.add_modadd_component(
                 data_id_list + subkey_id_list, data_bit_positions + subkey_bit_positions, 64
             ).id
 
@@ -231,12 +231,12 @@ class ThreefishBlockCipher(Cipher):
             r = ROUND_CONSTANTS[d % 8][self.n][j]
 
             data_id_list, data_bit_positions = extract_inputs(*data, list(range(2 * j * 64, (2 * j + 2) * 64)))
-            new_data[2 * j] = self.add_MODADD_component(data_id_list, data_bit_positions, 64).id
+            new_data[2 * j] = self.add_modadd_component(data_id_list, data_bit_positions, 64).id
 
             data_id_list, data_bit_positions = extract_inputs(*data, list(range((2 * j + 1) * 64, (2 * j + 2) * 64)))
             lrot = self.add_rotate_component(data_id_list, data_bit_positions, 64, -r).id
 
-            new_data[2 * j + 1] = self.add_XOR_component([lrot, new_data[2 * j]], [list(range(64))] * 2, 64).id
+            new_data[2 * j + 1] = self.add_xor_component([lrot, new_data[2 * j]], [list(range(64))] * 2, 64).id
 
         return new_data, [list(range(64))] * self.nw
 
@@ -260,7 +260,7 @@ class ThreefishBlockCipher(Cipher):
         j = (s + self.nw - 3) % (self.nw + 1)
         key_id_list, key_bit_positions = extract_inputs(*key, list(range(j * 64, (j + 1) * 64)))
         tweak_id_list, tweak_bit_positions = extract_inputs(*tweak, list(range(i * 64, (i + 1) * 64)))
-        subkey_id_list[-3] = self.add_MODADD_component(
+        subkey_id_list[-3] = self.add_modadd_component(
             key_id_list + tweak_id_list, key_bit_positions + tweak_bit_positions, 64
         ).id
 
@@ -268,14 +268,14 @@ class ThreefishBlockCipher(Cipher):
         j = (s + self.nw - 2) % (self.nw + 1)
         key_id_list, key_bit_positions = extract_inputs(*key, list(range(j * 64, (j + 1) * 64)))
         tweak_id_list, tweak_bit_positions = extract_inputs(*tweak, list(range(i * 64, (i + 1) * 64)))
-        subkey_id_list[-2] = self.add_MODADD_component(
+        subkey_id_list[-2] = self.add_modadd_component(
             key_id_list + tweak_id_list, key_bit_positions + tweak_bit_positions, 64
         ).id
 
         s_const = self.add_constant_component(64, s).id
         j = (s + self.nw - 1) % (self.nw + 1)
         key_id_list, key_bit_positions = extract_inputs(*key, list(range(j * 64, (j + 1) * 64)))
-        subkey_id_list[-1] = self.add_MODADD_component(
+        subkey_id_list[-1] = self.add_modadd_component(
             key_id_list + [s_const], key_bit_positions + [list(range(64))], 64
         ).id
 

--- a/claasp/ciphers/block_ciphers/twine_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/twine_block_cipher.py
@@ -108,16 +108,16 @@ class TwineBlockCipher(Cipher):
 
     def update_key(self, k, i):
         def update_word(emitting_word_indx, receiving_word_indx):
-            sbox = self.add_SBOX_component([k], [get_word_bit_indexes(emitting_word_indx)], 4, self.sbox).id
-            return self.add_XOR_component([sbox, k], [list(range(4)), get_word_bit_indexes(receiving_word_indx)], 4).id
+            sbox = self.add_sbox_component([k], [get_word_bit_indexes(emitting_word_indx)], 4, self.sbox).id
+            return self.add_xor_component([sbox, k], [list(range(4)), get_word_bit_indexes(receiving_word_indx)], 4).id
 
         xor0 = update_word(0, 1)
         xor1 = update_word(16, 4)
 
         c0 = self.add_constant_component(6, self.round_constants[i - 1]).id
         pad = self.add_constant_component(1, 0b0).id
-        xor_c0 = self.add_XOR_component([pad, c0, k], [[0], list(range(3)), get_word_bit_indexes(7)], 4).id
-        xor_c1 = self.add_XOR_component([pad, c0, k], [[0], list(range(3, 6)), get_word_bit_indexes(19)], 4).id
+        xor_c0 = self.add_xor_component([pad, c0, k], [[0], list(range(3)), get_word_bit_indexes(7)], 4).id
+        xor_c1 = self.add_xor_component([pad, c0, k], [[0], list(range(3, 6)), get_word_bit_indexes(19)], 4).id
 
         if self.key_bit_size == 80:
             input_ids = [xor1, k, xor_c0, k, xor_c1, xor0, k]
@@ -154,14 +154,14 @@ class TwineBlockCipher(Cipher):
 
     def round_function(self, x, k):
         sb_order = [0, 5, 1, 4, 3, 6, 2, 7]
-        after_key_add = self.add_XOR_component(
+        after_key_add = self.add_xor_component(
             [x, k], [[_ for i in range(8) for _ in get_word_bit_indexes(2 * i)], list(range(32))], 32
         ).id
         sb_outputs = [
-            self.add_SBOX_component([after_key_add], [get_word_bit_indexes(i)], 4, self.sbox).id for i in range(8)
+            self.add_sbox_component([after_key_add], [get_word_bit_indexes(i)], 4, self.sbox).id for i in range(8)
         ]
         xor_outputs = [
-            self.add_XOR_component([sb_outputs[i], x], [list(range(4))] + [get_word_bit_indexes(2 * i + 1)], 4).id
+            self.add_xor_component([sb_outputs[i], x], [list(range(4))] + [get_word_bit_indexes(2 * i + 1)], 4).id
             for i in sb_order
         ]
         round_output = self.add_round_output_component(

--- a/claasp/ciphers/block_ciphers/twofish_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/twofish_block_cipher.py
@@ -173,7 +173,7 @@ class TwofishBlockCipher(Cipher):
             )
             A = self.h_function(X1.id, [M_e[k].id for k in range(self.key_k)], M_e_positions)
             B = self.h_function(X2.id, [M_o[k].id for k in range(self.key_k)], M_o_positions)
-            keys_list[2 * i] = self.add_MODADD_component(
+            keys_list[2 * i] = self.add_modadd_component(
                 [A, B],
                 [
                     list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))),
@@ -181,17 +181,17 @@ class TwofishBlockCipher(Cipher):
                 ],
                 32,
             )
-            B1 = self.add_SHIFT_component(
+            B1 = self.add_shift_component(
                 [B], [list(chain(range(16, 24), range(8, 16), range(8), range(24, 32)))], 32, -1
             )
-            A1 = self.add_MODADD_component(
+            A1 = self.add_modadd_component(
                 [A, B1.id], [list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))), list(range(32))], 32
             )
             keys_list[2 * i + 1] = A1
 
         state = [0, 0, 0, 0]
         for i in range(2):
-            s0 = self.add_XOR_component(
+            s0 = self.add_xor_component(
                 [INPUT_PLAINTEXT, keys_list[2 * i].id],
                 [
                     list(
@@ -207,7 +207,7 @@ class TwofishBlockCipher(Cipher):
                 32,
             )
             state[2 * i] = s0
-            s1 = self.add_XOR_component(
+            s1 = self.add_xor_component(
                 [INPUT_PLAINTEXT, keys_list[2 * i + 1].id],
                 [
                     list(
@@ -242,7 +242,7 @@ class TwofishBlockCipher(Cipher):
             )
             A = self.h_function(X1.id, [M_e[k].id for k in range(self.key_k)], M_e_positions)
             B = self.h_function(X2.id, [M_o[k].id for k in range(self.key_k)], M_o_positions)
-            keys_list[(2 * round_number + 8)] = self.add_MODADD_component(
+            keys_list[(2 * round_number + 8)] = self.add_modadd_component(
                 [A, B],
                 [
                     list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))),
@@ -250,10 +250,10 @@ class TwofishBlockCipher(Cipher):
                 ],
                 32,
             )
-            B1 = self.add_SHIFT_component(
+            B1 = self.add_shift_component(
                 [B], [list(chain(range(16, 24), range(8, 16), range(8), range(24, 32)))], 32, -1
             )
-            A1 = self.add_MODADD_component(
+            A1 = self.add_modadd_component(
                 [A, B1.id], [list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))), list(range(32))], 32
             )
             keys_list[(2 * round_number + 9)] = A1
@@ -262,7 +262,7 @@ class TwofishBlockCipher(Cipher):
             T0 = self.h_function(state[0].id, [S[k].id for k in range(self.key_k)], S_positions)
             X = self.add_rotate_component([state[1].id], [list(range(32))], 32, -8)
             T1 = self.h_function(X.id, [S[k].id for k in range(self.key_k)], S_positions)
-            F0 = self.add_MODADD_component(
+            F0 = self.add_modadd_component(
                 [T0, T1, keys_list[2 * round_number + 8].id],
                 [
                     list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))),
@@ -271,10 +271,10 @@ class TwofishBlockCipher(Cipher):
                 ],
                 32,
             )
-            FT = self.add_SHIFT_component(
+            FT = self.add_shift_component(
                 [T1], [list(chain(range(24, 32), range(16, 24), range(8, 16), range(8)))], 32, -1
             )
-            F1 = self.add_MODADD_component(
+            F1 = self.add_modadd_component(
                 [T0, FT.id, keys_list[2 * round_number + 9].id],
                 [
                     list(chain(range(24, 32), range(16, 24), range(8, 16), range(8))),
@@ -283,9 +283,9 @@ class TwofishBlockCipher(Cipher):
                 ],
                 32,
             )
-            R0_to_rot = self.add_XOR_component([state[2].id, F0.id], [list(range(32)), list(range(32))], 32)
+            R0_to_rot = self.add_xor_component([state[2].id, F0.id], [list(range(32)), list(range(32))], 32)
             R0 = self.add_rotate_component([R0_to_rot.id], [list(range(32))], 32, 1)
-            R1 = self.add_XOR_component([state[3].id, F1.id], [list(range(1, 32)) + [0], list(range(32))], 32)
+            R1 = self.add_xor_component([state[3].id, F1.id], [list(range(1, 32)) + [0], list(range(32))], 32)
             state[2] = state[0]
             state[3] = state[1]
             state[0] = R0
@@ -295,10 +295,10 @@ class TwofishBlockCipher(Cipher):
             if round_number == number_of_rounds - 1:
                 output = [0, 0, 0, 0]
                 for i in range(2):
-                    output[2 * i] = self.add_XOR_component(
+                    output[2 * i] = self.add_xor_component(
                         [state[(2 * i + 2) % 4].id, keys_list[2 * i + 4].id], [list(range(32)) for _ in range(2)], 32
                     )
-                    output[2 * i + 1] = self.add_XOR_component(
+                    output[2 * i + 1] = self.add_xor_component(
                         [state[((2 * i + 1) + 2) % 4].id, keys_list[(2 * i + 1) + 4].id],
                         [list(range(32)), list(chain(range(9, 32), range(9)))],
                         32,
@@ -324,69 +324,69 @@ class TwofishBlockCipher(Cipher):
         if self.key_k == 4:
             y4_j = X
             y_i[3] = [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [y4_j], [list(range(8 * (3 - j), 8 * (4 - j)))], 8, self.q_PERMUTATIONS[int(abs(j - 1.5))]
                 )
                 for j in range(4)
             ]
-            y3_j = self.add_XOR_component(
+            y3_j = self.add_xor_component(
                 [y_i[3][j].id for j in range(4)] + [L[3]], [list(range(8)) for _ in range(4)] + [L_bits[3]], 32
             )
             y_i[2] = [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [y3_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[1 - int(j / 2)]
                 )
                 for j in range(4)
             ]
-            y2_j = self.add_XOR_component(
+            y2_j = self.add_xor_component(
                 [y_i[2][j].id for j in range(4)] + [L[2]], [list(range(8)) for _ in range(4)] + [L_bits[2]], 32
             )
             y_i[1] = [
-                self.add_SBOX_component([y2_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[j % 2])
+                self.add_sbox_component([y2_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[j % 2])
                 for j in range(4)
             ]
-            y1_j = self.add_XOR_component(
+            y1_j = self.add_xor_component(
                 [y_i[1][j].id for j in range(4)] + [L[1]], [list(range(8)) for _ in range(4)] + [L_bits[1]], 32
             )
 
         elif self.key_k == 3:
             y3_j = X
             y_i[2] = [
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     [y3_j], [list(range(8 * (3 - j), 8 * (4 - j)))], 8, self.q_PERMUTATIONS[1 - int(j / 2)]
                 )
                 for j in range(4)
             ]
-            y2_j = self.add_XOR_component(
+            y2_j = self.add_xor_component(
                 [y_i[2][j].id for j in range(4)] + [L[2]], [list(range(8)) for _ in range(4)] + [L_bits[2]], 32
             )
             y_i[1] = [
-                self.add_SBOX_component([y2_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[j % 2])
+                self.add_sbox_component([y2_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[j % 2])
                 for j in range(4)
             ]
-            y1_j = self.add_XOR_component(
+            y1_j = self.add_xor_component(
                 [y_i[1][j].id for j in range(4)] + [L[1]], [list(range(8)) for _ in range(4)] + [L_bits[1]], 32
             )
 
         elif self.key_k == 2:
             y_i[1] = [
-                self.add_SBOX_component([y2_j], [list(range(8 * (3 - j), 8 * (4 - j)))], 8, self.q_PERMUTATIONS[j % 2])
+                self.add_sbox_component([y2_j], [list(range(8 * (3 - j), 8 * (4 - j)))], 8, self.q_PERMUTATIONS[j % 2])
                 for j in range(4)
             ]
-            y1_j = self.add_XOR_component(
+            y1_j = self.add_xor_component(
                 [y_i[1][j].id for j in range(4)] + [L[1]], [list(range(8)) for _ in range(4)] + [L_bits[1]], 32
             )
 
         y_i[0] = [
-            self.add_SBOX_component([y1_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[int(j / 2)])
+            self.add_sbox_component([y1_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[int(j / 2)])
             for j in range(4)
         ]
-        y0_j = self.add_XOR_component(
+        y0_j = self.add_xor_component(
             [y_i[0][j].id for j in range(4)] + [L[0]], [list(range(8)) for _ in range(4)] + [L_bits[0]], 32
         )
 
         y = [
-            self.add_SBOX_component([y0_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[1 - (j % 2)])
+            self.add_sbox_component([y0_j.id], [list(range(8 * j, 8 * (j + 1)))], 8, self.q_PERMUTATIONS[1 - (j % 2)])
             for j in range(4)
         ]
 

--- a/claasp/ciphers/block_ciphers/ublock_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/ublock_block_cipher.py
@@ -140,7 +140,7 @@ class UblockBlockCipher(Cipher):
             key_0, key_1, key_2, key_3, round_key = self.key_schedule(key_0, key_1, key_2, key_3, RC[round_number])
 
         # cipher output and round key output
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + state_right.id + round_key.id,
             state_left.input_bit_positions + state_right.input_bit_positions + round_key.input_bit_positions,
             self.block_bit_size,
@@ -193,7 +193,7 @@ class UblockBlockCipher(Cipher):
 
     def round_function(self, state_left, state_right, round_key):
         # state xor round_key
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + state_right.id + round_key.id,
             state_left.input_bit_positions + state_right.input_bit_positions + round_key.input_bit_positions,
             self.block_bit_size,
@@ -208,7 +208,7 @@ class UblockBlockCipher(Cipher):
         window_size = SBOX_SIZE
         n = int(self.half_block_bit_size / window_size)
         for i in range(n):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 state_left.id,
                 [state_left.input_bit_positions[0][i * window_size : (i + 1) * window_size]],
                 window_size,
@@ -222,7 +222,7 @@ class UblockBlockCipher(Cipher):
         window_size = SBOX_SIZE
         n = int(self.half_block_bit_size / window_size)
         for i in range(n):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 state_right.id,
                 [state_right.input_bit_positions[0][i * window_size : (i + 1) * window_size]],
                 window_size,
@@ -232,7 +232,7 @@ class UblockBlockCipher(Cipher):
         state_right = ComponentState(ids, [list(range(window_size))] * n)
 
         # state_right = state_left xor state_right
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + state_right.id,
             state_left.input_bit_positions + state_right.input_bit_positions,
             self.half_block_bit_size,
@@ -249,7 +249,7 @@ class UblockBlockCipher(Cipher):
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + temp.id, state_left.input_bit_positions + temp.input_bit_positions, self.half_block_bit_size
         )
         state_left = ComponentState([self.get_current_component_id()], [list(range(self.half_block_bit_size))])
@@ -264,7 +264,7 @@ class UblockBlockCipher(Cipher):
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             temp.id + state_right.id,
             temp.input_bit_positions + state_right.input_bit_positions,
             self.half_block_bit_size,
@@ -281,7 +281,7 @@ class UblockBlockCipher(Cipher):
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + temp.id, state_left.input_bit_positions + temp.input_bit_positions, self.half_block_bit_size
         )
         state_left = ComponentState([self.get_current_component_id()], [list(range(self.half_block_bit_size))])
@@ -296,7 +296,7 @@ class UblockBlockCipher(Cipher):
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             temp.id + state_right.id,
             temp.input_bit_positions + state_right.input_bit_positions,
             self.half_block_bit_size,
@@ -304,7 +304,7 @@ class UblockBlockCipher(Cipher):
         state_right = ComponentState([self.get_current_component_id()], [list(range(self.half_block_bit_size))])
 
         # state_left = state_left xor state_right
-        self.add_XOR_component(
+        self.add_xor_component(
             state_left.id + state_right.id,
             state_left.input_bit_positions + state_right.input_bit_positions,
             self.half_block_bit_size,
@@ -343,7 +343,7 @@ class UblockBlockCipher(Cipher):
         self.add_constant_component(RC_SIZE, RC)
         round_constant = ComponentState([self.get_current_component_id()], [list(range(RC_SIZE))])
         if self.key_block_size == RC_SIZE:
-            self.add_XOR_component(
+            self.add_xor_component(
                 key_0.id + round_constant.id, key_0.input_bit_positions + round_constant.input_bit_positions, RC_SIZE
             )
             temp = ComponentState([self.get_current_component_id()], [list(range(self.key_block_size))])
@@ -351,7 +351,7 @@ class UblockBlockCipher(Cipher):
             window_size = SBOX_SIZE
             n = int(self.key_block_size / window_size)
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     temp.id, [list(range(i * window_size, (i + 1) * window_size))], window_size, SBOX
                 )
                 ids.append(self.get_current_component_id())
@@ -359,7 +359,7 @@ class UblockBlockCipher(Cipher):
         else:
             key_0_left = ComponentState(key_0.id, [list(range(RC_SIZE))])
             key_0_right = ComponentState(key_0.id, [list(range(RC_SIZE, self.key_block_size))])
-            self.add_XOR_component(
+            self.add_xor_component(
                 key_0_left.id + round_constant.id,
                 key_0_left.input_bit_positions + round_constant.input_bit_positions,
                 RC_SIZE,
@@ -369,13 +369,13 @@ class UblockBlockCipher(Cipher):
             window_size = SBOX_SIZE
             n = int(RC_SIZE / window_size)
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     temp.id, [list(range(i * window_size, (i + 1) * window_size))], window_size, SBOX
                 )
                 ids.append(self.get_current_component_id())
             n = int((self.key_block_size - RC_SIZE) / window_size)
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     key_0_right.id,
                     [key_0_right.input_bit_positions[0][i * window_size : (i + 1) * window_size]],
                     window_size,
@@ -383,7 +383,7 @@ class UblockBlockCipher(Cipher):
                 )
                 ids.append(self.get_current_component_id())
             temp = ComponentState(ids, [list(range(window_size))] * int(self.key_block_size / window_size))
-        self.add_XOR_component(
+        self.add_xor_component(
             key_2.id + temp.id, key_2.input_bit_positions + temp.input_bit_positions, self.key_block_size
         )
         key_2 = ComponentState([self.get_current_component_id()], [list(range(self.key_block_size))])
@@ -393,12 +393,12 @@ class UblockBlockCipher(Cipher):
         window_size = SBOX_SIZE
         n = int(self.key_block_size / window_size)
         for i in range(n):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 key_1.id, [key_1.input_bit_positions[0][i * window_size : (i + 1) * window_size]], window_size, SBOX_TK
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             key_3.id + temp.id, key_3.input_bit_positions + temp.input_bit_positions, self.key_block_size
         )
         key_3 = ComponentState([self.get_current_component_id()], [list(range(self.key_block_size))])

--- a/claasp/ciphers/block_ciphers/ublock_single_linear_layer_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/ublock_single_linear_layer_block_cipher.py
@@ -209,7 +209,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
             key_0, key_1, key_2, key_3, round_key = self.key_schedule(key_0, key_1, key_2, key_3, RC[round_number])
 
         # cipher output and round key output
-        self.add_XOR_component(
+        self.add_xor_component(
             state.id + round_key.id, state.input_bit_positions + round_key.input_bit_positions, self.block_bit_size
         )
         cipher_output = ComponentState([self.get_current_component_id()], [list(range(self.block_bit_size))])
@@ -228,7 +228,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
 
     def round_function(self, state, round_key):
         # state xor round_key
-        self.add_XOR_component(
+        self.add_xor_component(
             state.id + round_key.id, state.input_bit_positions + round_key.input_bit_positions, self.block_bit_size
         )
         state = ComponentState([self.get_current_component_id()], [list(range(self.block_bit_size))])
@@ -237,7 +237,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
         window_size = SBOX_SIZE
         n = self.block_bit_size // window_size
         for i in range(n):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 state.id, [state.input_bit_positions[0][i * window_size : (i + 1) * window_size]], window_size, SBOX
             )
             ids.append(self.get_current_component_id())
@@ -281,7 +281,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
         self.add_constant_component(RC_SIZE, RC)
         round_constant = ComponentState([self.get_current_component_id()], [list(range(RC_SIZE))])
         if self.key_block_size == RC_SIZE:
-            self.add_XOR_component(
+            self.add_xor_component(
                 key_0.id + round_constant.id,
                 key_0.input_bit_positions + round_constant.input_bit_positions,
                 RC_SIZE,
@@ -291,7 +291,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
             window_size = SBOX_SIZE
             n = int(self.key_block_size / window_size)
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     temp.id, [list(range(i * window_size, (i + 1) * window_size))], window_size, SBOX
                 )
                 ids.append(self.get_current_component_id())
@@ -299,7 +299,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
         else:
             key_0_left = ComponentState(key_0.id, [list(range(RC_SIZE))])
             key_0_right = ComponentState(key_0.id, [list(range(RC_SIZE, self.key_block_size))])
-            self.add_XOR_component(
+            self.add_xor_component(
                 key_0_left.id + round_constant.id,
                 key_0_left.input_bit_positions + round_constant.input_bit_positions,
                 RC_SIZE,
@@ -309,13 +309,13 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
             window_size = SBOX_SIZE
             n = RC_SIZE // window_size
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     temp.id, [list(range(i * window_size, (i + 1) * window_size))], window_size, SBOX
                 )
                 ids.append(self.get_current_component_id())
             n = (self.key_block_size - RC_SIZE) // window_size
             for i in range(n):
-                self.add_SBOX_component(
+                self.add_sbox_component(
                     key_0_right.id,
                     [key_0_right.input_bit_positions[0][i * window_size : (i + 1) * window_size]],
                     window_size,
@@ -323,7 +323,7 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
                 )
                 ids.append(self.get_current_component_id())
             temp = ComponentState(ids, [list(range(window_size))] * int(self.key_block_size / window_size))
-        self.add_XOR_component(
+        self.add_xor_component(
             key_2.id + temp.id, key_2.input_bit_positions + temp.input_bit_positions, self.key_block_size
         )
         key_2 = ComponentState([self.get_current_component_id()], [list(range(self.key_block_size))])
@@ -333,12 +333,12 @@ class UblockSingleLinearLayerBlockCipher(Cipher):
         window_size = SBOX_SIZE
         n = self.key_block_size // window_size
         for i in range(n):
-            self.add_SBOX_component(
+            self.add_sbox_component(
                 key_1.id, [key_1.input_bit_positions[0][i * window_size : (i + 1) * window_size]], window_size, SBOX_TK
             )
             ids.append(self.get_current_component_id())
         temp = ComponentState(ids, [list(range(window_size))] * n)
-        self.add_XOR_component(
+        self.add_xor_component(
             key_3.id + temp.id, key_3.input_bit_positions + temp.input_bit_positions, self.key_block_size
         )
         key_3 = ComponentState([self.get_current_component_id()], [list(range(self.key_block_size))])

--- a/claasp/ciphers/block_ciphers/xtea_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/xtea_block_cipher.py
@@ -115,16 +115,16 @@ class XTeaBlockCipher(Cipher):
 
             # OPERATION 1
             # v1 << l
-            ls1_id = self.add_SHIFT_component([data[1][0]], [data[1][1]], self.word_size, -left_shift_amount).id
+            ls1_id = self.add_shift_component([data[1][0]], [data[1][1]], self.word_size, -left_shift_amount).id
 
             # (v1 >> r)
-            rs1_id = self.add_SHIFT_component([data[1][0]], [data[1][1]], self.word_size, right_shift_amount).id
+            rs1_id = self.add_shift_component([data[1][0]], [data[1][1]], self.word_size, right_shift_amount).id
 
             # (v1 << l) ^ (v1 >> r)
-            xor1_id = self.add_XOR_component([ls1_id, rs1_id], [word_bit_positions] * 2, self.word_size).id
+            xor1_id = self.add_xor_component([ls1_id, rs1_id], [word_bit_positions] * 2, self.word_size).id
 
             # ((v1 << l) ^ (v1 >> r)) + v1
-            sum1_id = self.add_MODADD_component(
+            sum1_id = self.add_modadd_component(
                 [xor1_id, data[1][0]], [word_bit_positions, data[1][1]], self.word_size
             ).id
 
@@ -134,15 +134,15 @@ class XTeaBlockCipher(Cipher):
 
             # sum + key[sum & 3]
             i = sum_constant & 3
-            sum2_id = self.add_MODADD_component(
+            sum2_id = self.add_modadd_component(
                 [sum_constant_id, key[i][0]], [word_bit_positions, key[i][1]], self.word_size
             ).id
 
             # (((v1 << l) ^ (v1 >> r)) + v1) ^ (sum + key[sum & 3])
-            xor2_id = self.add_XOR_component([sum1_id, sum2_id], [word_bit_positions] * 2, self.word_size).id
+            xor2_id = self.add_xor_component([sum1_id, sum2_id], [word_bit_positions] * 2, self.word_size).id
 
             # v0 = v0 + ((((v1 << l) ^ (v1 >> r)) + v1) ^ (sum + key[sum & 3]))
-            v0 = self.add_MODADD_component([data[0][0], xor2_id], [data[0][1], word_bit_positions], self.word_size).id
+            v0 = self.add_modadd_component([data[0][0], xor2_id], [data[0][1], word_bit_positions], self.word_size).id
 
             # OPERATION 2
             # sum = sum + delta
@@ -150,28 +150,28 @@ class XTeaBlockCipher(Cipher):
             sum_constant_id = self.add_constant_component(self.word_size, sum_constant).id
 
             # v0 << l
-            ls2_id = self.add_SHIFT_component([v0], [word_bit_positions], self.word_size, -left_shift_amount).id
+            ls2_id = self.add_shift_component([v0], [word_bit_positions], self.word_size, -left_shift_amount).id
 
             # v0 >> r
-            rs2_id = self.add_SHIFT_component([v0], [word_bit_positions], self.word_size, right_shift_amount).id
+            rs2_id = self.add_shift_component([v0], [word_bit_positions], self.word_size, right_shift_amount).id
 
             # (v0 << l) ^ (v0 >> r)
-            xor3_id = self.add_XOR_component([ls2_id, rs2_id], [word_bit_positions] * 2, self.word_size).id
+            xor3_id = self.add_xor_component([ls2_id, rs2_id], [word_bit_positions] * 2, self.word_size).id
 
             # ((v0 << l) ^ (v0 >> r)) + v0
-            sum3_id = self.add_MODADD_component([xor3_id, v0], [word_bit_positions] * 2, self.word_size).id
+            sum3_id = self.add_modadd_component([xor3_id, v0], [word_bit_positions] * 2, self.word_size).id
 
             # sum + key[(sum>>11) & 3]
             i = (sum_constant >> 11) & 3
-            sum4_id = self.add_MODADD_component(
+            sum4_id = self.add_modadd_component(
                 [sum_constant_id, key[i][0]], [word_bit_positions, key[i][1]], self.word_size
             ).id
 
             # (((v0 << l) ^ (v0 >> r)) + v0) ^ (sum + key[(sum>>11) & 3])
-            xor4_id = self.add_XOR_component([sum3_id, sum4_id], [word_bit_positions] * 2, self.word_size).id
+            xor4_id = self.add_xor_component([sum3_id, sum4_id], [word_bit_positions] * 2, self.word_size).id
 
             # v1 = v1 + ((((v0 << l) ^ (v0 >> r)) + v0) ^ (sum + key[(sum>>11) & 3]))
-            v1 = self.add_MODADD_component([data[1][0], xor4_id], [data[1][1], word_bit_positions], self.word_size).id
+            v1 = self.add_modadd_component([data[1][0], xor4_id], [data[1][1], word_bit_positions], self.word_size).id
 
             # ROUND OUTPUT
             data[0] = v0, word_bit_positions

--- a/claasp/ciphers/hash_functions/blake2_hash_function.py
+++ b/claasp/ciphers/hash_functions/blake2_hash_function.py
@@ -324,13 +324,13 @@ class Blake2HashFunction(Cipher):
 
         for i in range(self.n):
             if m[i] is None:
-                new_state_id[j] = self.add_MODADD_component(
+                new_state_id[j] = self.add_modadd_component(
                     [new_state_id[j], new_state_id[(j + 1) % self.n]],
                     [new_state_range[j], new_state_range[(j + 1) % self.n]],
                     self.word_size,
                 ).id
             else:
-                new_state_id[j] = self.add_MODADD_component(
+                new_state_id[j] = self.add_modadd_component(
                     [new_state_id[j], new_state_id[(j + 1) % self.n], data_word_ids[m[i]]],
                     [new_state_range[j], new_state_range[(j + 1) % self.n], data_word_ranges[m[i]]],
                     self.word_size,
@@ -338,7 +338,7 @@ class Blake2HashFunction(Cipher):
 
             new_state_range[j] = list(range(self.word_size))
 
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [new_state_id[(j - 1) % self.n], new_state_id[j]],
                 [new_state_range[(j - 1) % self.n], new_state_range[j]],
                 self.word_size,

--- a/claasp/ciphers/hash_functions/blake_hash_function.py
+++ b/claasp/ciphers/hash_functions/blake_hash_function.py
@@ -375,24 +375,24 @@ class BlakeHashFunction(Cipher):
 
         for i in range(self.n):
             if m[i] is None:
-                new_state_id[j] = self.add_MODADD_component(
+                new_state_id[j] = self.add_modadd_component(
                     [new_state_id[j], new_state_id[(j + 1) % self.n]],
                     [new_state_range[j], new_state_range[(j + 1) % self.n]],
                     self.word_size,
                 ).id
             else:
                 const_id = self.add_constant_component(self.word_size, self.constants[c[i]]).id
-                opt_xor_id = self.add_XOR_component(
+                opt_xor_id = self.add_xor_component(
                     [data_word_ids[m[i]], const_id],
                     [data_word_ranges[m[i]], list(range(self.word_size))],
                     self.word_size,
                 ).id
-                temp_add_id = self.add_MODADD_component(
+                temp_add_id = self.add_modadd_component(
                     [new_state_id[j], new_state_id[(j + 1) % self.n]],
                     [new_state_range[j], new_state_range[(j + 1) % self.n]],
                     self.word_size,
                 ).id
-                new_state_id[j] = self.add_MODADD_component(
+                new_state_id[j] = self.add_modadd_component(
                     [temp_add_id, opt_xor_id],
                     [list(range(self.word_size)), list(range(self.word_size))],
                     self.word_size,
@@ -400,7 +400,7 @@ class BlakeHashFunction(Cipher):
 
             new_state_range[j] = list(range(self.word_size))
 
-            xor_id = self.add_XOR_component(
+            xor_id = self.add_xor_component(
                 [new_state_id[(j - 1) % self.n], new_state_id[j]],
                 [new_state_range[(j - 1) % self.n], new_state_range[j]],
                 self.word_size,

--- a/claasp/ciphers/hash_functions/md5_hash_function.py
+++ b/claasp/ciphers/hash_functions/md5_hash_function.py
@@ -164,17 +164,17 @@ class MD5HashFunction(Cipher):
         return self.add_xor_component_in_md5(Y, X_or_notZ)
 
     def add_and_component_in_md5(self, component_0, component_1):
-        return self.add_AND_component(
+        return self.add_and_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_modadd_component_in_md5(self, component_0, component_1):
-        return self.add_MODADD_component(
+        return self.add_modadd_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_modadd_component_in_md5_for_x(self, x, component):
-        return self.add_MODADD_component(
+        return self.add_modadd_component(
             [x.id, component.id], [x.input_bit_positions[0], list(range(self.word_size))], self.word_size
         )
 
@@ -182,17 +182,17 @@ class MD5HashFunction(Cipher):
         return self.add_rotate_component([component.id], [list(range(self.word_size))], self.word_size, amount)
 
     def add_xor_component_in_md5(self, component_0, component_1):
-        return self.add_XOR_component(
+        return self.add_xor_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_or_component_in_md5(self, component_0, component_1):
-        return self.add_OR_component(
+        return self.add_or_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_not_component_in_md5(self, component):
-        return self.add_NOT_component([component.id], [list(range(self.word_size))], self.word_size)
+        return self.add_not_component([component.id], [list(range(self.word_size))], self.word_size)
 
     def add_round_output_component_in_md5(self, A, B, C, D):
         return self.add_round_output_component(

--- a/claasp/ciphers/hash_functions/sha1_hash_function.py
+++ b/claasp/ciphers/hash_functions/sha1_hash_function.py
@@ -153,12 +153,12 @@ class SHA1HashFunction(Cipher):
         )
 
     def add_and_component_in_sha1(self, component_0, component_1):
-        return self.add_AND_component(
+        return self.add_and_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_modadd_component_in_sha1(self, component_0, component_1):
-        return self.add_MODADD_component(
+        return self.add_modadd_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
@@ -172,7 +172,7 @@ class SHA1HashFunction(Cipher):
 
     def compute_temp_and_s_30_b(self, A, B, E, ft_B_C_D, K, W):
         S_5_A = self.add_rotate_component_in_sha1(A, -(5 % self.word_size))
-        TEMP = self.add_MODADD_component(
+        TEMP = self.add_modadd_component(
             [S_5_A.id, ft_B_C_D.id, E.id, K.id, W.id],
             [list(range(self.word_size)) for _ in range(4)] + W.input_bit_positions,
             self.word_size,
@@ -183,16 +183,16 @@ class SHA1HashFunction(Cipher):
 
     def rounds_0_19(self, A, B, C, D, E, K, W):
         B_AND_C = self.add_and_component_in_sha1(B, C)
-        NOT_B = self.add_NOT_component([B.id], [list(range(self.word_size))], self.word_size)
+        NOT_B = self.add_not_component([B.id], [list(range(self.word_size))], self.word_size)
         NOT_B_AND_D = self.add_and_component_in_sha1(NOT_B, D)
-        ft_B_C_D = self.add_OR_component(
+        ft_B_C_D = self.add_or_component(
             [B_AND_C.id, NOT_B_AND_D.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
         return self.compute_temp_and_s_30_b(A, B, E, ft_B_C_D, K, W)
 
     def rounds_20_39(self, A, B, C, D, E, K, W):
-        ft_B_C_D = self.add_XOR_component(
+        ft_B_C_D = self.add_xor_component(
             [B.id, C.id, D.id],
             [list(range(self.word_size)), list(range(self.word_size)), list(range(self.word_size))],
             self.word_size,
@@ -204,7 +204,7 @@ class SHA1HashFunction(Cipher):
         B_AND_C = self.add_and_component_in_sha1(B, C)
         B_AND_D = self.add_and_component_in_sha1(B, D)
         C_AND_D = self.add_and_component_in_sha1(C, D)
-        ft_B_C_D = self.add_OR_component(
+        ft_B_C_D = self.add_or_component(
             [B_AND_C.id, B_AND_D.id, C_AND_D.id],
             [list(range(self.word_size)), list(range(self.word_size)), list(range(self.word_size))],
             self.word_size,
@@ -213,7 +213,7 @@ class SHA1HashFunction(Cipher):
         return self.compute_temp_and_s_30_b(A, B, E, ft_B_C_D, K, W)
 
     def schedule(self, W, t):
-        Wt_temp = self.add_XOR_component(
+        Wt_temp = self.add_xor_component(
             [W[t - 3].id, W[t - 8].id, W[t - 14].id, W[t - 16].id],
             W[t - 3].input_bit_positions
             + W[t - 8].input_bit_positions

--- a/claasp/ciphers/hash_functions/sha2_hash_function.py
+++ b/claasp/ciphers/hash_functions/sha2_hash_function.py
@@ -220,12 +220,12 @@ class SHA2HashFunction(Cipher):
         )
 
     def add_and_component_sha2(self, component_0, component_1):
-        return self.add_AND_component(
+        return self.add_and_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
     def add_modadd_component_sha2(self, component_0, component_1):
-        return self.add_MODADD_component(
+        return self.add_modadd_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
@@ -240,7 +240,7 @@ class SHA2HashFunction(Cipher):
         )
 
     def add_xor_component_sha2(self, component_0, component_1):
-        return self.add_XOR_component(
+        return self.add_xor_component(
             [component_0.id, component_1.id], [list(range(self.word_size)), list(range(self.word_size))], self.word_size
         )
 
@@ -250,7 +250,7 @@ class SHA2HashFunction(Cipher):
             ROTR_13 = self.add_rotate_component_sha2(component_0, 13)
             ROTR_22 = self.add_rotate_component_sha2(component_0, 22)
 
-            BSIG0 = self.add_XOR_component(
+            BSIG0 = self.add_xor_component(
                 [ROTR_2.id, ROTR_13.id, ROTR_22.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
@@ -258,7 +258,7 @@ class SHA2HashFunction(Cipher):
             ROTR_11 = self.add_rotate_component_sha2(component_1, 11)
             ROTR_25 = self.add_rotate_component_sha2(component_1, 25)
 
-            BSIG1 = self.add_XOR_component(
+            BSIG1 = self.add_xor_component(
                 [ROTR_6.id, ROTR_11.id, ROTR_25.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
@@ -267,7 +267,7 @@ class SHA2HashFunction(Cipher):
             ROTR_34 = self.add_rotate_component_sha2(component_0, 34)
             ROTR_39 = self.add_rotate_component_sha2(component_0, 39)
 
-            BSIG0 = self.add_XOR_component(
+            BSIG0 = self.add_xor_component(
                 [ROTR_28.id, ROTR_34.id, ROTR_39.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
@@ -275,7 +275,7 @@ class SHA2HashFunction(Cipher):
             ROTR_18 = self.add_rotate_component_sha2(component_1, 18)
             ROTR_41 = self.add_rotate_component_sha2(component_1, 41)
 
-            BSIG1 = self.add_XOR_component(
+            BSIG1 = self.add_xor_component(
                 [ROTR_14.id, ROTR_18.id, ROTR_41.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
@@ -283,7 +283,7 @@ class SHA2HashFunction(Cipher):
 
     def compute_ch(self, x, y, z):
         x_AND_y = self.add_and_component_sha2(x, y)
-        NOT_x = self.add_NOT_component([x.id], [list(range(self.word_size))], self.word_size)
+        NOT_x = self.add_not_component([x.id], [list(range(self.word_size))], self.word_size)
         NOT_x_XOR_z = self.add_and_component_sha2(NOT_x, z)
 
         return self.add_xor_component_sha2(x_AND_y, NOT_x_XOR_z)
@@ -293,7 +293,7 @@ class SHA2HashFunction(Cipher):
         y_AND_z = self.add_and_component_sha2(y, z)
         x_AND_z = self.add_and_component_sha2(x, z)
 
-        return self.add_XOR_component(
+        return self.add_xor_component(
             [x_AND_y.id, y_AND_z.id, x_AND_z.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
         )
 
@@ -301,34 +301,34 @@ class SHA2HashFunction(Cipher):
         if self.output_bit_size in (224, 256):
             ROTR_7 = self.add_rotate_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 7)
             ROTR_18 = self.add_rotate_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 18)
-            SHR_3 = self.add_SHIFT_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 3)
+            SHR_3 = self.add_shift_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 3)
 
-            SSIG0 = self.add_XOR_component(
+            SSIG0 = self.add_xor_component(
                 [ROTR_7.id, ROTR_18.id, SHR_3.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
             ROTR_17 = self.add_rotate_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 17)
             ROTR_19 = self.add_rotate_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 19)
-            SHR_10 = self.add_SHIFT_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 10)
+            SHR_10 = self.add_shift_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 10)
 
-            SSIG1 = self.add_XOR_component(
+            SSIG1 = self.add_xor_component(
                 [ROTR_17.id, ROTR_19.id, SHR_10.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
         elif self.output_bit_size in (384, 512):
             ROTR_1 = self.add_rotate_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 1)
             ROTR_8 = self.add_rotate_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 8)
-            SHR_7 = self.add_SHIFT_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 7)
+            SHR_7 = self.add_shift_component([W[t - 15].id], W[t - 15].input_bit_positions, self.word_size, 7)
 
-            SSIG0 = self.add_XOR_component(
+            SSIG0 = self.add_xor_component(
                 [ROTR_1.id, ROTR_8.id, SHR_7.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
             ROTR_19 = self.add_rotate_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 19)
             ROTR_61 = self.add_rotate_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 61)
-            SHR_6 = self.add_SHIFT_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 6)
+            SHR_6 = self.add_shift_component([W[t - 2].id], W[t - 2].input_bit_positions, self.word_size, 6)
 
-            SSIG1 = self.add_XOR_component(
+            SSIG1 = self.add_xor_component(
                 [ROTR_19.id, ROTR_61.id, SHR_6.id], [list(range(self.word_size)) for _ in range(3)], self.word_size
             )
 
@@ -338,7 +338,7 @@ class SHA2HashFunction(Cipher):
         BSIG0_a, BSIG1_e = self.compute_bsig0_bsig1(a, e)
         CH_e_f_g = self.compute_ch(e, f, g)
 
-        T1 = self.add_MODADD_component(
+        T1 = self.add_modadd_component(
             [h.id, BSIG1_e.id, CH_e_f_g.id, Kt.id, W.id],
             [list(range(self.word_size)) for _ in range(4)] + W.input_bit_positions,
             self.word_size,
@@ -354,7 +354,7 @@ class SHA2HashFunction(Cipher):
     def schedule(self, W, t):
         W15, W2 = self.compute_ssig0_ssig1(W, t)
 
-        Wt = self.add_MODADD_component(
+        Wt = self.add_modadd_component(
             [W15.id, W2.id, W[t - 7].id, W[t - 16].id],
             [list(range(self.word_size)), list(range(self.word_size))]
             + W[t - 7].input_bit_positions

--- a/claasp/ciphers/hash_functions/whirlpool_hash_function.py
+++ b/claasp/ciphers/hash_functions/whirlpool_hash_function.py
@@ -106,7 +106,7 @@ class WhirlpoolHashFunction(Cipher):
 
         round_key = self.add_constant_component(self.cipher_block_size, 0x00)  # Initial Key value
 
-        add_round_key = self.add_XOR_component(
+        add_round_key = self.add_xor_component(
             [INPUT_MESSAGE, round_key.id],
             [list(range(self.cipher_block_size)), list(range(self.cipher_block_size))],
             self.cipher_block_size,
@@ -127,14 +127,14 @@ class WhirlpoolHashFunction(Cipher):
             key_shift_column_components = self.create_shift_column_components(key_sboxes_components, word_size)
             key_mix_row_components = self.create_mix_row_components(key_shift_column_components)
 
-            add_round_constant = self.add_XOR_component(
+            add_round_constant = self.add_xor_component(
                 [key_mix_row_components[i].id for i in range(self.num_columns)] + [round_constant.id],
                 [list(range(self.column_size)) for _ in range(self.num_columns)]
                 + [list(range(self.cipher_block_size))],
                 self.cipher_block_size,
             )
 
-            add_round_key = self.add_XOR_component(
+            add_round_key = self.add_xor_component(
                 [mix_row_components[i].id for i in range(self.num_columns)] + [add_round_constant.id],
                 [list(range(self.column_size)) for _ in range(self.num_columns)]
                 + [list(range(self.cipher_block_size))],
@@ -150,7 +150,7 @@ class WhirlpoolHashFunction(Cipher):
             if round_number != number_of_rounds - 1:
                 self.add_round()
 
-        output = self.add_XOR_component(
+        output = self.add_xor_component(
             [INPUT_MESSAGE, add_round_key.id],
             [list(range(self.cipher_block_size)), list(range(self.cipher_block_size))],
             self.cipher_block_size,
@@ -161,7 +161,7 @@ class WhirlpoolHashFunction(Cipher):
     def create_sbox_component(self, add_round_key):
         sboxes_components = []
         for j in range(self.num_sboxes):
-            sbox = self.add_SBOX_component(
+            sbox = self.add_sbox_component(
                 [add_round_key.id],
                 [list(range(j * self.sbox_bit_size, (j + 1) * self.sbox_bit_size))],
                 self.sbox_bit_size,

--- a/claasp/ciphers/mac/siphash_mac.py
+++ b/claasp/ciphers/mac/siphash_mac.py
@@ -224,7 +224,7 @@ class SiphashMAC(Cipher):
     def _modadd_words(self, word_a, word_b):
         links_a, pos_a = self._state_links_positions(word_a)
         links_b, pos_b = self._state_links_positions(word_b)
-        component = self.add_MODADD_component(
+        component = self.add_modadd_component(
             links_a + links_b,
             pos_a + pos_b,
             64,
@@ -265,7 +265,7 @@ class SiphashMAC(Cipher):
     def _xor_words(self, word_a, word_b):
         links_a, pos_a = self._state_links_positions(word_a)
         links_b, pos_b = self._state_links_positions(word_b)
-        component = self.add_XOR_component(
+        component = self.add_xor_component(
             links_a + links_b,
             pos_a + pos_b,
             64,

--- a/claasp/ciphers/permutations/ascon_permutation.py
+++ b/claasp/ciphers/permutations/ascon_permutation.py
@@ -94,57 +94,57 @@ class AsconPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, ci)
         c = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], c])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # substitution layer
         # S[0] ^= S[4]
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[4]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[4] ^= S[3]
         inputs_id, inputs_pos = get_inputs_parameter([state[4], state[3]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[4] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[2] ^= S[1]
         inputs_id, inputs_pos = get_inputs_parameter([state[2], state[1]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # T = [(~S[i]) & S[(i + 1) % 5] for i in range(5)]
         T = []
         for i in range(WORD_NUM):
-            self.add_NOT_component(state[i].id, state[i].input_bit_positions, WORD_SIZE)
+            self.add_not_component(state[i].id, state[i].input_bit_positions, WORD_SIZE)
             s = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
             inputs_id, inputs_pos = get_inputs_parameter([s, state[(i + 1) % WORD_NUM]])
-            self.add_AND_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_and_component(inputs_id, inputs_pos, WORD_SIZE)
             T.append(ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]))
 
         # S[i] ^= T[(i+1)%5] for i in range(5)
         for i in range(WORD_NUM):
             inputs_id, inputs_pos = get_inputs_parameter([state[i], T[(i + 1) % WORD_NUM]])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[1] ^= S[0]
         inputs_id, inputs_pos = get_inputs_parameter([state[1], state[0]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[3] ^= S[2]
         inputs_id, inputs_pos = get_inputs_parameter([state[3], state[2]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[0] ^= S[4]
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[4]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # S[2] = ~S[2]
-        self.add_NOT_component(state[2].id, state[2].input_bit_positions, WORD_SIZE)
+        self.add_not_component(state[2].id, state[2].input_bit_positions, WORD_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         inputs = []
@@ -161,7 +161,7 @@ class AsconPermutation(Cipher):
             self.add_rotate_component(state[i].id, state[i].input_bit_positions, WORD_SIZE, LINEAR_LAYER_ROT[i][1])
             s2 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
             inputs_id, inputs_pos = get_inputs_parameter([state[i], s1, s2])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state

--- a/claasp/ciphers/permutations/ascon_sbox_sigma_no_matrix_permutation.py
+++ b/claasp/ciphers/permutations/ascon_sbox_sigma_no_matrix_permutation.py
@@ -102,7 +102,7 @@ class AsconSboxSigmaNoMatrixPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, ci)
         constant = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], constant])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         substitution_layer = []
@@ -112,7 +112,7 @@ class AsconSboxSigmaNoMatrixPermutation(Cipher):
                 inputs_pos = [[i], [i + 64], [i], [i + 192], [i + 256]]
             else:
                 inputs_pos = [[i]] * 5
-            self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, ASCON_SBOX)
+            self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, ASCON_SBOX)
             substitution_layer.append(ComponentState([self.get_current_component_id()], [list(range(SBOX_SIZE))]))
 
         inputs_id = []
@@ -133,7 +133,7 @@ class AsconSboxSigmaNoMatrixPermutation(Cipher):
             s1 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
             self.add_rotate_component(inputs_id, inputs_pos, WORD_SIZE, LINEAR_LAYER_ROT[i][1])
             s2 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
-            self.add_XOR_component(
+            self.add_xor_component(
                 inputs_id + s1.id + s2.id, inputs_pos + s1.input_bit_positions + s2.input_bit_positions, WORD_SIZE
             )
             state[i] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])

--- a/claasp/ciphers/permutations/ascon_sbox_sigma_permutation.py
+++ b/claasp/ciphers/permutations/ascon_sbox_sigma_permutation.py
@@ -103,7 +103,7 @@ class AsconSboxSigmaPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, ci)
         constant = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], constant])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         substitution_layer = []
@@ -113,7 +113,7 @@ class AsconSboxSigmaPermutation(Cipher):
                 inputs_pos = [[i], [i + 64], [i], [i + 192], [i + 256]]
             else:
                 inputs_pos = [[i]] * 5
-            self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, ASCON_SBOX)
+            self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, ASCON_SBOX)
             substitution_layer.append(ComponentState([self.get_current_component_id()], [list(range(SBOX_SIZE))]))
 
         linear_layer = []

--- a/claasp/ciphers/permutations/gaston_permutation.py
+++ b/claasp/ciphers/permutations/gaston_permutation.py
@@ -136,14 +136,14 @@ class GastonPermutation(Cipher):
 
     def gaston_theta(self, state):
         inputs_id, inputs_pos = get_inputs_parameter([state[i] for i in range(GASTON_NROWS)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(P.id, P.input_bit_positions, WORD_SIZE, -GASTON_r)
         P_rot = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         inputs_id, inputs_pos = get_inputs_parameter([P, P_rot])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         # column parity P
 
@@ -154,19 +154,19 @@ class GastonPermutation(Cipher):
             Q_rows.append(q)
 
         inputs_id, inputs_pos = get_inputs_parameter([Q_rows[i] for i in range(GASTON_NROWS)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         Q = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(Q.id, Q.input_bit_positions, WORD_SIZE, -GASTON_s)
         Q_rot = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         inputs_id, inputs_pos = get_inputs_parameter([Q, Q_rot])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         Q = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         # column parity Q
 
         inputs_id, inputs_pos = get_inputs_parameter([P, Q])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(P.id, P.input_bit_positions, WORD_SIZE, -GASTON_u)
@@ -174,7 +174,7 @@ class GastonPermutation(Cipher):
 
         for row in range(GASTON_NROWS):
             inputs_id, inputs_pos = get_inputs_parameter([state[row], P])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[row] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state
@@ -190,7 +190,7 @@ class GastonPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, rc)
         const = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], const])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state
@@ -198,7 +198,7 @@ class GastonPermutation(Cipher):
     def gaston_chi(self, state):
         not_comp = [None] * GASTON_NROWS
         for row in range(GASTON_NROWS):
-            self.add_NOT_component(state[row].id, state[row].input_bit_positions, WORD_SIZE)
+            self.add_not_component(state[row].id, state[row].input_bit_positions, WORD_SIZE)
             not_comp[row] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         and_comp = [None] * GASTON_NROWS
@@ -206,12 +206,12 @@ class GastonPermutation(Cipher):
             inputs_id, inputs_pos = get_inputs_parameter(
                 [state[(row + 2) % GASTON_NROWS], not_comp[(row + 1) % GASTON_NROWS]]
             )
-            self.add_AND_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_and_component(inputs_id, inputs_pos, WORD_SIZE)
             and_comp[row] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         for row in range(GASTON_NROWS):
             inputs_id, inputs_pos = get_inputs_parameter([state[row], and_comp[row]])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[row] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state

--- a/claasp/ciphers/permutations/gaston_sbox_permutation.py
+++ b/claasp/ciphers/permutations/gaston_sbox_permutation.py
@@ -143,14 +143,14 @@ class GastonSboxPermutation(Cipher):
 
     def gaston_theta(self, state):
         inputs_id, inputs_pos = get_inputs_parameter([state[i] for i in range(GASTON_NROWS)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(P.id, P.input_bit_positions, WORD_SIZE, -GASTON_r)
         P_rot = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         inputs_id, inputs_pos = get_inputs_parameter([P, P_rot])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         # column parity P
 
@@ -161,19 +161,19 @@ class GastonSboxPermutation(Cipher):
             Q_rows.append(q)
 
         inputs_id, inputs_pos = get_inputs_parameter([Q_rows[i] for i in range(GASTON_NROWS)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         Q = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(Q.id, Q.input_bit_positions, WORD_SIZE, -GASTON_s)
         Q_rot = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         inputs_id, inputs_pos = get_inputs_parameter([Q, Q_rot])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         Q = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         # column parity Q
 
         inputs_id, inputs_pos = get_inputs_parameter([P, Q])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         P = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         self.add_rotate_component(P.id, P.input_bit_positions, WORD_SIZE, -GASTON_u)
@@ -181,7 +181,7 @@ class GastonSboxPermutation(Cipher):
 
         for row in range(GASTON_NROWS):
             inputs_id, inputs_pos = get_inputs_parameter([state[row], P])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[row] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state
@@ -197,7 +197,7 @@ class GastonSboxPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, rc)
         const = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], const])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state
@@ -208,7 +208,7 @@ class GastonSboxPermutation(Cipher):
         output_ids = []
         for k in range(WORD_SIZE):
             inputs_pos = [[k] for _ in range(GASTON_NROWS)]
-            self.add_SBOX_component(inputs_id, inputs_pos, GASTON_NROWS, SBOX)
+            self.add_sbox_component(inputs_id, inputs_pos, GASTON_NROWS, SBOX)
             output_ids = output_ids + [self.get_current_component_id()]
 
         for i in range(GASTON_NROWS):

--- a/claasp/ciphers/permutations/gaston_sbox_theta_permutation.py
+++ b/claasp/ciphers/permutations/gaston_sbox_theta_permutation.py
@@ -148,7 +148,7 @@ class GastonSboxThetaPermutation(Cipher):
         self.add_constant_component(WORD_SIZE, rc)
         const = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], const])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state
@@ -159,7 +159,7 @@ class GastonSboxThetaPermutation(Cipher):
         output_ids = []
         for k in range(WORD_SIZE):
             inputs_pos = [[k] for _ in range(GASTON_NROWS)]
-            self.add_SBOX_component(inputs_id, inputs_pos, GASTON_NROWS, SBOX)
+            self.add_sbox_component(inputs_id, inputs_pos, GASTON_NROWS, SBOX)
             output_ids = output_ids + [self.get_current_component_id()]
 
         for i in range(GASTON_NROWS):

--- a/claasp/ciphers/permutations/gift_permutation.py
+++ b/claasp/ciphers/permutations/gift_permutation.py
@@ -157,49 +157,49 @@ class GiftPermutation(Cipher):
         # subcells
         # S1 = S1 xor (S0 & S2)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[2]])
-        self.add_AND_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
         input_bit_positions = list(range(STATE_SIZE))
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[1], temp])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S0 = S0 xor (S1 & S3)
         inputs_id, inputs_pos = get_inputs_parameter([state[1], state[3]])
-        self.add_AND_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], temp])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S2 = S2 xor (S0 or S1)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[1]])
-        self.add_OR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_or_component(inputs_id, inputs_pos, STATE_SIZE)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], temp])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = S3 xor S2
         inputs_id, inputs_pos = get_inputs_parameter([state[2], state[3]])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S1 = S1 xor S3
         inputs_id, inputs_pos = get_inputs_parameter([state[1], state[3]])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = ~S3
-        self.add_NOT_component(state[3].id, state[3].input_bit_positions, STATE_SIZE)
+        self.add_not_component(state[3].id, state[3].input_bit_positions, STATE_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S2 = S2 xor (S0 & S1)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[1]])
-        self.add_AND_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], temp])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S0, S1, S2, S3 = S3, S1, S2, S0
@@ -213,12 +213,12 @@ class GiftPermutation(Cipher):
         # addroundkey
         # S2 = S2 xor U
         inputs_id, inputs_pos = get_inputs_parameter([state[2], round_key_u])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S1 = S1 xor V
         inputs_id, inputs_pos = get_inputs_parameter([state[1], round_key_v])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = S3 xor ci
@@ -226,7 +226,7 @@ class GiftPermutation(Cipher):
         self.add_constant_component(STATE_SIZE, ci)
         c = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[3], c])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         return state

--- a/claasp/ciphers/permutations/gift_sbox_permutation.py
+++ b/claasp/ciphers/permutations/gift_sbox_permutation.py
@@ -168,7 +168,7 @@ class GiftSboxPermutation(Cipher):
                 inputs_id = inputs_id + state[i].id
                 inputs_pos = inputs_pos + [[state[i].input_bit_positions[0][k]]]
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_SBOX_component(inputs_id, inputs_pos, S_BOX_SIZE, S_BOX)
+            self.add_sbox_component(inputs_id, inputs_pos, S_BOX_SIZE, S_BOX)
             for i in range(STATE_NUM):
                 state_new[i].id[k] = self.get_current_component_id()
                 state_new[i].input_bit_positions[k] = [i]
@@ -184,12 +184,12 @@ class GiftSboxPermutation(Cipher):
         # addroundkey
         # S2 = S2 xor U
         inputs_id, inputs_pos = get_inputs_parameter([state[2], round_key_u])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[2] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
 
         # S1 = S1 xor V
         inputs_id, inputs_pos = get_inputs_parameter([state[1], round_key_v])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
 
         # S3 = S3 xor ci
@@ -197,7 +197,7 @@ class GiftSboxPermutation(Cipher):
         self.add_constant_component(STATE_SIZE, ci)
         c = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[3], c])
-        self.add_XOR_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
 
         return state

--- a/claasp/ciphers/permutations/gimli_permutation.py
+++ b/claasp/ciphers/permutations/gimli_permutation.py
@@ -118,7 +118,7 @@ class GimliPermutation(Cipher):
         inputs_id = c.id + states[0][0].id
         inputs_pos = c.input_bit_positions + states[0][0].input_bit_positions
 
-        self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
         states[0][0] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return states
@@ -169,28 +169,28 @@ class GimliPermutation(Cipher):
         sp_states = [[{} for _ in range(N_COLS)] for _ in range(N_ROWS)]
         for column_number in range(N_COLS):
             # x
-            self.add_SHIFT_component(
+            self.add_shift_component(
                 b[2][column_number].id, b[2][column_number].input_bit_positions, self.word_bit_size, -1
             )
             b0_shift1 = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b[0][column_number].id + b0_shift1.id
             inputs_pos = b[0][column_number].input_bit_positions + b0_shift1.input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b0_xor1 = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
-            self.add_AND_component(
+            self.add_and_component(
                 b[1][column_number].id + b[2][column_number].id,
                 b[1][column_number].input_bit_positions + b[2][column_number].input_bit_positions,
                 self.word_bit_size,
             )
             b0_and = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
-            self.add_SHIFT_component(b0_and.id, b0_and.input_bit_positions, self.word_bit_size, -2)
+            self.add_shift_component(b0_and.id, b0_and.input_bit_positions, self.word_bit_size, -2)
             b0_shift2 = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b0_xor1.id + b0_shift2.id
             inputs_pos = b0_xor1.input_bit_positions + b0_shift2.input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
 
             # Swap x <- z
             sp_states[2][column_number] = ComponentState(
@@ -201,21 +201,21 @@ class GimliPermutation(Cipher):
             inputs_id = b[1][column_number].id + b[0][column_number].id
             inputs_pos = b[1][column_number].input_bit_positions + b[0][column_number].input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b1_xor = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
-            self.add_OR_component(
+            self.add_or_component(
                 b[0][column_number].id + b[2][column_number].id,
                 b[0][column_number].input_bit_positions + b[2][column_number].input_bit_positions,
                 self.word_bit_size,
             )
             b1_or = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
-            self.add_SHIFT_component(b1_or.id, b1_or.input_bit_positions, self.word_bit_size, -1)
+            self.add_shift_component(b1_or.id, b1_or.input_bit_positions, self.word_bit_size, -1)
             b1_shift = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b1_xor.id + b1_shift.id
             inputs_pos = b1_xor.input_bit_positions + b1_shift.input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
 
             sp_states[1][column_number] = ComponentState(
                 [self.get_current_component_id()], [list(range(self.word_bit_size))]
@@ -225,21 +225,21 @@ class GimliPermutation(Cipher):
             inputs_id = b[2][column_number].id + b[1][column_number].id
             inputs_pos = b[2][column_number].input_bit_positions + b[1][column_number].input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b2_xor = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
-            self.add_AND_component(
+            self.add_and_component(
                 b[0][column_number].id + b[1][column_number].id,
                 b[0][column_number].input_bit_positions + b[1][column_number].input_bit_positions,
                 self.word_bit_size,
             )
             b2_and = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
-            self.add_SHIFT_component(b2_and.id, b2_and.input_bit_positions, self.word_bit_size, -3)
+            self.add_shift_component(b2_and.id, b2_and.input_bit_positions, self.word_bit_size, -3)
             b2_shift = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b2_xor.id + b2_shift.id
             inputs_pos = b2_xor.input_bit_positions + b2_shift.input_bit_positions
 
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             # Swap z <- x
             sp_states[0][column_number] = ComponentState(
                 [self.get_current_component_id()], [list(range(self.word_bit_size))]

--- a/claasp/ciphers/permutations/gimli_sbox_permutation.py
+++ b/claasp/ciphers/permutations/gimli_sbox_permutation.py
@@ -139,26 +139,26 @@ class GimliSboxPermutation(Cipher):
         for column_number in range(N_COLS):
             # ------------------------------------------------------
             # x before substitution_layer-box
-            self.add_SHIFT_component(
+            self.add_shift_component(
                 b[2][column_number].id, b[2][column_number].input_bit_positions, self.word_bit_size, -1
             )
             b0_shift1 = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b[0][column_number].id + b0_shift1.id
             inputs_pos = b[0][column_number].input_bit_positions + b0_shift1.input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b0_xor = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             # ------------------------------------------------------
             # y before Sbox
             inputs_id = b[1][column_number].id + b[0][column_number].id
             inputs_pos = b[1][column_number].input_bit_positions + b[0][column_number].input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b1_xor = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
             # ------------------------------------------------------
             # z before Sbox
             inputs_id = b[2][column_number].id + b[1][column_number].id
             inputs_pos = b[2][column_number].input_bit_positions + b[1][column_number].input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             b2_xor = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
             # ------------------------------------------------------
@@ -173,7 +173,7 @@ class GimliSboxPermutation(Cipher):
                     ]
                 else:
                     inputs_pos = [[i]] * N_ROWS
-                self.add_SBOX_component(inputs_id, inputs_pos, N_ROWS, GIMLI_SBOX)
+                self.add_sbox_component(inputs_id, inputs_pos, N_ROWS, GIMLI_SBOX)
                 substitution_layer.append(ComponentState([self.get_current_component_id()], [list(range(SBOX_SIZE))]))
 
             inputs_id = []
@@ -185,11 +185,11 @@ class GimliSboxPermutation(Cipher):
 
             # ------------------------------------------------------
             # x after substitution_layer-box
-            self.add_SHIFT_component(lane_after_sb[0].id, lane_after_sb[0].input_bit_positions, self.word_bit_size, -2)
+            self.add_shift_component(lane_after_sb[0].id, lane_after_sb[0].input_bit_positions, self.word_bit_size, -2)
             b0_shift2 = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b0_xor.id + b0_shift2.id
             inputs_pos = b0_xor.input_bit_positions + b0_shift2.input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
 
             # Swap x <- z
             sp_states[2][column_number] = ComponentState(
@@ -197,22 +197,22 @@ class GimliSboxPermutation(Cipher):
             )
             # ------------------------------------------------------
             # y after substitution_layer-box
-            self.add_SHIFT_component(lane_after_sb[1].id, lane_after_sb[1].input_bit_positions, self.word_bit_size, -1)
+            self.add_shift_component(lane_after_sb[1].id, lane_after_sb[1].input_bit_positions, self.word_bit_size, -1)
             b1_shift = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b1_xor.id + b1_shift.id
             inputs_pos = b1_xor.input_bit_positions + b1_shift.input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
 
             sp_states[1][column_number] = ComponentState(
                 [self.get_current_component_id()], [list(range(self.word_bit_size))]
             )
             # ------------------------------------------------------
             # z after substitution_layer-box
-            self.add_SHIFT_component(lane_after_sb[2].id, lane_after_sb[2].input_bit_positions, self.word_bit_size, -3)
+            self.add_shift_component(lane_after_sb[2].id, lane_after_sb[2].input_bit_positions, self.word_bit_size, -3)
             b2_shift = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
             inputs_id = b2_xor.id + b2_shift.id
             inputs_pos = b2_xor.input_bit_positions + b2_shift.input_bit_positions
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
 
             # Swap z <- x
             sp_states[0][column_number] = ComponentState(
@@ -228,7 +228,7 @@ class GimliSboxPermutation(Cipher):
         inputs_id = c.id + states[0][0].id
         inputs_pos = c.input_bit_positions + states[0][0].input_bit_positions
 
-        self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
         states[0][0] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return states

--- a/claasp/ciphers/permutations/grain_core_permutation.py
+++ b/claasp/ciphers/permutations/grain_core_permutation.py
@@ -87,7 +87,7 @@ class GrainCorePermutation(Cipher):
             self.add_round()
 
             state_id_list, state_bit_positions = extract_inputs(*state, [0, 13, 23, 38, 51, 62])
-            new_bit_id = self.add_XOR_component(state_id_list, state_bit_positions, 1).id
+            new_bit_id = self.add_xor_component(state_id_list, state_bit_positions, 1).id
 
             state_id_list, state_bit_positions = extract_inputs(*state, list(range(1, 80)))
             state = state_id_list + [new_bit_id], state_bit_positions + [[0]]

--- a/claasp/ciphers/permutations/keccak_invertible_permutation.py
+++ b/claasp/ciphers/permutations/keccak_invertible_permutation.py
@@ -146,7 +146,7 @@ class KeccakInvertiblePermutation(Cipher):
                     inputs_id = inputs_id + b[i][j].id
                     inputs_pos = inputs_pos + [[k]]
                 inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-                self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
+                self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
                 for i in range(X_NUM):
                     state_new[i][j].id[k] = self.get_current_component_id()
                     state_new[i][j].input_bit_positions[k] = [i]
@@ -168,7 +168,7 @@ class KeccakInvertiblePermutation(Cipher):
         inputs_id = c.id + state[0][0].id
         inputs_pos = c.input_bit_positions + state[0][0].input_bit_positions
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
         state[0][0] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return state

--- a/claasp/ciphers/permutations/keccak_permutation.py
+++ b/claasp/ciphers/permutations/keccak_permutation.py
@@ -148,19 +148,19 @@ class KeccakPermutation(Cipher):
         # A[x,y] = B[x,y] xor ((not B[x+1,y]) and B[x+2,y]), for (x,y) in (range(5), range(5))
         for i in range(X_NUM):
             for j in range(Y_NUM):
-                self.add_NOT_component(
+                self.add_not_component(
                     b[(i + 1) % X_NUM][j].id, b[(i + 1) % X_NUM][j].input_bit_positions, self.word_bit_size
                 )
                 b_not = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
                 inputs_id = b[(i + 2) % X_NUM][j].id + b_not.id
                 inputs_pos = b[(i + 2) % X_NUM][j].input_bit_positions + b_not.input_bit_positions
-                self.add_AND_component(inputs_id, inputs_pos, self.word_bit_size)
+                self.add_and_component(inputs_id, inputs_pos, self.word_bit_size)
                 b_and = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
                 inputs_id = b[i][j].id + b_and.id
                 inputs_pos = b[i][j].input_bit_positions + b_and.input_bit_positions
-                self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+                self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
                 states[i][j] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
         self.add_round_output_nonlinear(states)
 
@@ -179,7 +179,7 @@ class KeccakPermutation(Cipher):
         # A[0,0] = A[0,0] xor RC
         inputs_id = c.id + states[0][0].id
         inputs_pos = c.input_bit_positions + states[0][0].input_bit_positions
-        self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
         states[0][0] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return states
@@ -228,7 +228,7 @@ class KeccakPermutation(Cipher):
                 inputs_id = inputs_id + states[i][j].id
                 inputs_pos = inputs_pos + states[i][j].input_bit_positions
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             c.append(ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))]))
         # D[x] = C[x - 1] xor rot(C[x + 1], 1) for x in range(5)
         d = []
@@ -238,14 +238,14 @@ class KeccakPermutation(Cipher):
             )
             inputs_id = c[(i - 1) % X_NUM].id + [self.get_current_component_id()]
             inputs_pos = c[(i - 1) % X_NUM].input_bit_positions + [list(range(self.word_bit_size))]
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             d.append(ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))]))
         # A[x, y] = A[x, y] xor D[x] for x in range(5), y in range(5)
         for i in range(X_NUM):
             for j in range(Y_NUM):
                 inputs_id = states[i][j].id + d[i].id
                 inputs_pos = states[i][j].input_bit_positions + d[i].input_bit_positions
-                self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+                self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
                 states[i][j] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return states

--- a/claasp/ciphers/permutations/keccak_sbox_permutation.py
+++ b/claasp/ciphers/permutations/keccak_sbox_permutation.py
@@ -145,7 +145,7 @@ class KeccakSboxPermutation(Cipher):
                     inputs_id = inputs_id + b[i][j].id
                     inputs_pos = inputs_pos + [[k]]
                 inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-                self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
+                self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
                 for i in range(X_NUM):
                     state_new[i][j].id[k] = self.get_current_component_id()
                     state_new[i][j].input_bit_positions[k] = [i]
@@ -167,7 +167,7 @@ class KeccakSboxPermutation(Cipher):
         inputs_id = c.id + state[0][0].id
         inputs_pos = c.input_bit_positions + state[0][0].input_bit_positions
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+        self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
         state[0][0] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return state
@@ -215,7 +215,7 @@ class KeccakSboxPermutation(Cipher):
                 inputs_id = inputs_id + state[i][j].id
                 inputs_pos = inputs_pos + state[i][j].input_bit_positions
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             c.append(ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))]))
         # D[x] = C[x - 1] xor rot(C[x + 1], 1) for x in range(5)
         d = []
@@ -225,14 +225,14 @@ class KeccakSboxPermutation(Cipher):
             )
             inputs_id = c[(i - 1) % X_NUM].id + [self.get_current_component_id()]
             inputs_pos = c[(i - 1) % X_NUM].input_bit_positions + [list(range(self.word_bit_size))]
-            self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+            self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
             d.append(ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))]))
         # A[x, y] = A[x, y] xor D[x] for x in range(5), y in range(5)
         for i in range(X_NUM):
             for j in range(Y_NUM):
                 inputs_id = state[i][j].id + d[i].id
                 inputs_pos = state[i][j].input_bit_positions + d[i].input_bit_positions
-                self.add_XOR_component(inputs_id, inputs_pos, self.word_bit_size)
+                self.add_xor_component(inputs_id, inputs_pos, self.word_bit_size)
                 state[i][j] = ComponentState([self.get_current_component_id()], [list(range(self.word_bit_size))])
 
         return state

--- a/claasp/ciphers/permutations/photon_permutation.py
+++ b/claasp/ciphers/permutations/photon_permutation.py
@@ -114,13 +114,13 @@ class PhotonPermutation(Cipher):
         # state[i,0] = state[i,0] xor RC[r] xor IC[i] for i in range(self.d)
         for i in range(self.d):
             inputs_id, inputs_pos = get_inputs_parameter([state[i * self.d], component_rc, components_ic[i]])
-            self.add_XOR_component(inputs_id, inputs_pos, self.cell_bits)
+            self.add_xor_component(inputs_id, inputs_pos, self.cell_bits)
             state[i * self.d] = ComponentState([self.get_current_component_id()], [list(range(self.cell_bits))])
 
         # SubCells
         # state[i,j] = s_box(state[i, j])
         for i in range(self.d * self.d):
-            self.add_SBOX_component(state[i].id, state[i].input_bit_positions, self.cell_bits, S_BOX)
+            self.add_sbox_component(state[i].id, state[i].input_bit_positions, self.cell_bits, S_BOX)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(self.cell_bits))])
 
         # ShiftRows

--- a/claasp/ciphers/permutations/sparkle_permutation.py
+++ b/claasp/ciphers/permutations/sparkle_permutation.py
@@ -114,19 +114,19 @@ class SparklePermutation(Cipher):
         self.add_rotate_component(state_y.id, state_y.input_bit_positions, WORD_SIZE, rotate_y)
         temp = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state_x, temp])
-        self.add_MODADD_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_modadd_component(inputs_id, inputs_pos, WORD_SIZE)
         state_x = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # y = y xor (x >> rotate_x)
         self.add_rotate_component(state_x.id, state_x.input_bit_positions, WORD_SIZE, rotate_x)
         temp = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state_y, temp])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state_y = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # x = x xor ci
         inputs_id, inputs_pos = get_inputs_parameter([state_x, ci])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state_x = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         return state_x, state_y
@@ -138,7 +138,7 @@ class SparklePermutation(Cipher):
             state_i.id, [[state_i.input_bit_positions[0][k] for k in range(WORD_SIZE // 2, WORD_SIZE)]]
         )
         inputs_id, inputs_pos = get_inputs_parameter([state_left, state_right])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE // 2)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE // 2)
         state_left = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE // 2))])
 
         inputs_id, inputs_pos = get_inputs_parameter([state_left, state_right])
@@ -153,13 +153,13 @@ class SparklePermutation(Cipher):
         # tx = x0 xor ... xor x_omega
         # ltx = l(tx)
         inputs_id, inputs_pos = get_inputs_parameter([state[i * 2] for i in range(omega)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         tx = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         tx = self.ell_function(tx)
 
         # ty = y0 xor ... xor y_omega
         inputs_id, inputs_pos = get_inputs_parameter([state[i * 2 + 1] for i in range(omega)])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         ty = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         ty = self.ell_function(ty)
 
@@ -172,24 +172,24 @@ class SparklePermutation(Cipher):
         state_old = deepcopy(state)
         for i in range(omega - 1):
             inputs_id, inputs_pos = get_inputs_parameter([state_old[(omega + i + 1) * 2], state_old[(i + 1) * 2], ty])
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[i * 2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
             state[(omega + i + 1) * 2] = state_old[2 * (i + 1)]
             inputs_id, inputs_pos = get_inputs_parameter(
                 [state_old[(omega + i + 1) * 2 + 1], state_old[(i + 1) * 2 + 1], tx]
             )
-            self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
             state[i * 2 + 1] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
             state[(omega + i + 1) * 2 + 1] = state_old[2 * (i + 1) + 1]
 
         # state[nb-2] = state[nb] ^ x0 ^ tmpy; state[nb] = x0;
         # state[nb-1] = state[nb+1] ^ y0 ^ tmpx; state[nb+1] = y0;
         inputs_id, inputs_pos = get_inputs_parameter([state_old[omega * 2], state_old[0], ty])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[(omega - 1) * 2] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         state[omega * 2] = state_old[0]
         inputs_id, inputs_pos = get_inputs_parameter([state_old[omega * 2 + 1], state_old[1], tx])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[(omega - 1) * 2 + 1] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         state[omega * 2 + 1] = state_old[1]
 
@@ -198,12 +198,12 @@ class SparklePermutation(Cipher):
     def round_function(self, state, constant_ci, constant_r, r):
         # y0 = y0 xor ci[r mod 8]
         inputs_id, inputs_pos = get_inputs_parameter([state[1], constant_ci[r % 8]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[1] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # y1 = y1 xor (r mod 2^32)
         inputs_id, inputs_pos = get_inputs_parameter([state[3], constant_r])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         state[3] = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         # xi, yi = alzette(xi, yi, ci)

--- a/claasp/ciphers/permutations/spongent_pi_fsr_permutation.py
+++ b/claasp/ciphers/permutations/spongent_pi_fsr_permutation.py
@@ -147,7 +147,7 @@ class SpongentPiFSRPermutation(Cipher):
     def icounter_update(self, icounter):
         # x0||x1||x2||x3||x4||x5||x6 -> x1||x2||x3||x4||x5||x6||x0 xor x1
         # fsr_polynomial = x0+x1+1 = x^7+x^6+1
-        self.add_FSR_component(
+        self.add_fsr_component(
             icounter.id, icounter.input_bit_positions, ICOUNTER_SIZE, [[[ICOUNTER_SIZE, [[0], [1]], []]], 1, 1]
         )
         icounter = ComponentState([self.get_current_component_id()], [list(range(ICOUNTER_SIZE))])
@@ -157,19 +157,19 @@ class SpongentPiFSRPermutation(Cipher):
     def round_function(self, state, icounter, const_0):
         # state[len-1] = state[len-1] xor 0|icounter
         inputs_id, inputs_pos = get_inputs_parameter([state[self.state_len - 1], const_0, icounter])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[self.state_len - 1] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[0] = state[0] xor reverse(0|icounter)
         self.add_reverse_component(icounter.id, icounter.input_bit_positions, ICOUNTER_SIZE)
         reverse_icounter = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], reverse_icounter, const_0])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[i] = sbox(state[i])
         for i in range(self.state_len):
-            self.add_SBOX_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
+            self.add_sbox_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[j] = permute(state[j])

--- a/claasp/ciphers/permutations/spongent_pi_permutation.py
+++ b/claasp/ciphers/permutations/spongent_pi_permutation.py
@@ -150,7 +150,7 @@ class SpongentPiPermutation(Cipher):
             icounter.id, icounter.input_bit_positions, SBOX_CELL_SIZE, [0, 7, 1, 2, 3, 4, 5, 6]
         )
         temp_rotate = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
-        self.add_XOR_component(
+        self.add_xor_component(
             temp_rotate.id + const_0.id + icounter.id,
             temp_rotate.input_bit_positions + const_0.input_bit_positions + [[icounter.input_bit_positions[0][2]]],
             SBOX_CELL_SIZE,
@@ -162,19 +162,19 @@ class SpongentPiPermutation(Cipher):
     def round_function(self, state, icounter):
         # state[len-1] = state[len-1] xor 0|icounter
         inputs_id, inputs_pos = get_inputs_parameter([state[self.state_len - 1], icounter])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[self.state_len - 1] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[0] = state[0] xor reverse(0|icounter)
         self.add_reverse_component(icounter.id, icounter.input_bit_positions, SBOX_CELL_SIZE)
         reverse_icounter = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], reverse_icounter])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[i] = sbox(state[i])
         for i in range(self.state_len):
-            self.add_SBOX_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
+            self.add_sbox_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[j] = permute(state[j])

--- a/claasp/ciphers/permutations/spongent_pi_precomputation_permutation.py
+++ b/claasp/ciphers/permutations/spongent_pi_precomputation_permutation.py
@@ -170,19 +170,19 @@ class SpongentPiPrecomputationPermutation(Cipher):
         self.add_constant_component(SBOX_CELL_SIZE, self.icounter_iv[r])
         icounter = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[self.state_len - 1], icounter])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[self.state_len - 1] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[0] = state[0] xor reverse(0|icounter)
         self.add_constant_component(SBOX_CELL_SIZE, self.icounter_iv_rev[r])
         reverse_icounter = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], reverse_icounter])
-        self.add_XOR_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, SBOX_CELL_SIZE)
         state[0] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[i] = sbox(state[i])
         for i in range(self.state_len):
-            self.add_SBOX_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
+            self.add_sbox_component(state[i].id, state[i].input_bit_positions, SBOX_CELL_SIZE, S_BOX)
             state[i] = ComponentState([self.get_current_component_id()], [list(range(SBOX_CELL_SIZE))])
 
         # state[j] = permute(state[j])

--- a/claasp/ciphers/permutations/tinyjambu_32bits_word_permutation.py
+++ b/claasp/ciphers/permutations/tinyjambu_32bits_word_permutation.py
@@ -108,11 +108,11 @@ class TinyJambuWordBasedPermutation(Cipher):
             ],
         )
         inputs_id, inputs_pos = get_inputs_parameter([input1, input2])
-        self.add_AND_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, WORD_SIZE)
 
         inputs_id = [self.get_current_component_id()]
         inputs_pos = [list(range(WORD_SIZE))]
-        self.add_NOT_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_not_component(inputs_id, inputs_pos, WORD_SIZE)
 
         temp = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         input1 = ComponentState(
@@ -130,7 +130,7 @@ class TinyJambuWordBasedPermutation(Cipher):
             ],
         )
         inputs_id, inputs_pos = get_inputs_parameter([state[0], input1, input2, temp, key[r % len(key)]])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         temp = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         for i in range(len(state) - 1):

--- a/claasp/ciphers/permutations/tinyjambu_fsr_32bits_word_permutation.py
+++ b/claasp/ciphers/permutations/tinyjambu_fsr_32bits_word_permutation.py
@@ -99,11 +99,11 @@ class TinyJambuFSRWordBasedPermutation(Cipher):
         # = (s0 xor x47 xor s70*s85 xor s91) xor kr xor 1
         # = fsr xor kr xor 1
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[1], state[2], state[3]])
-        self.add_FSR_component(inputs_id, inputs_pos, STATE_SIZE, [[[STATE_SIZE, FSR_POLYNOMIAL, []]], 1, FSR_LOOPS])
+        self.add_fsr_component(inputs_id, inputs_pos, STATE_SIZE, [[[STATE_SIZE, FSR_POLYNOMIAL, []]], 1, FSR_LOOPS])
         fsr_output = ComponentState([self.get_current_component_id()], [list(range(3 * WORD_SIZE, 4 * WORD_SIZE))])
 
         inputs_id, inputs_pos = get_inputs_parameter([fsr_output, key[r % len(key)], not_constant])
-        self.add_XOR_component(inputs_id, inputs_pos, WORD_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, WORD_SIZE)
         round_output = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         for i in range(len(state) - 1):

--- a/claasp/ciphers/permutations/tinyjambu_permutation.py
+++ b/claasp/ciphers/permutations/tinyjambu_permutation.py
@@ -89,11 +89,11 @@ class TinyJambuPermutation(Cipher):
     def round_function(self, state, key, r):
         # feedback = s0 xor s47 xor (∼ (s70 and s85)) xor s91 xor kr
         inputs_id, inputs_pos = get_inputs_parameter([state[70], state[85]])
-        self.add_AND_component(inputs_id, inputs_pos, 1)
-        self.add_NOT_component([self.get_current_component_id()], [[0]], 1)
+        self.add_and_component(inputs_id, inputs_pos, 1)
+        self.add_not_component([self.get_current_component_id()], [[0]], 1)
         temp = ComponentState([self.get_current_component_id()], [[0]])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[47], state[91], temp, key[(r) % len(key)]])
-        self.add_XOR_component(inputs_id, inputs_pos, 1)
+        self.add_xor_component(inputs_id, inputs_pos, 1)
         temp = ComponentState([self.get_current_component_id()], [[0]])
 
         for i in range(STATE_SIZE - 1):

--- a/claasp/ciphers/permutations/util.py
+++ b/claasp/ciphers/permutations/util.py
@@ -79,7 +79,7 @@ def sub_quarter_round_latin_dances(permutation, state, p1_index, p2_index, p3_in
     p3 = get_2d_array_element_from_1d_array_index(p3_index, state, 4)
     word_size = permutation.WORD_SIZE
 
-    p1 = permutation.add_MODADD_component(
+    p1 = permutation.add_modadd_component(
         [p1.id] + [p2.id],
         get_input_bit_positions_latin_dances(p1, word_size) + get_input_bit_positions_latin_dances(p2, word_size),
         word_size,
@@ -88,7 +88,7 @@ def sub_quarter_round_latin_dances(permutation, state, p1_index, p2_index, p3_in
         p2 = permutation.add_rotate_component(
             [p1.id], get_input_bit_positions_latin_dances(p1, word_size), word_size, rot_amount
         )
-        p3 = permutation.add_XOR_component(
+        p3 = permutation.add_xor_component(
             [p3.id] + [p2.id],
             get_input_bit_positions_latin_dances(p3, word_size) + get_input_bit_positions_latin_dances(p2, word_size),
             word_size,
@@ -96,7 +96,7 @@ def sub_quarter_round_latin_dances(permutation, state, p1_index, p2_index, p3_in
 
         set_2d_array_element_from_1d_array_index(p3_index, state, p3, 4)
     else:
-        p3 = permutation.add_XOR_component(
+        p3 = permutation.add_xor_component(
             [p3.id] + [p1.id],
             get_input_bit_positions_latin_dances(p3, word_size) + get_input_bit_positions_latin_dances(p1, word_size),
             word_size,

--- a/claasp/ciphers/permutations/xoodoo_invertible_permutation.py
+++ b/claasp/ciphers/permutations/xoodoo_invertible_permutation.py
@@ -125,7 +125,7 @@ class XoodooInvertiblePermutation(Cipher):
                 for i in range(PLANE_NUM):
                     inputs_id += [planes[i].id[j]]
                     inputs_pos += [[planes[i].input_bit_positions[j][k]]]
-                self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
+                self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
                 for i in range(PLANE_NUM):
                     planes_new[i].id[j] += [self.get_current_component_id()]
                     planes_new[i].input_bit_positions[j] += [[i]]
@@ -146,7 +146,7 @@ class XoodooInvertiblePermutation(Cipher):
         # A0,0 = A0,0 + Ci
         inputs_id = c.id + [planes[0].id[0]]
         inputs_pos = c.input_bit_positions + [planes[0].input_bit_positions[0]]
-        self.add_XOR_component(inputs_id, inputs_pos, LANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, LANE_SIZE)
         planes[0].id[0] = self.get_current_component_id()
         planes[0].input_bit_positions[0] = list(range(LANE_SIZE))
 

--- a/claasp/ciphers/permutations/xoodoo_permutation.py
+++ b/claasp/ciphers/permutations/xoodoo_permutation.py
@@ -140,12 +140,12 @@ class XoodooPermutation(Cipher):
         for i in range(PLANE_NUM):
             inputs_id = planes[(i + 1) % PLANE_NUM].id
             inputs_pos = planes[(i + 1) % PLANE_NUM].input_bit_positions
-            self.add_NOT_component(inputs_id, inputs_pos, PLANE_SIZE)
+            self.add_not_component(inputs_id, inputs_pos, PLANE_SIZE)
             p = ComponentState([self.get_current_component_id()], [list(range(PLANE_SIZE))])
 
             inputs_id = planes[(i + 2) % PLANE_NUM].id + p.id
             inputs_pos = planes[(i + 2) % PLANE_NUM].input_bit_positions + p.input_bit_positions
-            self.add_AND_component(inputs_id, inputs_pos, PLANE_SIZE)
+            self.add_and_component(inputs_id, inputs_pos, PLANE_SIZE)
             p = ComponentState([self.get_current_component_id()], [list(range(PLANE_SIZE))])
             b.append(deepcopy(p))
         # Ai = Ai + Bi
@@ -153,7 +153,7 @@ class XoodooPermutation(Cipher):
             inputs_id = planes[i].id + b[i].id
             inputs_pos = planes[i].input_bit_positions + b[i].input_bit_positions
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
             planes[i] = ComponentState(
                 [self.get_current_component_id() for _ in range(LANE_NUM)],
                 [[k + j * LANE_SIZE for k in range(LANE_SIZE)] for j in range(LANE_NUM)],
@@ -166,7 +166,7 @@ class XoodooPermutation(Cipher):
         # A0,0 = A0,0 + Ci
         inputs_id = c.id + [planes[0].id[0]]
         inputs_pos = c.input_bit_positions + [planes[0].input_bit_positions[0]]
-        self.add_XOR_component(inputs_id, inputs_pos, LANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, LANE_SIZE)
         planes[0].id[0] = self.get_current_component_id()
         planes[0].input_bit_positions[0] = list(range(LANE_SIZE))
 
@@ -217,7 +217,7 @@ class XoodooPermutation(Cipher):
             inputs_id = inputs_id + planes[i].id
             inputs_pos = inputs_pos + planes[i].input_bit_positions
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
         p = ComponentState(
             [self.get_current_component_id() for _ in range(LANE_NUM)],
             [[k + j * LANE_SIZE for k in range(LANE_SIZE)] for j in range(LANE_NUM)],
@@ -233,14 +233,14 @@ class XoodooPermutation(Cipher):
             inputs_id = inputs_id + q[k].id
             inputs_pos = inputs_pos + q[k].input_bit_positions
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
         p = ComponentState([self.get_current_component_id()], [list(range(PLANE_SIZE))])
         # Ai = Ai + P
         for i in range(PLANE_NUM):
             inputs_id = planes[i].id + p.id
             inputs_pos = planes[i].input_bit_positions + p.input_bit_positions
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
             planes[i] = ComponentState(
                 [self.get_current_component_id() for _ in range(LANE_NUM)],
                 [[k + j * LANE_SIZE for k in range(LANE_SIZE)] for j in range(LANE_NUM)],

--- a/claasp/ciphers/permutations/xoodoo_sbox_permutation.py
+++ b/claasp/ciphers/permutations/xoodoo_sbox_permutation.py
@@ -126,7 +126,7 @@ class XoodooSboxPermutation(Cipher):
                 for i in range(PLANE_NUM):
                     inputs_id += [planes[i].id[j]]
                     inputs_pos += [[planes[i].input_bit_positions[j][k]]]
-                self.add_SBOX_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
+                self.add_sbox_component(inputs_id, inputs_pos, SBOX_SIZE, SBOX)
                 for i in range(PLANE_NUM):
                     planes_new[i].id[j] += [self.get_current_component_id()]
                     planes_new[i].input_bit_positions[j] += [[i]]
@@ -147,7 +147,7 @@ class XoodooSboxPermutation(Cipher):
         # A0,0 = A0,0 + Ci
         inputs_id = c.id + [planes[0].id[0]]
         inputs_pos = c.input_bit_positions + [planes[0].input_bit_positions[0]]
-        self.add_XOR_component(inputs_id, inputs_pos, LANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, LANE_SIZE)
         planes[0].id[0] = self.get_current_component_id()
         planes[0].input_bit_positions[0] = list(range(LANE_SIZE))
 
@@ -195,7 +195,7 @@ class XoodooSboxPermutation(Cipher):
         # P = A0+A1+A2
         inputs_id, inputs_pos = calculate_inputs(planes)
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
         p = ComponentState(
             [self.get_current_component_id() for _ in range(LANE_NUM)],
             [[k + j * LANE_SIZE for k in range(LANE_SIZE)] for j in range(LANE_NUM)],
@@ -211,7 +211,7 @@ class XoodooSboxPermutation(Cipher):
             inputs_id = inputs_id + q[k].id
             inputs_pos = inputs_pos + q[k].input_bit_positions
         inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-        self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
         p = ComponentState([self.get_current_component_id()], [list(range(PLANE_SIZE))])
         # Ai = Ai + P
         for i in range(PLANE_NUM):
@@ -227,7 +227,7 @@ class XoodooSboxPermutation(Cipher):
             inputs_id = inputs_id + p.id
             inputs_pos = inputs_pos + p.input_bit_positions
             inputs_id, inputs_pos = simplify_inputs(inputs_id, inputs_pos)
-            self.add_XOR_component(inputs_id, inputs_pos, PLANE_SIZE)
+            self.add_xor_component(inputs_id, inputs_pos, PLANE_SIZE)
             plane = ComponentState(
                 [self.get_current_component_id() for _ in range(LANE_NUM)],
                 [[k + j * LANE_SIZE for k in range(LANE_SIZE)] for j in range(LANE_NUM)],

--- a/claasp/ciphers/single_component_ciphers/and_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/and_cipher.py
@@ -47,7 +47,7 @@ class AndCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        and_component = self.add_AND_component(
+        and_component = self.add_and_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/single_component_ciphers/fsr_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/fsr_cipher.py
@@ -38,7 +38,7 @@ class FsrCipher(SingleComponentCipher):
             cipher_inputs_bit_size=[register_size],
             cipher_output_bit_size=register_size,
         )
-        fsr_component = self.add_FSR_component(
+        fsr_component = self.add_fsr_component(
             [INPUT_PLAINTEXT],
             [list(range(register_size))],
             register_size,

--- a/claasp/ciphers/single_component_ciphers/modadd_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/modadd_cipher.py
@@ -43,7 +43,7 @@ class ModaddCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        modadd_component = self.add_MODADD_component(
+        modadd_component = self.add_modadd_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/single_component_ciphers/modmul_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/modmul_cipher.py
@@ -43,7 +43,7 @@ class ModmulCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        modmul_component = self.add_MODMUL_component(
+        modmul_component = self.add_modmul_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/single_component_ciphers/modsub_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/modsub_cipher.py
@@ -43,7 +43,7 @@ class ModsubCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        modsub_component = self.add_MODSUB_component(
+        modsub_component = self.add_modsub_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/single_component_ciphers/not_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/not_cipher.py
@@ -35,5 +35,5 @@ class NotCipher(SingleComponentCipher):
             cipher_inputs_bit_size=[bit_size],
             cipher_output_bit_size=bit_size,
         )
-        not_component = self.add_NOT_component([INPUT_PLAINTEXT], [list(range(bit_size))], bit_size)
+        not_component = self.add_not_component([INPUT_PLAINTEXT], [list(range(bit_size))], bit_size)
         add_cipher_output_from_component(self, not_component)

--- a/claasp/ciphers/single_component_ciphers/or_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/or_cipher.py
@@ -42,7 +42,7 @@ class OrCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        or_component = self.add_OR_component(
+        or_component = self.add_or_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/single_component_ciphers/sbox_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/sbox_cipher.py
@@ -38,7 +38,7 @@ class SboxCipher(SingleComponentCipher):
             cipher_inputs_bit_size=[bit_size],
             cipher_output_bit_size=bit_size,
         )
-        sbox_component = self.add_SBOX_component(
+        sbox_component = self.add_sbox_component(
             [INPUT_PLAINTEXT],
             [list(range(bit_size))],
             bit_size,

--- a/claasp/ciphers/single_component_ciphers/shift_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/shift_cipher.py
@@ -36,5 +36,5 @@ class ShiftCipher(SingleComponentCipher):
             cipher_inputs_bit_size=[bit_size],
             cipher_output_bit_size=bit_size,
         )
-        shift_component = self.add_SHIFT_component([INPUT_PLAINTEXT], [list(range(bit_size))], bit_size, parameter)
+        shift_component = self.add_shift_component([INPUT_PLAINTEXT], [list(range(bit_size))], bit_size, parameter)
         add_cipher_output_from_component(self, shift_component)

--- a/claasp/ciphers/single_component_ciphers/xor_cipher.py
+++ b/claasp/ciphers/single_component_ciphers/xor_cipher.py
@@ -42,7 +42,7 @@ class XorCipher(SingleComponentCipher):
             cipher_inputs_bit_size=cipher_inputs_bit_size,
             cipher_output_bit_size=word_bit_size,
         )
-        xor_component = self.add_XOR_component(
+        xor_component = self.add_xor_component(
             cipher_inputs,
             equal_input_bit_positions(word_bit_size, number_of_inputs),
             word_bit_size,

--- a/claasp/ciphers/stream_ciphers/a5_1_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/a5_1_stream_cipher.py
@@ -113,7 +113,7 @@ class A51StreamCipher(Cipher):
             for i in range(len(REGISTERS)):
                 regs_xor_output.append(ComponentState(regs.id, [[regs_output_bit[i]]]))
             inputs_id, inputs_pos = get_inputs_parameter(regs_xor_output)
-            self.add_XOR_component(inputs_id, inputs_pos, 1)
+            self.add_xor_component(inputs_id, inputs_pos, 1)
             cipher_output.append(ComponentState([self.get_current_component_id()], [[0]]))
 
         inputs_id, inputs_pos = get_inputs_parameter(cipher_output)
@@ -135,7 +135,7 @@ class A51StreamCipher(Cipher):
         # load key
         fsr_description = [[[register[BIT_LENGTH], register[TAPPED_BITS]] for register in REGISTERS], 1]
         for i in range(key_bit_size):
-            self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+            self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
             inputs = [regs]
@@ -143,12 +143,12 @@ class A51StreamCipher(Cipher):
                 inputs.append(constant_0[j])
                 inputs.append(ComponentState([INPUT_KEY], [[i]]))
             inputs_id, inputs_pos = get_inputs_parameter(inputs)
-            self.add_XOR_component(inputs_id, inputs_pos, regs_size)
+            self.add_xor_component(inputs_id, inputs_pos, regs_size)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         # load frame
         for i in range(frame_bit_size):
-            self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+            self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
             inputs = [regs]
@@ -156,7 +156,7 @@ class A51StreamCipher(Cipher):
                 inputs.append(constant_0[j])
                 inputs.append(ComponentState([INPUT_FRAME], [[i]]))
             inputs_id, inputs_pos = get_inputs_parameter(inputs)
-            self.add_XOR_component(inputs_id, inputs_pos, regs_size)
+            self.add_xor_component(inputs_id, inputs_pos, regs_size)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         # normal clocked without output
@@ -165,14 +165,14 @@ class A51StreamCipher(Cipher):
             1,
             number_of_normal_clocks_at_initialization,
         ]
-        self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+        self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
         regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         return regs
 
     def round_function(self, regs, regs_size, fsr_description):
         self.add_round()
-        self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+        self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
         regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         return regs

--- a/claasp/ciphers/stream_ciphers/a5_2_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/a5_2_stream_cipher.py
@@ -114,11 +114,11 @@ class A52StreamCipher(Cipher):
             for k in regs_and_bit:
                 for i in range(len(k)):
                     for j in range(i + 1, len(k)):
-                        self.add_AND_component(regs.id, [[k[i], k[j]]], 1)
+                        self.add_and_component(regs.id, [[k[i], k[j]]], 1)
                         regs_xor_output.append(ComponentState([self.get_current_component_id()], [[0]]))
 
             inputs_id, inputs_pos = get_inputs_parameter(regs_xor_output)
-            self.add_XOR_component(inputs_id, inputs_pos, 1)
+            self.add_xor_component(inputs_id, inputs_pos, 1)
             cipher_output.append(ComponentState([self.get_current_component_id()], [[0]]))
 
             regs = self._round_function(regs=regs, regs_size=regs_size, fsr_description=fsr_description)
@@ -142,7 +142,7 @@ class A52StreamCipher(Cipher):
         # load key
         fsr_description = [[[register[BIT_LENGTH], register[TAPPED_BITS]] for register in REGISTERS], 1]
         for i in range(key_bit_size):
-            self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+            self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
             inputs = [regs]
@@ -150,12 +150,12 @@ class A52StreamCipher(Cipher):
                 inputs.append(constant_0[j])
                 inputs.append(ComponentState([INPUT_KEY], [[i]]))
             inputs_id, inputs_pos = get_inputs_parameter(inputs)
-            self.add_XOR_component(inputs_id, inputs_pos, regs_size)
+            self.add_xor_component(inputs_id, inputs_pos, regs_size)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         # load frame
         for i in range(frame_bit_size):
-            self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+            self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
             inputs = [regs]
@@ -163,13 +163,13 @@ class A52StreamCipher(Cipher):
                 inputs.append(constant_0[j])
                 inputs.append(ComponentState([INPUT_FRAME], [[i]]))
             inputs_id, inputs_pos = get_inputs_parameter(inputs)
-            self.add_XOR_component(inputs_id, inputs_pos, regs_size)
+            self.add_xor_component(inputs_id, inputs_pos, regs_size)
             regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
         # For A5/2, somebits is fixed to 1 after frame is loaded
         self.add_constant_component(regs_size, MASK_AFTER_FRAME_SETUP)
         mask = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
         inputs_id, inputs_pos = get_inputs_parameter([regs, mask])
-        self.add_OR_component(inputs_id, inputs_pos, regs_size)
+        self.add_or_component(inputs_id, inputs_pos, regs_size)
         regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         # normal clocked without output
@@ -178,14 +178,14 @@ class A52StreamCipher(Cipher):
             1,
             number_of_normal_clocks_at_initialization,
         ]
-        self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+        self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
         regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         return regs
 
     def _round_function(self, regs, regs_size, fsr_description):
         self.add_round()
-        self.add_FSR_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
+        self.add_fsr_component(regs.id, regs.input_bit_positions, regs_size, fsr_description)
         regs = ComponentState([self.get_current_component_id()], [list(range(regs_size))])
 
         return regs

--- a/claasp/ciphers/stream_ciphers/bivium_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/bivium_stream_cipher.py
@@ -95,7 +95,7 @@ class BiviumStreamCipher(Cipher):
         for clock_number in range(self._get_len_of_keystream(keystream_bit_len)):
             self.add_round()
             key_stream = self.bivium_key_stream(biv_state, clock_number, key_stream)
-            biv_state = self.add_FSR_component(
+            biv_state = self.add_fsr_component(
                 [biv_state], [list(range(self.state_bit_size))], self.state_bit_size, NLFSR_DESCR
             ).id
 
@@ -126,8 +126,8 @@ class BiviumStreamCipher(Cipher):
         cst0 = self.add_constant_component(13, 0x0).id
         state0_id = [cst0] + key[0] + [cst0] + iv[0]
         state0_pos = [list(range(13)), list(range(self.key_bit_size)), list(range(4)), list(range(self.iv_bit_size))]
-        biv_state = self.add_FSR_component(state0_id, state0_pos, self.state_bit_size, NLFSR_DESCR).id
-        biv_state = self.add_FSR_component(
+        biv_state = self.add_fsr_component(state0_id, state0_pos, self.state_bit_size, NLFSR_DESCR).id
+        biv_state = self.add_fsr_component(
             [biv_state],
             [list(range(self.state_bit_size))],
             self.state_bit_size,
@@ -137,7 +137,7 @@ class BiviumStreamCipher(Cipher):
         return biv_state
 
     def bivium_key_stream(self, state, clock_number, ks):
-        z = self.add_XOR_component([state, state, state, state], [[0], [27], [93], [108]], 1).id
+        z = self.add_xor_component([state, state, state, state], [[0], [27], [93], [108]], 1).id
         if clock_number == 0:
             ks = self.add_round_output_component([z], [[0]], 1).id
         else:

--- a/claasp/ciphers/stream_ciphers/bluetooth_stream_cipher_e0.py
+++ b/claasp/ciphers/stream_ciphers/bluetooth_stream_cipher_e0.py
@@ -98,7 +98,7 @@ class BluetoothStreamCipherE0(Cipher):
             self.add_round()
             keystream = self.e0_keystream(lfsr_state, fsm_id, fsm_pos, clock_number, keystream)
             fsm_id, fsm_pos = self.e0_nonlinear_function(lfsr_state, fsm_id, fsm_pos)
-            lfsr_state = self.add_FSR_component(
+            lfsr_state = self.add_fsr_component(
                 [lfsr_state], [list(range(self.lfsr_state_bit_size))], self.lfsr_state_bit_size, LFSR_DESCR
             ).id
 
@@ -115,28 +115,28 @@ class BluetoothStreamCipherE0(Cipher):
         z_pos = [57]
         u_pos = [96]
 
-        y0 = self.add_XOR_component([x_id, y_id, z_id, u_id], [x_pos, y_pos, z_pos, u_pos], 1).id
+        y0 = self.add_xor_component([x_id, y_id, z_id, u_id], [x_pos, y_pos, z_pos, u_pos], 1).id
 
-        y1_0 = self.add_XOR_component([y_id, z_id, u_id], [y_pos, z_pos, u_pos], 1).id
-        y1_0 = self.add_AND_component([x_id, y1_0], [x_pos, [0]], 1).id
-        y1_1 = self.add_XOR_component([z_id, u_id], [z_pos, u_pos], 1).id
-        y1_1 = self.add_AND_component([y_id, y1_1], [y_pos, [0]], 1).id
-        y1_2 = self.add_AND_component([z_id, u_id], [z_pos, u_pos], 1).id
-        y1 = self.add_XOR_component([y1_0, y1_1, y1_2], [[0], [0], [0]], 1).id
+        y1_0 = self.add_xor_component([y_id, z_id, u_id], [y_pos, z_pos, u_pos], 1).id
+        y1_0 = self.add_and_component([x_id, y1_0], [x_pos, [0]], 1).id
+        y1_1 = self.add_xor_component([z_id, u_id], [z_pos, u_pos], 1).id
+        y1_1 = self.add_and_component([y_id, y1_1], [y_pos, [0]], 1).id
+        y1_2 = self.add_and_component([z_id, u_id], [z_pos, u_pos], 1).id
+        y1 = self.add_xor_component([y1_0, y1_1, y1_2], [[0], [0], [0]], 1).id
 
-        y2 = self.add_AND_component([x_id, y_id, z_id, u_id], [x_pos, y_pos, z_pos, u_pos], 1).id
+        y2 = self.add_and_component([x_id, y_id, z_id, u_id], [x_pos, y_pos, z_pos, u_pos], 1).id
 
-        t0_0 = self.add_AND_component([y0, fsm_id[2]], [[0], fsm_pos[2]], 1).id
-        t0 = self.add_XOR_component(
+        t0_0 = self.add_and_component([y0, fsm_id[2]], [[0], fsm_pos[2]], 1).id
+        t0 = self.add_xor_component(
             [t0_0, y1, fsm_id[3], fsm_id[2], fsm_id[1], fsm_id[0]],
             [[0], [0], fsm_pos[3], fsm_pos[2], fsm_pos[1], fsm_pos[0]],
             1,
         ).id
 
-        t1_0 = self.add_AND_component([y1, fsm_id[3]], [[0], fsm_pos[3]], 1).id
-        t1_1 = self.add_AND_component([y0, fsm_id[2], fsm_id[3]], [[0], fsm_pos[2], fsm_pos[3]], 1).id
-        t1_2 = self.add_AND_component([y1, y0, fsm_id[2]], [[0], [0], fsm_pos[2]], 1).id
-        t1 = self.add_XOR_component(
+        t1_0 = self.add_and_component([y1, fsm_id[3]], [[0], fsm_pos[3]], 1).id
+        t1_1 = self.add_and_component([y0, fsm_id[2], fsm_id[3]], [[0], fsm_pos[2], fsm_pos[3]], 1).id
+        t1_2 = self.add_and_component([y1, y0, fsm_id[2]], [[0], [0], fsm_pos[2]], 1).id
+        t1 = self.add_xor_component(
             [y2, t1_0, t1_1, t1_2, fsm_id[3], fsm_id[0]], [[0], [0], [0], [0], fsm_pos[3], fsm_pos[0]], 1
         ).id
 
@@ -169,7 +169,7 @@ class BluetoothStreamCipherE0(Cipher):
     def e0_keystream(self, lfsr_state, fsm_id, fsm_pos, clock_number, ks):
         ks_id = [lfsr_state, lfsr_state, lfsr_state, lfsr_state, fsm_id[2]]
         ks_pos = [[1], [32], [57], [96], fsm_pos[2]]
-        z = self.add_XOR_component(ks_id, ks_pos, 1).id
+        z = self.add_xor_component(ks_id, ks_pos, 1).id
         if clock_number == 0:
             ks = self.add_round_output_component([z], [[0]], 1).id
         else:

--- a/claasp/ciphers/stream_ciphers/chacha_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/chacha_stream_cipher.py
@@ -113,7 +113,7 @@ class ChachaStreamCipher(ChachaPermutation):
         lst_ids = []
         for i in range(4):
             for j in range(4):
-                state_of_final_components[i][j] = self.add_MODADD_component(
+                state_of_final_components[i][j] = self.add_modadd_component(
                     [input_state_of_components[i][j].id] + [state_of_components_permutation[i][j].id],
                     input_state_of_components[i][j].input_bit_positions + [list(range(32))],
                     self.WORD_SIZE

--- a/claasp/ciphers/stream_ciphers/snow3g_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/snow3g_stream_cipher.py
@@ -144,7 +144,7 @@ class Snow3GStreamCipher(Cipher):
         const_1 = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
         # lfsr cells-1th to 4th:  k_0+1, k_1+1, k_2+1, k_3+1
         for i in range(4):
-            self.add_XOR_component(
+            self.add_xor_component(
                 [key.id[0]] + const_1,
                 [list(range(i * WORD_SIZE, (i + 1) * WORD_SIZE)), list(range(WORD_SIZE))],
                 WORD_SIZE,
@@ -157,12 +157,12 @@ class Snow3GStreamCipher(Cipher):
             LFSR_P[i + 4] = [list(range(i * WORD_SIZE, (i + 1) * WORD_SIZE))]
 
         # lfsr[8]: k0+1
-        self.add_XOR_component([key.id[0]] + const_1, [list(range(WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE)
+        self.add_xor_component([key.id[0]] + const_1, [list(range(WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE)
         LFSR_S[8] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
         LFSR_P[8] = [list(range(WORD_SIZE))]
 
         # lfsr[9]: k1+1+iv3
-        self.add_XOR_component(
+        self.add_xor_component(
             [key.id[0]] + const_1 + [iv[0][0]],
             [list(range(WORD_SIZE, 2 * WORD_SIZE)), list(range(WORD_SIZE)), list(range(3 * WORD_SIZE, 4 * WORD_SIZE))],
             WORD_SIZE,
@@ -171,7 +171,7 @@ class Snow3GStreamCipher(Cipher):
         LFSR_P[9] = [list(range(WORD_SIZE))]
 
         # lfsr[10] :k2+1+iv2
-        self.add_XOR_component(
+        self.add_xor_component(
             [key.id[0]] + const_1 + [iv[0][0]],
             [
                 list(range(2 * WORD_SIZE, 3 * WORD_SIZE)),
@@ -184,14 +184,14 @@ class Snow3GStreamCipher(Cipher):
         LFSR_P[10] = [list(range(WORD_SIZE))]
 
         # lfsr[11]: k3+1
-        self.add_XOR_component(
+        self.add_xor_component(
             [key.id[0]] + const_1, [list(range(3 * WORD_SIZE, 4 * WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE
         )
         LFSR_S[11] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
         LFSR_P[11] = [list(range(WORD_SIZE))]
 
         # lfsr[12] : k0+iv1
-        self.add_XOR_component(
+        self.add_xor_component(
             [key.id[0], iv[0][0]], [list(range(WORD_SIZE)), list(range(WORD_SIZE, 2 * WORD_SIZE))], WORD_SIZE
         )
         LFSR_S[12] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
@@ -203,7 +203,7 @@ class Snow3GStreamCipher(Cipher):
             LFSR_P[12 + i + 1] = [list(range((i + 1) * WORD_SIZE, (i + 2) * WORD_SIZE))]
 
         # s15=k3+iv0
-        self.add_XOR_component(
+        self.add_xor_component(
             [key.id[0], iv[0][0]], [list(range(3 * WORD_SIZE, 4 * WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE
         )
         LFSR_S[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
@@ -216,16 +216,16 @@ class Snow3GStreamCipher(Cipher):
         FSM_P[1] = [list(range(8))] * 4
 
     def clock_fsm(self, const_0):
-        self.add_MODADD_component(LFSR_S[15] + FSM_R[0], LFSR_P[15] + FSM_P[0], WORD_SIZE)
+        self.add_modadd_component(LFSR_S[15] + FSM_R[0], LFSR_P[15] + FSM_P[0], WORD_SIZE)
         F = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_XOR_component(F + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
+        self.add_xor_component(F + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
         F = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_XOR_component(FSM_R[2] + LFSR_S[5], FSM_P[2] + LFSR_P[5], WORD_SIZE)
+        self.add_xor_component(FSM_R[2] + LFSR_S[5], FSM_P[2] + LFSR_P[5], WORD_SIZE)
         r = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_MODADD_component(r + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
+        self.add_modadd_component(r + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
         r = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
         FSM_R[2], FSM_P[2] = self.S2(FSM_R[1], FSM_P[1], const_0)
@@ -238,7 +238,7 @@ class Snow3GStreamCipher(Cipher):
     def S1(self, w_id, w_pos, const_0):
         sba = []
         for i in range(4):
-            self.add_SBOX_component(w_id, [w_pos[0][i * 8 : i * 8 + 8]], 8, SBoxA)
+            self.add_sbox_component(w_id, [w_pos[0][i * 8 : i * 8 + 8]], 8, SBoxA)
             sba.append([ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]])
 
         id_0 = sba[0] + [const_0.id[0]] + sba[0] + sba[0] + [const_0.id[0]] + sba[0] + sba[0]
@@ -249,23 +249,23 @@ class Snow3GStreamCipher(Cipher):
 
         ids = id_0 + sba[1] + sba[2] + id_3 + sba[3]
         pos = pos_0 + [list(range(8))] + [list(range(8))] + pos_0 + [list(range(8))]
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r0 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = id_0 + sba[0] + id_1 + sba[2] + sba[3]
         pos = pos_0 + [list(range(8))] + pos_0 + [list(range(8))] + [list(range(8))]
 
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r1 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = sba[0] + id_1 + sba[1] + id_2 + sba[3]
         pos = [list(range(8))] + pos_0 + [list(range(8))] + pos_0 + [list(range(8))]
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r2 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = sba[0] + sba[1] + id_2 + sba[2] + id_3
         pos = [list(range(8))] + [list(range(8))] + pos_0 + [list(range(8))] + pos_0
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r3 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         S1_id = r0 + r1 + r2 + r3
@@ -275,7 +275,7 @@ class Snow3GStreamCipher(Cipher):
     def S2(self, w_id, w_pos, const_0):
         sbq = []
         for i in range(4):
-            self.add_SBOX_component([w_id[i]], [w_pos[i]], 8, SBoxQ)
+            self.add_sbox_component([w_id[i]], [w_pos[i]], 8, SBoxQ)
             sbq.append([ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]])
 
         id_0 = sbq[0] + [const_0.id[0]] + sbq[0] + sbq[0] + [const_0.id[0]] + sbq[0] + [const_0.id[0]] + sbq[0]
@@ -286,23 +286,23 @@ class Snow3GStreamCipher(Cipher):
 
         ids = id_0 + sbq[1] + sbq[2] + id_3 + sbq[3]
         pos = pos_0 + [list(range(8))] + [list(range(8))] + pos_0 + [list(range(8))]
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r0 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = id_0 + sbq[0] + id_1 + sbq[2] + sbq[3]
         pos = pos_0 + [list(range(8))] + pos_0 + [list(range(8))] + [list(range(8))]
 
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r1 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = sbq[0] + id_1 + sbq[1] + id_2 + sbq[3]
         pos = [list(range(8))] + pos_0 + [list(range(8))] + pos_0 + [list(range(8))]
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r2 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         ids = sbq[0] + sbq[1] + id_2 + sbq[2] + id_3
         pos = [list(range(8))] + [list(range(8))] + pos_0 + [list(range(8))] + pos_0
-        self.add_XOR_component(ids, pos, 8)
+        self.add_xor_component(ids, pos, 8)
         r3 = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
 
         S2_id = r0 + r1 + r2 + r3
@@ -311,7 +311,7 @@ class Snow3GStreamCipher(Cipher):
 
     def clock_lfsr_initialization_mode(self, F, const_0):
         self.clock_lfsr(const_0)
-        self.add_XOR_component(LFSR_S[15] + F, LFSR_P[15] + [list(range(WORD_SIZE))], WORD_SIZE)
+        self.add_xor_component(LFSR_S[15] + F, LFSR_P[15] + [list(range(WORD_SIZE))], WORD_SIZE)
         LFSR_S[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
         LFSR_P[15] = [list(range(WORD_SIZE))]
 
@@ -328,7 +328,7 @@ class Snow3GStreamCipher(Cipher):
             fsr_ids = fsr_ids + LFSR_S[i]
             fsr_pos = fsr_pos + LFSR_P[i]
 
-        self.add_FSR_component(fsr_ids, fsr_pos, WORD_SIZE * WORD_NUM, LFSR_DESCR)
+        self.add_fsr_component(fsr_ids, fsr_pos, WORD_SIZE * WORD_NUM, LFSR_DESCR)
         S15 = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE * WORD_NUM))]).id[0]]
         for i in range(WORD_NUM - 1):
             LFSR_S[i] = LFSR_S[i + 1]
@@ -341,13 +341,13 @@ class Snow3GStreamCipher(Cipher):
         S0a_id, S0a_pos = self.MULalpha(S0, const_0)
         s0_id = S0 + [const_0.id[0]] + S0a_id
         s0_pos = [LFSR_P[0][0][8:WORD_SIZE], list(range(8))] + S0a_pos
-        self.add_XOR_component(s0_id, s0_pos, WORD_SIZE)
+        self.add_xor_component(s0_id, s0_pos, WORD_SIZE)
         S0a = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
         S11a_id, S11a_pos = self.DIValpha(LFSR_S[11], const_0)
         s11_id = [const_0.id[0]] + LFSR_S[11] + S11a_id
         s11_pos = [list(range(8)), LFSR_P[11][0][0:24]] + S11a_pos
-        self.add_XOR_component(s11_id, s11_pos, WORD_SIZE)
+        self.add_xor_component(s11_id, s11_pos, WORD_SIZE)
         S11a = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
         return S0a, S11a
@@ -390,12 +390,12 @@ class Snow3GStreamCipher(Cipher):
         m_id2 = V + [const_0.id[0]] + V + [const_0.id[0]] + V + [const_0.id[0]] + V
         m_pos2 = [[P[0]]] + [[0]] + [[P[0]]] + [[0]] + [[P[0]]] + [[0, 1]] + [[P[0]]]
 
-        self.add_XOR_component(m_id1 + m_id2, m_pos1 + m_pos2, 8)
+        self.add_xor_component(m_id1 + m_id2, m_pos1 + m_pos2, 8)
         V = [ComponentState([self.get_current_component_id()], [list(range(8))]).id[0]]
         return V
 
     def snow3g_key_stream(self, F, keystream, clock_number):
-        key_word = self.add_XOR_component(F + LFSR_S[0], [list(range(WORD_SIZE))] + LFSR_P[0], WORD_SIZE).id
+        key_word = self.add_xor_component(F + LFSR_S[0], [list(range(WORD_SIZE))] + LFSR_P[0], WORD_SIZE).id
         if clock_number == 0:
             keystream = self.add_round_output_component([key_word], [list(range(WORD_SIZE))], WORD_SIZE).id
         else:

--- a/claasp/ciphers/stream_ciphers/trivium_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/trivium_stream_cipher.py
@@ -90,7 +90,7 @@ class TriviumStreamCipher(Cipher):
         for clock_number in range(self.get_keystream_bit_len(keystream_bit_len)):
             self.add_round()
             key_stream = self.trivium_key_stream(triv_state, clock_number, key_stream)
-            triv_state = self.add_FSR_component(
+            triv_state = self.add_fsr_component(
                 [triv_state], [list(range(self.state_bit_size))], state_bit_size, NLFSR_DESCR
             ).id
 
@@ -128,7 +128,7 @@ class TriviumStreamCipher(Cipher):
             list(range(self.iv_bit_size)),
             list(range(111)),
         ]
-        triv_state = self.add_FSR_component(state0_id, state0_pos, self.state_bit_size,
+        triv_state = self.add_fsr_component(state0_id, state0_pos, self.state_bit_size,
                                             NLFSR_DESCR + [self.number_of_initialization_clocks]).id
         self.add_round_output_component([triv_state], [list(range(self.state_bit_size))], self.state_bit_size)
         return triv_state
@@ -136,7 +136,7 @@ class TriviumStreamCipher(Cipher):
     def trivium_key_stream(self, state, clock_number, key_stream):
         k_bits_id = [state, state, state, state, state, state]
         k_bits_pos = [[0], [27], [93], [108], [177], [222]]
-        key_stream_bit = self.add_XOR_component(k_bits_id, k_bits_pos, 1).id
+        key_stream_bit = self.add_xor_component(k_bits_id, k_bits_pos, 1).id
         if clock_number == 0:
             key_stream = self.add_round_output_component([key_stream_bit], [[0]], 1).id
         else:

--- a/claasp/ciphers/stream_ciphers/zuc_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/zuc_stream_cipher.py
@@ -131,10 +131,10 @@ class ZucStreamCipher(Cipher):
 
     def lfsr_with_initialization_mode(self, W):
         self.clocking_lfsr()
-        self.add_SHIFT_component([W.id[0]], [list(range(WORD_SIZE))], WORD_SIZE, 1)
+        self.add_shift_component([W.id[0]], [list(range(WORD_SIZE))], WORD_SIZE, 1)
         W = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
-        self.add_MODADD_component(
+        self.add_modadd_component(
             LFSR_S[15] + [W.id[0]], LFSR_P[15] + [list(range(1, WORD_SIZE))], LFSR_W_SIZE, (2**LFSR_W_SIZE) - 1
         )
         LFSR_S[15] = [ComponentState([self.get_current_component_id()], [list(range(LFSR_W_SIZE))]).id[0]]
@@ -156,7 +156,7 @@ class ZucStreamCipher(Cipher):
         pr5 = ComponentState([self.get_current_component_id()], [list(range(LFSR_W_SIZE))])
 
         ids = [pr1.id[0], pr2.id[0], pr3.id[0], pr4.id[0], pr5.id[0]] + LFSR_S[0]
-        self.add_MODADD_component(ids, [list(range(LFSR_W_SIZE))] * 5 + LFSR_P[0], LFSR_W_SIZE, (2**LFSR_W_SIZE) - 1)
+        self.add_modadd_component(ids, [list(range(LFSR_W_SIZE))] * 5 + LFSR_P[0], LFSR_W_SIZE, (2**LFSR_W_SIZE) - 1)
         s16 = ComponentState([self.get_current_component_id()], [list(range(LFSR_W_SIZE))])
 
         for i in range(15):
@@ -169,20 +169,20 @@ class ZucStreamCipher(Cipher):
         s15h_id, s15h_ps = self.lfsr_S_high_16bits(LFSR_S[15], LFSR_P[15])
         s14l_id, s14l_ps = self.lfsr_S_low_16bits(LFSR_S[14], LFSR_P[14])
 
-        self.add_XOR_component(s15h_id + s14l_id + FSM_R[0], s15h_ps + s14l_ps + FSM_P[0], WORD_SIZE)
+        self.add_xor_component(s15h_id + s14l_id + FSM_R[0], s15h_ps + s14l_ps + FSM_P[0], WORD_SIZE)
 
         W = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
-        self.add_MODADD_component([W.id[0]] + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
+        self.add_modadd_component([W.id[0]] + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
         W = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         s11l_id, s11l_ps = self.lfsr_S_low_16bits(LFSR_S[11], LFSR_P[11])
         s9h_id, s9h_ps = self.lfsr_S_high_16bits(LFSR_S[9], LFSR_P[9])
-        self.add_MODADD_component(FSM_R[0] + s11l_id + s9h_id, FSM_P[0] + s11l_ps + s9h_ps, WORD_SIZE)
+        self.add_modadd_component(FSM_R[0] + s11l_id + s9h_id, FSM_P[0] + s11l_ps + s9h_ps, WORD_SIZE)
         W1 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         s7l_id, s7l_ps = self.lfsr_S_low_16bits(LFSR_S[7], LFSR_P[7])
         s5h_id, s5h_ps = self.lfsr_S_high_16bits(LFSR_S[5], LFSR_P[5])
-        self.add_XOR_component(FSM_R[1] + s7l_id + s5h_id, FSM_P[1] + s7l_ps + s5h_ps, WORD_SIZE)
+        self.add_xor_component(FSM_R[1] + s7l_id + s5h_id, FSM_P[1] + s7l_ps + s5h_ps, WORD_SIZE)
         W2 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
 
         l1 = self.linear_transform_L1(W1, W2)
@@ -193,10 +193,10 @@ class ZucStreamCipher(Cipher):
         return W
 
     def s_box_layer(self, lo):
-        s_box_1 = self.add_SBOX_component([lo.id[0]], [list(range(8))], 8, Sbox1).id
-        s_box_2 = self.add_SBOX_component([lo.id[0]], [list(range(8, 16))], 8, Sbox2).id
-        s_box_3 = self.add_SBOX_component([lo.id[0]], [list(range(16, 24))], 8, Sbox1).id
-        s_box_4 = self.add_SBOX_component([lo.id[0]], [list(range(24, 32))], 8, Sbox2).id
+        s_box_1 = self.add_sbox_component([lo.id[0]], [list(range(8))], 8, Sbox1).id
+        s_box_2 = self.add_sbox_component([lo.id[0]], [list(range(8, 16))], 8, Sbox2).id
+        s_box_3 = self.add_sbox_component([lo.id[0]], [list(range(16, 24))], 8, Sbox1).id
+        s_box_4 = self.add_sbox_component([lo.id[0]], [list(range(24, 32))], 8, Sbox2).id
         s_box_id = [s_box_1, s_box_2, s_box_3, s_box_4]
         return s_box_id, [list(range(8))] * 4
 
@@ -207,7 +207,7 @@ class ZucStreamCipher(Cipher):
         rot4 = self.linear_layer_rotation(W1, W2, -24)
         ids = [W1.id[0], W2.id[0], rot1.id[0], rot2.id[0], rot3.id[0], rot4.id[0]]
         pos = [list(range(16, WORD_SIZE)), list(range(0, 16))] + [list(range(WORD_SIZE))] * 4
-        self.add_XOR_component(ids, pos, WORD_SIZE)
+        self.add_xor_component(ids, pos, WORD_SIZE)
         l1 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         return l1
 
@@ -218,14 +218,14 @@ class ZucStreamCipher(Cipher):
         rot4 = self.linear_layer_rotation(W1, W2, -30)
         ids = [W1.id[0], W2.id[0], rot1.id[0], rot2.id[0], rot3.id[0], rot4.id[0]]
         pos = [list(range(16, WORD_SIZE)), list(range(16))] + [list(range(WORD_SIZE))] * 4
-        self.add_XOR_component(ids, pos, WORD_SIZE)
+        self.add_xor_component(ids, pos, WORD_SIZE)
         l2 = ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))])
         return l2
 
     def key_stream(self, w, clock_number, key_st):
         s2l_id, s2l_ps = self.lfsr_S_low_16bits(LFSR_S[2], LFSR_P[2])
         s0h_id, s0h_ps = self.lfsr_S_high_16bits(LFSR_S[0], LFSR_P[0])
-        key_word = self.add_XOR_component(
+        key_word = self.add_xor_component(
             [w.id[0]] + s2l_id + s0h_id, [list(range(WORD_SIZE))] + s2l_ps + s0h_ps, WORD_SIZE
         ).id
         if clock_number == 0:

--- a/claasp/ciphers/toys/fancy_block_cipher.py
+++ b/claasp/ciphers/toys/fancy_block_cipher.py
@@ -120,7 +120,7 @@ class FancyBlockCipher(Cipher):
                     "round_key_output",
                 )
                 constant = self.add_constant_component(block_bit_size, 0xFEDCBA)
-                type1_xor_with_key = self.add_XOR_component(
+                type1_xor_with_key = self.add_xor_component(
                     [constant.id, linear_layer.id, type1_key_schedule_xor.id, type1_key_schedule_and.id],
                     [
                         list(range(block_bit_size)),
@@ -148,18 +148,18 @@ class FancyBlockCipher(Cipher):
                 b = self.sbox_bit_size
                 type2_sboxes = []
                 for j in range(self.num_sboxes):
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type1_xor_with_key.id], [list(range(j * b + 0, j * b + b))], b, self.sbox_description
                     )
                     type2_sboxes.append(sbox)
 
                 # key schedule for type 2 round
-                type2_key_schedule_xor = self.add_XOR_component(
+                type2_key_schedule_xor = self.add_xor_component(
                     [type1_key_schedule_xor.id, type1_key_schedule_and.id],
                     [list(range(int(key_bit_size / 2))), list(range(int(key_bit_size / 2)))],
                     int(key_bit_size / 2),
                 )
-                type2_key_schedule_and = self.add_AND_component(
+                type2_key_schedule_and = self.add_and_component(
                     [type2_key_schedule_xor.id, type1_key_schedule_and.id],
                     [list(range(int(key_bit_size / 2))) for _ in range(2)],
                     int(key_bit_size / 2),
@@ -172,7 +172,7 @@ class FancyBlockCipher(Cipher):
                 )
 
                 # Modular addition 8
-                type2_modadd1 = self.add_MODADD_component(
+                type2_modadd1 = self.add_modadd_component(
                     [
                         type2_key_schedule_xor.id,
                         type2_sboxes[0].id,
@@ -191,7 +191,7 @@ class FancyBlockCipher(Cipher):
                 )
 
                 # Modular addition 9
-                type2_modadd2 = self.add_MODADD_component(
+                type2_modadd2 = self.add_modadd_component(
                     [
                         type2_key_schedule_xor.id,
                         type2_sboxes[3].id,
@@ -218,7 +218,7 @@ class FancyBlockCipher(Cipher):
                 )
 
                 # Right shift_3 11
-                shift = self.add_SHIFT_component(
+                shift = self.add_shift_component(
                     [type2_sboxes[4].id, type2_sboxes[5].id],
                     [list(range(int(self.sbox_bit_size / 2), self.sbox_bit_size)), list(range(self.sbox_bit_size))],
                     int(block_bit_size / 4),
@@ -226,14 +226,14 @@ class FancyBlockCipher(Cipher):
                 )
 
                 # xor 12
-                type2_xor1 = self.add_XOR_component(
+                type2_xor1 = self.add_xor_component(
                     [type2_modadd1.id, rotation.id, type2_key_schedule_and.id],
                     [list(range(int(block_bit_size / 4))) for _ in range(3)],
                     int(block_bit_size / 4),
                 )
 
                 # xor 13
-                type2_xor2 = self.add_XOR_component(
+                type2_xor2 = self.add_xor_component(
                     [type2_modadd2.id, shift.id, type2_key_schedule_and.id],
                     [
                         list(range(int(block_bit_size / 4))),
@@ -264,38 +264,38 @@ class FancyBlockCipher(Cipher):
         for j in range(self.num_sboxes):
             b = self.sbox_bit_size
             if round_number == 0:
-                sbox = self.add_SBOX_component(
+                sbox = self.add_sbox_component(
                     [INPUT_PLAINTEXT], [list(range(j * b + 0, j * b + b))], b, self.sbox_description
                 )
             else:
                 if j == 0:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_modadd1.id], [list(range(4))], self.sbox_bit_size, self.sbox_description
                     )
                 elif j == 1:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_modadd1.id, type2_xor1.id],
                         [list(range(4, 6)), list(range(2))],
                         self.sbox_bit_size,
                         self.sbox_description,
                     )
                 elif j == 2:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_xor1.id], [list(range(2, 6))], self.sbox_bit_size, self.sbox_description
                     )
                 elif j == 3:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_modadd2.id], [list(range(4))], self.sbox_bit_size, self.sbox_description
                     )
                 elif j == 4:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_modadd2.id, type2_xor2.id],
                         [list(range(4, 6)), list(range(2))],
                         self.sbox_bit_size,
                         self.sbox_description,
                     )
                 elif j == 5:
-                    sbox = self.add_SBOX_component(
+                    sbox = self.add_sbox_component(
                         [type2_xor2.id], [list(range(2, 6))], self.sbox_bit_size, self.sbox_description
                     )
                 else:
@@ -307,13 +307,13 @@ class FancyBlockCipher(Cipher):
         self, key_bit_size, round_number, type1_key_schedule_xor, type2_key_schedule_and
     ):
         if round_number == 0:
-            type1_key_schedule_and = self.add_AND_component(
+            type1_key_schedule_and = self.add_and_component(
                 [type1_key_schedule_xor.id, INPUT_KEY],
                 [list(range(int(key_bit_size / 2))), [i + int(key_bit_size / 2) for i in range(int(key_bit_size / 2))]],
                 int(key_bit_size / 2),
             )
         else:
-            type1_key_schedule_and = self.add_AND_component(
+            type1_key_schedule_and = self.add_and_component(
                 [type1_key_schedule_xor.id, type2_key_schedule_and.id],
                 [list(range(int(key_bit_size / 2))) for _ in range(2)],
                 int(key_bit_size / 2),
@@ -325,13 +325,13 @@ class FancyBlockCipher(Cipher):
         self, key_bit_size, round_number, type2_key_schedule_and, type2_key_schedule_xor
     ):
         if round_number == 0:
-            type1_key_schedule_xor = self.add_XOR_component(
+            type1_key_schedule_xor = self.add_xor_component(
                 [INPUT_KEY, INPUT_KEY],
                 [list(range(int(key_bit_size / 2))), list(range(int(key_bit_size / 2), key_bit_size))],
                 int(key_bit_size / 2),
             )
         else:
-            type1_key_schedule_xor = self.add_XOR_component(
+            type1_key_schedule_xor = self.add_xor_component(
                 [type2_key_schedule_xor.id, type2_key_schedule_and.id],
                 [list(range(int(key_bit_size / 2))), list(range(int(key_bit_size / 2)))],
                 int(key_bit_size / 2),

--- a/claasp/ciphers/toys/toy_cipherfour.py
+++ b/claasp/ciphers/toys/toy_cipherfour.py
@@ -97,7 +97,7 @@ class ToyCipherFour(Cipher):
         for round_idx in range(number_of_rounds - 1):
             # XOR with round key
             self.add_round()
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [state, key],
                 [
                     list(range(block_bit_size)),
@@ -110,7 +110,7 @@ class ToyCipherFour(Cipher):
             # S-box layer
             sbox_outputs = []
             for ns in range(self.number_of_sboxes):
-                sbox_component = self.add_SBOX_component(
+                sbox_component = self.add_sbox_component(
                     [state],
                     [[ns * self.sbox_bit_size + i for i in range(self.sbox_bit_size)]],
                     self.sbox_bit_size,
@@ -126,7 +126,7 @@ class ToyCipherFour(Cipher):
         self.add_round()
 
         # XOR with round key
-        xor = self.add_XOR_component(
+        xor = self.add_xor_component(
             [state, key],
             [list(range(block_bit_size)), list(range(4 * block_bit_size, 5 * block_bit_size))],
             block_bit_size,
@@ -136,7 +136,7 @@ class ToyCipherFour(Cipher):
         # Last round does not include permutation
         sbox_outputs = []
         for ns in range(self.number_of_sboxes):
-            sbox_component = self.add_SBOX_component(
+            sbox_component = self.add_sbox_component(
                 [state],
                 [[ns * self.sbox_bit_size + i for i in range(self.sbox_bit_size)]],
                 self.sbox_bit_size,
@@ -149,7 +149,7 @@ class ToyCipherFour(Cipher):
             raise IndexError(f"Expected at least 4 SBOX outputs, but got {len(sbox_outputs)}.")
 
         # Final XOR with the last round key
-        xor = self.add_XOR_component(
+        xor = self.add_xor_component(
             [sbox_outputs[0]] + [sbox_outputs[1]] + [sbox_outputs[2]] + [sbox_outputs[3]] + [key],
             [list(range(4))] * 4 + [list(range(5 * block_bit_size, 6 * block_bit_size))],
             block_bit_size,

--- a/claasp/ciphers/toys/toyaes_block_cipher.py
+++ b/claasp/ciphers/toys/toyaes_block_cipher.py
@@ -198,7 +198,7 @@ class ToyAESBlockCipher(Cipher):
         # Rounds definition:
         # Round 0 different from others since it starts with first_add_round_key
         self.add_round()
-        first_add_round_key = self.add_XOR_component(
+        first_add_round_key = self.add_xor_component(
             [INPUT_KEY, INPUT_PLAINTEXT],
             [list(range(self.key_block_size)), list(range(self.cipher_block_size))],
             int(self.cipher_block_size),
@@ -231,14 +231,14 @@ class ToyAESBlockCipher(Cipher):
         sboxes_components = []
         for j in range(self.num_sboxes):
             if round_number == 0:
-                sbox = self.add_SBOX_component(
+                sbox = self.add_sbox_component(
                     [first_add_round_key.id],
                     [list(range(j * self.sbox_bit_size, (j + 1) * self.sbox_bit_size))],
                     self.sbox_bit_size,
                     self.sbox[word_size],
                 )
             else:
-                sbox = self.add_SBOX_component(
+                sbox = self.add_sbox_component(
                     [add_round_key.id],
                     [list(range(j * self.sbox_bit_size, (j + 1) * self.sbox_bit_size))],
                     self.sbox_bit_size,
@@ -293,7 +293,7 @@ class ToyAESBlockCipher(Cipher):
     def create_key_sbox_components(self, key_rotation, word_size):
         key_sboxes_components = []
         for i in range(self.num_rows):
-            key_sub = self.add_SBOX_component(
+            key_sub = self.add_sbox_component(
                 [key_rotation.id],
                 [list(range(i * self.sbox_bit_size, (i + 1) * self.sbox_bit_size))],
                 self.sbox_bit_size,
@@ -321,14 +321,14 @@ class ToyAESBlockCipher(Cipher):
 
     def create_xor_components(self, constant, key_sboxes_components, remaining_xors, xor1, round_number):
         if round_number == 0:
-            xor1 = self.add_XOR_component(
+            xor1 = self.add_xor_component(
                 [key_sboxes_components[i].id for i in range(self.num_rows)] + [constant.id, INPUT_KEY],
                 [list(range(self.sbox_bit_size)) for _ in range(self.num_rows)]
                 + [list(range(self.row_size)) for _ in range(2)],
                 self.row_size,
             )
         else:
-            xor1 = self.add_XOR_component(
+            xor1 = self.add_xor_component(
                 [key_sboxes_components[i].id for i in range(self.num_rows)] + [constant.id, xor1.id],
                 [list(range(self.sbox_bit_size)) for _ in range(self.num_rows)]
                 + [list(range(self.row_size)) for _ in range(2)],
@@ -337,7 +337,7 @@ class ToyAESBlockCipher(Cipher):
         tmp_remaining_xors = [xor1]
         for i in range(self.num_rows - 1):
             if round_number == 0:
-                xor = self.add_XOR_component(
+                xor = self.add_xor_component(
                     [tmp_remaining_xors[i].id, INPUT_KEY],
                     [
                         list(range(self.row_size)),
@@ -346,7 +346,7 @@ class ToyAESBlockCipher(Cipher):
                     self.row_size,
                 )
             else:
-                xor = self.add_XOR_component(
+                xor = self.add_xor_component(
                     [tmp_remaining_xors[i].id, remaining_xors[i + 1].id],
                     [list(range(self.row_size)), list(range(self.row_size))],
                     self.row_size,
@@ -358,7 +358,7 @@ class ToyAESBlockCipher(Cipher):
 
     def create_round_key(self, mix_column_components, remaining_xors, round_number, shift_row_components):
         if round_number != self.nrounds - 1:
-            add_round_key = self.add_XOR_component(
+            add_round_key = self.add_xor_component(
                 [mix_column_components[i].id for i in range(self.num_rows)]
                 + [remaining_xors[i].id for i in range(self.num_rows)],
                 [list(range(self.row_size)) for _ in range(2 * self.num_rows)],
@@ -373,7 +373,7 @@ class ToyAESBlockCipher(Cipher):
                 shift_rows_input_position_lists.extend(
                     [list(range(i * self.sbox_bit_size, (i + 1) * self.sbox_bit_size)) for _ in range(self.num_rows)]
                 )
-            add_round_key = self.add_XOR_component(
+            add_round_key = self.add_xor_component(
                 shift_rows_ids + [remaining_xors[i].id for i in range(self.num_rows)],
                 shift_rows_input_position_lists + [list(range(self.row_size)) for _ in range(self.num_rows)],
                 self.cipher_block_size,

--- a/claasp/ciphers/toys/toyfeistel.py
+++ b/claasp/ciphers/toys/toyfeistel.py
@@ -88,11 +88,11 @@ class ToyFeistel(Cipher):
 
     def update_key(self, k, i):
         rot_5 = self.add_rotate_component([k], [list(range(self.key_bit_size))], self.key_bit_size, -5).id
-        xor0 = self.add_XOR_component(
+        xor0 = self.add_xor_component(
             [k, rot_5], [list(range(self.key_bit_size)), list(range(self.key_bit_size))], self.key_bit_size
         ).id
         c0 = self.add_constant_component(self.key_bit_size // 2, i).id
-        xor1 = self.add_XOR_component(
+        xor1 = self.add_xor_component(
             [xor0, c0],
             [list(range(self.key_bit_size // 2, self.key_bit_size)), list(range(self.key_bit_size // 2))],
             self.key_bit_size // 2,
@@ -107,13 +107,13 @@ class ToyFeistel(Cipher):
 
     def round_function(self, state, key):
         right_half_positions = list(range(self.block_bit_size // 2, self.block_bit_size))
-        after_key_add = self.add_XOR_component(
+        after_key_add = self.add_xor_component(
             [state, key], [right_half_positions, list(range(self.block_bit_size // 2))], self.block_bit_size // 2
         ).id
-        sb_output = self.add_SBOX_component(
+        sb_output = self.add_sbox_component(
             [after_key_add], [list(range(self.block_bit_size // 2))], self.block_bit_size // 2, self.sbox
         ).id
-        new_right_word = self.add_XOR_component(
+        new_right_word = self.add_xor_component(
             [sb_output, state],
             [list(range(self.block_bit_size // 2))] + [list(range(self.block_bit_size // 2))],
             self.block_bit_size // 2,

--- a/claasp/ciphers/toys/toyspn1.py
+++ b/claasp/ciphers/toys/toyspn1.py
@@ -118,7 +118,7 @@ class ToySPN1(Cipher):
             self.add_round_key_output_component([INPUT_KEY], [list(range(key_bit_size))], key_bit_size)
 
             # XOR with round key
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [xor_input1] + [xor_input2],
                 [list(range(block_bit_size)), list(range(block_bit_size))],
                 block_bit_size,
@@ -127,7 +127,7 @@ class ToySPN1(Cipher):
             # S-box layer
             sbox_ids_list = []
             for ns in range(self.number_of_sboxes):
-                sbox_component = self.add_SBOX_component(
+                sbox_component = self.add_sbox_component(
                     [xor.id],
                     [[ns * self.sbox_bit_size + i for i in range(self.sbox_bit_size)]],
                     self.sbox_bit_size,

--- a/claasp/ciphers/toys/toyspn2.py
+++ b/claasp/ciphers/toys/toyspn2.py
@@ -118,7 +118,7 @@ class ToySPN2(Cipher):
             self.add_round_key_output_component([round_key.id], [list(range(key_bit_size))], key_bit_size)
 
             # XOR with round key
-            xor = self.add_XOR_component(
+            xor = self.add_xor_component(
                 [xor_input1] + [round_key.id],
                 [list(range(block_bit_size)), list(range(block_bit_size))],
                 block_bit_size,
@@ -127,7 +127,7 @@ class ToySPN2(Cipher):
             # S-box layer
             sbox_ids_list = []
             for ns in range(self.number_of_sboxes):
-                sbox_component = self.add_SBOX_component(
+                sbox_component = self.add_sbox_component(
                     [xor.id],
                     [[ns * self.sbox_bit_size + i for i in range(self.sbox_bit_size)]],
                     self.sbox_bit_size,

--- a/claasp/components/and_component.py
+++ b/claasp/components/and_component.py
@@ -24,7 +24,7 @@ from claasp.components.multi_input_non_linear_logical_operator_component import 
 
 def cp_twoterms(model, inp1, inp2, out, cp_constraints):
     cp_constraints.append(
-        f"constraint Ham_weight(Andz({inp1}, {inp2}, {out})) == 0 /\\ p[{model.c}] = Ham_weight(OR({inp1}, {inp2}));"
+        f"constraint Ham_weight(Andz({inp1}, {inp2}, {out})) == 0 /\\ p[{model.c}] = Ham_weight(Or({inp1}, {inp2}));"
     )
     return cp_constraints
 
@@ -94,7 +94,7 @@ def cp_xor_linear_probability_lat(numadd):
     return lat
 
 
-class AND(MultiInputNonlinearLogicalOperator):
+class And(MultiInputNonlinearLogicalOperator):
     """
     Construct an AND component.
 
@@ -116,15 +116,15 @@ class AND(MultiInputNonlinearLogicalOperator):
 
     EXAMPLES::
 
-        sage: from claasp.components.and_component import AND
-        sage: component = AND(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+        sage: from claasp.components.and_component import And
+        sage: component = And(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
         sage: print(component.id)
         and_0_0
         sage: print(component.type)
         word_operation
         sage: print(component.description)
         ['AND', 2]
-        sage: component3 = AND(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2)
+        sage: component3 = And(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2)
         sage: print(component3.description)  # 6 total bits / output_bit_size 2 = 3 operands
         ['AND', 3]
     """
@@ -192,8 +192,8 @@ class AND(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.and_component import AND
-            sage: and_component = AND(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.and_component import And
+            sage: and_component = And(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: and_component.cp_constraints()
             ([],
              ['constraint and_0_0[0] = input1[0] * input2[0];',
@@ -341,8 +341,8 @@ class AND(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.and_component import AND
-            sage: and_component = AND(0, 0, ['plaintext', 'key'], [list(range(16)), list(range(16))], 16)
+            sage: from claasp.components.and_component import And
+            sage: and_component = And(0, 0, ['plaintext', 'key'], [list(range(16)), list(range(16))], 16)
             sage: input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
             sage: output = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
             sage: and_component.generic_sign_linear_constraints(input, output)
@@ -381,8 +381,8 @@ class AND(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.and_component import AND
-            sage: and_component = AND(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.and_component import And
+            sage: and_component = And(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: and_component.sat_constraints()
             (['and_0_0_0', 'and_0_0_1'],
             ['-and_0_0_0 plaintext_0',
@@ -414,8 +414,8 @@ class AND(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.and_component import AND
-            sage: and_component = AND(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.and_component import And
+            sage: and_component = And(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: and_component.smt_constraints()
             (['and_0_0_0', 'and_0_0_1'],
             ['(assert (= and_0_0_0 (and plaintext_0 key_0)))',

--- a/claasp/components/fsr_component.py
+++ b/claasp/components/fsr_component.py
@@ -70,7 +70,7 @@ def _words_array_to_bits(word_array, word_gf):
     return output
 
 
-class FSR(Component):
+class Fsr(Component):
     """
     Construct an FSR component.
 
@@ -86,9 +86,9 @@ class FSR(Component):
 
     EXAMPLES::
 
-        sage: from claasp.components.fsr_component import FSR
+        sage: from claasp.components.fsr_component import Fsr
         sage: fsr_description = [[[[5, [[4], [5], [6, 7]]], [7, [[0], [8], [1, 2]]]], 1]]
-        sage: component = FSR(0, 0, ['input'], [[0, 1, 2, 3, 4, 5, 6, 7, 8]], 0, fsr_description)
+        sage: component = Fsr(0, 0, ['input'], [[0, 1, 2, 3, 4, 5, 6, 7, 8]], 0, fsr_description)
         sage: print(component.id)
         fsr_0_0
         sage: print(component.type)

--- a/claasp/components/intermediate_output_component.py
+++ b/claasp/components/intermediate_output_component.py
@@ -194,7 +194,7 @@ class IntermediateOutput(CipherOutput):
             ....:             cipher_output_bit_size=block_bit_size,
             ....:         )
             ....:         self.add_round()
-            ....:         xor_component = self.add_XOR_component(
+            ....:         xor_component = self.add_xor_component(
             ....:             [INPUT_PLAINTEXT, INPUT_KEY],
             ....:             [list(range(block_bit_size)), list(range(block_bit_size))],
             ....:             block_bit_size,
@@ -261,7 +261,7 @@ class IntermediateOutput(CipherOutput):
             ....:             cipher_output_bit_size=block_bit_size,
             ....:         )
             ....:         self.add_round()
-            ....:         xor_component = self.add_XOR_component(
+            ....:         xor_component = self.add_xor_component(
             ....:             [INPUT_PLAINTEXT, INPUT_KEY],
             ....:             [list(range(block_bit_size)), list(range(block_bit_size))],
             ....:             block_bit_size,
@@ -321,7 +321,7 @@ class IntermediateOutput(CipherOutput):
             ....:             cipher_output_bit_size=block_bit_size,
             ....:         )
             ....:         self.add_round()
-            ....:         xor_component = self.add_XOR_component(
+            ....:         xor_component = self.add_xor_component(
             ....:             [INPUT_PLAINTEXT, INPUT_KEY],
             ....:             [list(range(block_bit_size)), list(range(block_bit_size))],
             ....:             block_bit_size,

--- a/claasp/components/modadd_component.py
+++ b/claasp/components/modadd_component.py
@@ -117,7 +117,7 @@ def smt_modadd_seq(outputs_ids, inputs_ids, carries_ids):
     return constraints
 
 
-class MODADD(Modular):
+class ModAdd(Modular):
     """
     Construct a modular addition component.
 
@@ -133,8 +133,8 @@ class MODADD(Modular):
 
     EXAMPLES::
 
-        sage: from claasp.components.modadd_component import MODADD
-        sage: component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+        sage: from claasp.components.modadd_component import ModAdd
+        sage: component = ModAdd(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
         sage: print(component.id)
         modadd_0_0
         sage: print(component.type)
@@ -247,8 +247,8 @@ class MODADD(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modadd_component import MODADD
-            sage: modadd_component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modadd_component import ModAdd
+            sage: modadd_component = ModAdd(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modadd_component.cms_constraints()[:1]
             (['carry_modadd_0_0_0', 'modadd_0_0_0', 'modadd_0_0_1'],)
         """
@@ -292,8 +292,8 @@ class MODADD(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modadd_component import MODADD
-            sage: modadd_component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modadd_component import ModAdd
+            sage: modadd_component = ModAdd(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modadd_component.cp_constraints()[:1]
             (['array[0..1] of var 0..1: pre_modadd_0_0_0;', 'array[0..1] of var 0..1: pre_modadd_0_0_1;', 'array[1..1] of var 0..1: carry_modadd_0_0;'],)
         """
@@ -381,8 +381,8 @@ class MODADD(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modadd_component import MODADD
-            sage: modadd_component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modadd_component import ModAdd
+            sage: modadd_component = ModAdd(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modadd_component.sat_constraints()[:1]
             (['carry_0_modadd_0_0_0', 'modadd_0_0_0', 'modadd_0_0_1'],)
         """
@@ -418,8 +418,8 @@ class MODADD(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modadd_component import MODADD
-            sage: modadd_component = MODADD(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modadd_component import ModAdd
+            sage: modadd_component = ModAdd(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modadd_component.smt_constraints()[:1]
             (['carry_0_modadd_0_0_0', 'modadd_0_0_0', 'modadd_0_0_1'],)
         """

--- a/claasp/components/modmul_component.py
+++ b/claasp/components/modmul_component.py
@@ -19,7 +19,7 @@
 from claasp.components.modular_component import Modular
 
 
-class MODMUL(Modular):
+class ModMul(Modular):
     """
     Construct a modular multiplication component.
 
@@ -42,15 +42,15 @@ class MODMUL(Modular):
 
     EXAMPLES::
 
-        sage: from claasp.components.modmul_component import MODMUL
-        sage: component = MODMUL(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+        sage: from claasp.components.modmul_component import ModMul
+        sage: component = ModMul(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
         sage: print(component.id)
         modmul_0_0
         sage: print(component.type)
         word_operation
         sage: print(component.description)  # 4 total bits / output_bit_size 2 = 2 operands
         ['MODMUL', 2, 2]
-        sage: component3 = MODMUL(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2, 4)
+        sage: component3 = ModMul(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2, 4)
         sage: print(component3.description)  # 6 total bits / output_bit_size 2 = 3 operands
         ['MODMUL', 3, 4]
     """

--- a/claasp/components/modsub_component.py
+++ b/claasp/components/modsub_component.py
@@ -32,7 +32,7 @@ def cp_twoterms(input_1, input_2, out, component_name, input_length, cp_constrai
     return cp_declarations, cp_constraints
 
 
-class MODSUB(Modular):
+class ModSub(Modular):
     """
     Construct a modular subtraction component.
 
@@ -57,15 +57,15 @@ class MODSUB(Modular):
 
     EXAMPLES::
 
-        sage: from claasp.components.modsub_component import MODSUB
-        sage: component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+        sage: from claasp.components.modsub_component import ModSub
+        sage: component = ModSub(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
         sage: print(component.id)
         modsub_0_0
         sage: print(component.type)
         word_operation
         sage: print(component.description)  # 4 total bits / output_bit_size 2 = 2 operands
         ['MODSUB', 2, 2]
-        sage: component3 = MODSUB(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2, 4)
+        sage: component3 = ModSub(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2, 4)
         sage: print(component3.description)  # 6 total bits / output_bit_size 2 = 3 operands
         ['MODSUB', 3, 4]
     """
@@ -176,8 +176,8 @@ class MODSUB(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modsub_component import MODSUB
-            sage: modsub_component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modsub_component import ModSub
+            sage: modsub_component = ModSub(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modsub_component.cms_constraints()[:1]
             (['temp_carry_input2_0', 'temp_input_input2_0', 'temp_input_input2_1', 'carry_modsub_0_0_0', 'modsub_0_0_0', 'modsub_0_0_1'],)
         """
@@ -193,8 +193,8 @@ class MODSUB(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modsub_component import MODSUB
-            sage: modsub_component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modsub_component import ModSub
+            sage: modsub_component = ModSub(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modsub_component.cp_constraints()[:1]
             (['array[0..1] of var 0..1: constant_modsub_0_0= array1d(0..1,[0, 1]);', 'array[0..1] of var 0..1: modsub_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_0;', 'array[0..1] of var 0..1:pre_modsub_0_0_1;', 'array[0..1] of var 0..1:pre_minus_pre_modsub_0_0_1;', 'array[0..1] of var 0..1:minus_pre_modsub_0_0_1;'],)
         """
@@ -293,8 +293,8 @@ class MODSUB(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modsub_component import MODSUB
-            sage: modsub_component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modsub_component import ModSub
+            sage: modsub_component = ModSub(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modsub_component.sat_constraints()[:1]
             (['temp_carry_input2_0', 'temp_input_input2_0', 'temp_input_input2_1', 'carry_modsub_0_0_0', 'modsub_0_0_0', 'modsub_0_0_1'],)
         """
@@ -367,8 +367,8 @@ class MODSUB(Modular):
 
         EXAMPLES::
 
-            sage: from claasp.components.modsub_component import MODSUB
-            sage: modsub_component = MODSUB(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
+            sage: from claasp.components.modsub_component import ModSub
+            sage: modsub_component = ModSub(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2, 2)
             sage: modsub_component.smt_constraints()[:1]
             (['temp_carry_input2_0', 'temp_input_input2_0', 'temp_input_input2_1', 'carry_modsub_0_0_0', 'modsub_0_0_0', 'modsub_0_0_1'],)
         """

--- a/claasp/components/modular_component.py
+++ b/claasp/components/modular_component.py
@@ -493,7 +493,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: model = MznModel(cipher)
@@ -567,7 +567,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: minizinc = MznXorDifferentialModelARXOptimized(cipher, sat_or_milp='milp')
@@ -690,7 +690,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: model = MznModel(cipher)
@@ -768,7 +768,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: modadd_component = cipher.component_from(0, 0)
@@ -923,7 +923,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: milp = MilpBitwiseDeterministicTruncatedXorDifferentialModel(cipher)
@@ -1027,7 +1027,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: milp = MilpBitwiseDeterministicTruncatedXorDifferentialModel(cipher)
@@ -1101,7 +1101,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: minizinc = MznXorDifferentialModelARXOptimized(cipher, sat_or_milp='milp')
@@ -1222,7 +1222,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: milp = MilpXorLinearModel(cipher)
@@ -1313,7 +1313,7 @@ class Modular(Component):
             ....:     def __init__(self):
             ....:         super().__init__('dummy_cipher', BLOCK_CIPHER, [INPUT_PLAINTEXT, INPUT_KEY], [4, 4], 4)
             ....:         self.add_round()
-            ....:         self.add_MODADD_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
+            ....:         self.add_modadd_component([INPUT_PLAINTEXT, INPUT_KEY], [list(range(4)), list(range(4))], 4)
             ....:         self.add_cipher_output_component(['modadd_0_0'], [list(range(4))], 4)
             sage: cipher = DummyCipher()
             sage: sat = SatModel(cipher)

--- a/claasp/components/not_component.py
+++ b/claasp/components/not_component.py
@@ -23,7 +23,7 @@ from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import WORD_OPERATION
 
 
-class NOT(Component):
+class Not(Component):
     """
     Construct a NOT component.
 
@@ -38,8 +38,8 @@ class NOT(Component):
 
     EXAMPLES::
 
-        sage: from claasp.components.not_component import NOT
-        sage: component = NOT(0, 0, ['input'], [[0, 1]], 2)
+        sage: from claasp.components.not_component import Not
+        sage: component = Not(0, 0, ['input'], [[0, 1]], 2)
         sage: print(component.id)
         not_0_0
         sage: print(component.type)
@@ -108,8 +108,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: output_ids, constraints = not_component.cms_constraints()
             sage: output_ids[0]
             'not_0_0_0'
@@ -134,8 +134,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: declarations, constraints = not_component.cp_constraints()
             sage: declarations
             []
@@ -160,8 +160,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: declarations, constraints = not_component.cp_deterministic_truncated_xor_differential_constraints()
             sage: declarations
             []
@@ -221,10 +221,10 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
+            sage: from claasp.components.not_component import Not
             sage: class DummyModel:
             ....:     word_size = 2
-            sage: not_component = NOT(0, 18, ['input0'], [list(range(8))], 8)
+            sage: not_component = Not(0, 18, ['input0'], [list(range(8))], 8)
             sage: not_component.cp_xor_differential_first_step_constraints(DummyModel())
             (['array[0..3] of var 0..1: not_0_18;'],
              ['constraint not_0_18[0] = input0[0];',
@@ -256,8 +256,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: declarations, constraints = not_component.cp_xor_differential_propagation_constraints()
             sage: declarations
             []
@@ -285,8 +285,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(64))], 64)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(64))], 64)
             sage: declarations, constraints = not_component.cp_xor_linear_mask_propagation_constraints()
             sage: declarations
             ['array[0..63] of var 0..1:not_0_0_i;', 'array[0..63] of var 0..1:not_0_0_o;']
@@ -333,7 +333,7 @@ class NOT(Component):
         EXAMPLES::
 
             sage: from claasp.ciphers.single_component_ciphers.not_cipher import NotCipher
-            sage: from claasp.components.not_component import NOT
+            sage: from claasp.components.not_component import Not
             sage: cipher = NotCipher(bit_size=32)
             sage: not_component = cipher.component_from(0, 0)
             sage: inputs = [0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0]
@@ -498,8 +498,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: output_ids, constraints = not_component.sat_constraints()
             sage: output_ids[0]
             'not_0_0_0'
@@ -533,8 +533,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: output_ids, constraints = not_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
             sage: output_ids[0]
             'not_0_0_0_0'
@@ -569,8 +569,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: output_ids, constraints = not_component.sat_xor_differential_propagation_constraints()
             sage: output_ids[-1]
             'not_0_0_31'
@@ -604,8 +604,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(32))], 32)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(32))], 32)
             sage: output_ids, constraints = not_component.sat_xor_linear_mask_propagation_constraints()
             sage: output_ids[0]
             'not_0_0_0_i'
@@ -636,8 +636,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(64))], 64)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(64))], 64)
             sage: output_ids, constraints = not_component.smt_constraints()
             sage: output_ids[0]
             'not_0_0_0'
@@ -666,8 +666,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(64))], 64)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(64))], 64)
             sage: output_ids, constraints = not_component.smt_xor_differential_propagation_constraints()
             sage: output_ids[-1]
             'not_0_0_63'
@@ -696,8 +696,8 @@ class NOT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.not_component import NOT
-            sage: not_component = NOT(0, 0, ['input0'], [list(range(64))], 64)
+            sage: from claasp.components.not_component import Not
+            sage: not_component = Not(0, 0, ['input0'], [list(range(64))], 64)
             sage: output_ids, constraints = not_component.smt_xor_linear_mask_propagation_constraints()
             sage: output_ids[0]
             'not_0_0_0_i'

--- a/claasp/components/or_component.py
+++ b/claasp/components/or_component.py
@@ -21,7 +21,7 @@ from claasp.cipher_modules.models.smt.utils import utils as smt_utils
 from claasp.components.multi_input_non_linear_logical_operator_component import MultiInputNonlinearLogicalOperator
 
 
-class OR(MultiInputNonlinearLogicalOperator):
+class Or(MultiInputNonlinearLogicalOperator):
     """
     Construct an OR component.
 
@@ -43,15 +43,15 @@ class OR(MultiInputNonlinearLogicalOperator):
 
     EXAMPLES::
 
-        sage: from claasp.components.or_component import OR
-        sage: component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+        sage: from claasp.components.or_component import Or
+        sage: component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
         sage: print(component.id)
         or_0_0
         sage: print(component.type)
         word_operation
         sage: print(component.description)
         ['OR', 2]
-        sage: component3 = OR(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2)
+        sage: component3 = Or(0, 1, ['a', 'b', 'c'], [[0, 1], [0, 1], [0, 1]], 2)
         sage: print(component3.description)  # 6 total bits / output_bit_size 2 = 3 operands
         ['OR', 3]
     """
@@ -127,8 +127,8 @@ class OR(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.or_component import OR
-            sage: or_component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.or_component import Or
+            sage: or_component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: or_component.cp_constraints()
             (['array[0..1] of var 0..1: or_0_0;',
             'array[0..1] of var 0..1:pre_or_0_0_0;',
@@ -238,14 +238,14 @@ class OR(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.or_component import OR
-            sage: or_component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.or_component import Or
+            sage: or_component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: input = [0, 0, 0, 1]
             sage: output = [0, 1]
             sage: or_component.generic_sign_linear_constraints(input, output)
             1
-            sage: from claasp.components.or_component import OR
-            sage: or_component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.or_component import Or
+            sage: or_component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: input = [0, 0, 0, 1]
             sage: output = [1, 1]
             sage: or_component.generic_sign_linear_constraints(input, output)
@@ -284,8 +284,8 @@ class OR(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.or_component import OR
-            sage: component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.or_component import Or
+            sage: component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: component.sat_constraints()
             (['or_0_0_0', 'or_0_0_1'],
             ['or_0_0_0 -input1_0',
@@ -317,8 +317,8 @@ class OR(MultiInputNonlinearLogicalOperator):
 
         EXAMPLES::
 
-            sage: from claasp.components.or_component import OR
-            sage: component = OR(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+            sage: from claasp.components.or_component import Or
+            sage: component = Or(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
             sage: component.smt_constraints()
             (['or_0_0_0', 'or_0_0_1'],
             ['(assert (= or_0_0_0 (or input1_0 input2_0)))',

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -1243,14 +1243,14 @@ class Sbox(Component):
             '\t};',
             '\tinput = select_bits(1, input_id, input_positions, 2);',
             '\tsubstitution_list = (uint64_t[]) {0, 1, 3, 2};',
-            '\tBitString* sbox_0_0 = Sbox(input, 2, substitution_list);\n',
+            '\tBitString* sbox_0_0 = SBOX(input, 2, substitution_list);\n',
             '\tdelete_bitstring(input);\n']
         """
         sbox_code = []
         self.select_bits(sbox_code)
 
         sbox_code.append(f"\tsubstitution_list = (uint64_t[]) {{{', '.join([str(x) for x in self.description])}}};")
-        sbox_code.append(f"\tBitString* {self.id} = Sbox(input, {self.output_bit_size}, substitution_list);\n")
+        sbox_code.append(f"\tBitString* {self.id} = SBOX(input, {self.output_bit_size}, substitution_list);\n")
 
         if verbosity:
             self.print_values(sbox_code)

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -102,11 +102,11 @@ def cp_update_ddt_valid_probabilities(
 
     EXAMPLES::
 
-        sage: from claasp.components.sbox_component import SBOX, cp_update_ddt_valid_probabilities
+        sage: from claasp.components.sbox_component import Sbox, cp_update_ddt_valid_probabilities
         sage: class DummyCipher:
         ....:     def is_spn(self):
         ....:         return True
-        sage: component = SBOX(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
+        sage: component = Sbox(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
         sage: cp_declarations, table_items, valid_probabilities, sbox_mant = [], [], set(), []
         sage: cp_update_ddt_valid_probabilities(DummyCipher(), component, 4, cp_declarations, table_items, valid_probabilities, sbox_mant)
         sage: len(valid_probabilities) > 0
@@ -163,8 +163,8 @@ def cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
 
     EXAMPLES::
 
-        sage: from claasp.components.sbox_component import SBOX, cp_update_lat_valid_probabilities
-        sage: component = SBOX(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
+        sage: from claasp.components.sbox_component import Sbox, cp_update_lat_valid_probabilities
+        sage: component = Sbox(0, 0, ['xor_0_0'], [[0, 1, 2, 3]], 4, [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
         sage: valid_probabilities, sbox_mant = set(), []
         sage: cp_update_lat_valid_probabilities(component, valid_probabilities, sbox_mant)
         sage: len(valid_probabilities) > 0
@@ -549,7 +549,7 @@ def _mzn_update_sbox_mant_for_deterministic_truncated_xor_differential(
     return already_in, output_id_link_sost, undisturbed_table_bits
 
 
-class SBOX(Component):
+class Sbox(Component):
     """
     Construct an S-box component.
 
@@ -565,8 +565,8 @@ class SBOX(Component):
 
     EXAMPLES::
 
-        sage: from claasp.components.sbox_component import SBOX
-        sage: component = SBOX(0, 0, ['input'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
+        sage: from claasp.components.sbox_component import Sbox
+        sage: component = Sbox(0, 0, ['input'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
         sage: print(component.id)
         sbox_0_0
         sage: print(component.type)
@@ -660,9 +660,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: present_sbox = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
-            sage: sbox_component = SBOX(0, 2, ['input'], [[0, 1, 2, 3]], 4, present_sbox)
+            sage: sbox_component = Sbox(0, 2, ['input'], [[0, 1, 2, 3]], 4, present_sbox)
             sage: valid_transitions = sbox_component.get_ddt_with_undisturbed_transitions()
             sage: len(valid_transitions)
             81
@@ -679,7 +679,7 @@ class SBOX(Component):
             ....:     0x1e, 0x13, 0x07, 0x0e, 0x00, 0x0d, 0x11, 0x18,
             ....:     0x10, 0x0c, 0x01, 0x19, 0x16, 0x0a, 0x0f, 0x17
             ....: ]
-            sage: sbox_component = SBOX(0, 3, ['input'], [[0, 1, 2, 3, 4]], 5, ascon_sbox)
+            sage: sbox_component = Sbox(0, 3, ['input'], [[0, 1, 2, 3, 4]], 5, ascon_sbox)
             sage: valid_transitions = sbox_component.get_ddt_with_undisturbed_transitions()
             sage: len(valid_transitions)
             243
@@ -743,9 +743,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: present_sbox = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
-            sage: sbox_component = SBOX(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
+            sage: sbox_component = Sbox(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
             sage: sbox_component.cms_constraints()
             (['sbox_0_2_0', 'sbox_0_2_1', 'sbox_0_2_2', 'sbox_0_2_3'],
              ['xor_0_0_4 xor_0_0_5 xor_0_0_6 xor_0_0_7 sbox_0_2_0',
@@ -773,9 +773,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: sbox = [12, 10, 13, 3, 14, 11, 15, 7, 8, 9, 1, 5, 0, 2, 4, 6]
-            sage: sbox_component = SBOX(0, 5, ['xor_0_1'], [[4, 5, 6, 7]], 4, sbox)
+            sage: sbox_component = Sbox(0, 5, ['xor_0_1'], [[4, 5, 6, 7]], 4, sbox)
             sage: sbox_component.cp_constraints([])
             (['array [1..16, 1..8] of int: table_sbox_0_5 = array2d(1..16, 1..8, [0,0,0,0,1,1,0,0,0,0,0,1,1,0,1,0,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,1,0,1,0,0,1,1,1,0,0,1,0,1,1,0,1,1,0,1,1,0,1,1,1,1,0,1,1,1,0,1,1,1,1,0,0,0,1,0,0,0,1,0,0,1,1,0,0,1,1,0,1,0,0,0,0,1,1,0,1,1,0,1,0,1,1,1,0,0,0,0,0,0,1,1,0,1,0,0,1,0,1,1,1,0,0,1,0,0,1,1,1,1,0,1,1,0]);'],
              ['constraint table([xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]++[sbox_0_5[0]]++[sbox_0_5[1]]++[sbox_0_5[2]]++[sbox_0_5[3]], table_sbox_0_5);'])
@@ -824,9 +824,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: sbox = [1, 2, 3, 4, 0, 7, 6, 5]
-            sage: sbox_component = SBOX(0, 1, ['xor_0_0'], [[0, 1, 2, 3]], 4, sbox)
+            sage: sbox_component = Sbox(0, 1, ['xor_0_0'], [[0, 1, 2, 3]], 4, sbox)
             sage: declarations, constraints, sbox_mant = sbox_component.cp_deterministic_truncated_xor_differential_constraints(sbox_mant = [])
             sage: declarations
             ['array [1..27, 1..6] of int: table_sbox_0_1 = array2d(1..27, 1..6, [0,0,0,0,0,0,0,0,1,2,1,1,0,1,0,2,1,0,0,1,1,2,0,1,1,0,0,2,0,1,1,0,1,2,1,0,1,1,0,2,1,1,1,1,1,1,0,0,0,0,2,2,2,2,0,2,0,2,2,0,0,2,2,2,2,2,2,0,0,2,0,2,2,0,2,2,2,2,2,2,0,2,2,2,2,2,2,2,2,2,0,2,1,2,2,1,2,0,1,2,1,2,2,2,1,2,2,2,0,1,2,2,2,2,2,1,0,2,1,2,2,1,2,2,2,2,2,1,1,2,0,2,1,0,2,2,2,2,1,2,0,2,2,1,1,2,2,2,2,2,1,2,1,2,2,0,1,1,2,2,2,2]);']
@@ -891,9 +891,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: lblock_sbox = [14, 9, 15, 0, 13, 4, 10, 11, 1, 2, 8, 3, 7, 6, 12, 5]
-            sage: sbox_component = SBOX(0, 2, ['xor_0_1'], [[4, 5, 6, 7]], 4, lblock_sbox)
+            sage: sbox_component = Sbox(0, 2, ['xor_0_1'], [[4, 5, 6, 7]], 4, lblock_sbox)
             sage: declarations, constraints, sbox_mant = sbox_component.cp_hybrid_deterministic_truncated_xor_differential_constraints(sbox_mant = [])
             sage: constraints
             ['constraint abstract_sbox_0_2(array1d(0..3, [xor_0_1[4]]++[xor_0_1[5]]++[xor_0_1[6]]++[xor_0_1[7]]), array1d(0..3, [sbox_0_2[0]]++[sbox_0_2[1]]++[sbox_0_2[2]]++[sbox_0_2[3]]), 0, 0);']
@@ -985,9 +985,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: sbox = [1, 2, 3, 4, 5, 6, 7, 0]
-            sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, sbox)
+            sage: sbox_component = Sbox(0, 0, ['plaintext'], [[0, 1, 2]], 3, sbox)
             sage: model = type('DummyModel', (), {'word_size': 3})()
             sage: sbox_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(model)
             ([], ['constraint if plaintext_value[0]==0 then sbox_0_0_active[0] = 0 else sbox_0_0_active[0] = 2 endif;'])
@@ -1020,14 +1020,14 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: class DummyModel:
             ....:     word_size = 2
             ....:     def __init__(self):
             ....:         self.input_sbox = []
             ....:         self.table_of_solutions_length = 0
             sage: model = DummyModel()
-            sage: sbox_component = SBOX(0, 0, ['input0'], [list(range(4))], 4, list(range(16)))
+            sage: sbox_component = Sbox(0, 0, ['input0'], [list(range(4))], 4, list(range(16)))
             sage: sbox_component.cp_xor_differential_first_step_constraints(model)
             (['array[0..1] of var 0..1: sbox_0_0;'],
                 ['constraint sbox_0_0[0] = input0[0];',
@@ -1065,8 +1065,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
             sage: cp = type('DummyModel', (), {})()
             sage: cp.sbox_mant = []
             sage: cp.component_and_probability = {}
@@ -1130,8 +1130,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['plaintext'], [[0, 1, 2]], 3, [0, 1, 2, 3, 4, 5, 6, 7])
             sage: cp = type('DummyModel', (), {})()
             sage: cp.sbox_mant = []
             sage: cp.component_and_probability = {}
@@ -1201,8 +1201,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['input'], [[0, 1]], 2, [0, 1, 3, 2])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['input'], [[0, 1]], 2, [0, 1, 3, 2])
             sage: sign_lat = sbox_component.generate_sbox_sign_lat()
             sage: sign_lat
             [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]]
@@ -1234,8 +1234,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['input'], [[0, 1]], 2, [0, 1, 3, 2])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['input'], [[0, 1]], 2, [0, 1, 3, 2])
             sage: code = sbox_component.get_bit_based_c_code(False)
             sage: code
             ['\tinput_id = (BitString*[]) {input};\n\tinput_positions = (uint16_t*[]) {',
@@ -1243,14 +1243,14 @@ class SBOX(Component):
             '\t};',
             '\tinput = select_bits(1, input_id, input_positions, 2);',
             '\tsubstitution_list = (uint64_t[]) {0, 1, 3, 2};',
-            '\tBitString* sbox_0_0 = SBOX(input, 2, substitution_list);\n',
+            '\tBitString* sbox_0_0 = Sbox(input, 2, substitution_list);\n',
             '\tdelete_bitstring(input);\n']
         """
         sbox_code = []
         self.select_bits(sbox_code)
 
         sbox_code.append(f"\tsubstitution_list = (uint64_t[]) {{{', '.join([str(x) for x in self.description])}}};")
-        sbox_code.append(f"\tBitString* {self.id} = SBOX(input, {self.output_bit_size}, substitution_list);\n")
+        sbox_code.append(f"\tBitString* {self.id} = Sbox(input, {self.output_bit_size}, substitution_list);\n")
 
         if verbosity:
             self.print_values(sbox_code)
@@ -1274,8 +1274,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
             sage: code = sbox_component.get_bit_based_vectorized_python_code(None, False)
             sage: code
             ['  sbox_0_0 = bit_vector_SBOX(bit_vector_CONCAT([bit_vector_select_word(x,  [0, 1]) ]), np.array([0, 1, 3, 2], dtype=np.uint8), output_bit_size = 2)']
@@ -1303,8 +1303,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
             sage: sbox_component.get_byte_based_vectorized_python_code('state')
             ['  sbox_0_0 = byte_vector_SBOX(state, [0, 1, 3, 2], 2)']
         """
@@ -1326,8 +1326,8 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
-            sage: sbox_component = SBOX(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
+            sage: from claasp.components.sbox_component import Sbox
+            sage: sbox_component = Sbox(0, 0, ['x'], [[0, 1]], 2, [0, 1, 3, 2])
             sage: sbox_component.get_word_based_c_code(False, 8, {})
             ['\t//// TODO']
         """
@@ -2068,9 +2068,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: present_sbox = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
-            sage: sbox_component = SBOX(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
+            sage: sbox_component = Sbox(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
             sage: sbox_component.sat_constraints()
             (['sbox_0_2_0', 'sbox_0_2_1', 'sbox_0_2_2', 'sbox_0_2_3'],
              ['xor_0_0_4 xor_0_0_5 xor_0_0_6 xor_0_0_7 sbox_0_2_0',
@@ -2111,9 +2111,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: present_sbox = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
-            sage: sbox_component = SBOX(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
+            sage: sbox_component = Sbox(0, 2, ['xor_0_0'], [[4, 5, 6, 7]], 4, present_sbox)
             sage: sbox_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
             (['sbox_0_2_0_0',
               'sbox_0_2_1_0',
@@ -2316,9 +2316,9 @@ class SBOX(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.sbox_component import SBOX
+            sage: from claasp.components.sbox_component import Sbox
             sage: sbox = [1, 2, 3, 0]
-            sage: component = SBOX(0, 1, ['input'], [[0, 1]], 2, sbox)
+            sage: component = Sbox(0, 1, ['input'], [[0, 1]], 2, sbox)
             sage: output_ids, asserts = component.smt_constraints()
             sage: output_ids
             ['sbox_0_1_0', 'sbox_0_1_1']

--- a/claasp/components/shift_component.py
+++ b/claasp/components/shift_component.py
@@ -23,7 +23,7 @@ from claasp.cipher_modules.models.sat.utils import constants, utils as sat_utils
 from claasp.name_mappings import WORD_OPERATION
 
 
-class SHIFT(Component):
+class Shift(Component):
     """
     Construct a SHIFT component.
 
@@ -39,8 +39,8 @@ class SHIFT(Component):
 
     EXAMPLES::
 
-        sage: from claasp.components.shift_component import SHIFT
-        sage: component = SHIFT(0, 0, ['input'], [[0, 1]], 2, -1)
+        sage: from claasp.components.shift_component import Shift
+        sage: component = Shift(0, 0, ['input'], [[0, 1]], 2, -1)
         sage: print(component.id)
         shift_0_0
         sage: print(component.type)
@@ -112,8 +112,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.cms_constraints()
             (['shift_0_0_0', 'shift_0_0_1'], ['-shift_0_0_0', 'shift_0_0_1 -input_0', 'input_0 -shift_0_0_1'])
         """
@@ -135,8 +135,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.cp_constraints()
             ([], ['constraint shift_0_0[0] = 0;', 'constraint shift_0_0[1] = input[0];'])
         """
@@ -183,8 +183,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.cp_inverse_constraints()
             ([], ['constraint shift_0_0_inverse[0] = 0;', 'constraint shift_0_0_inverse[1] = input[0];'])
         """
@@ -227,10 +227,10 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
+            sage: from claasp.components.shift_component import Shift
             sage: class DummyModel:
             ....:     word_size = 2
-            sage: shift_component = SHIFT(0, 18, ['sbox_0_2'], [list(range(4))], 4, -2)
+            sage: shift_component = Shift(0, 18, ['sbox_0_2'], [list(range(4))], 4, -2)
             sage: shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
             ([], ['constraint shift_0_18_active[0] = sbox_0_2_active[1];', 'constraint shift_0_18_active[1] = 0;', 'constraint shift_0_18_value[0] = sbox_0_2_active[1];', 'constraint shift_0_18_value[1] = 0;'])
         """
@@ -306,10 +306,10 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
+            sage: from claasp.components.shift_component import Shift
             sage: class DummyModel:
             ....:     word_size = 2
-            sage: shift_component = SHIFT(0, 18, ['input0'], [list(range(4))], 4, -2)
+            sage: shift_component = Shift(0, 18, ['input0'], [list(range(4))], 4, -2)
             sage: shift_component.cp_xor_differential_first_step_constraints(DummyModel())
             (['array[0..1] of var 0..1: shift_0_18;'], ['constraint shift_0_18[0] = input0[1];', 'constraint shift_0_18[1] = 0;'])
         """
@@ -381,8 +381,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.cp_xor_linear_mask_propagation_constraints()
             (['array[0..1] of var 0..1: shift_0_0_i;', 'array[0..1] of var 0..1: shift_0_0_o;'], ['constraint shift_0_0_i[1]=0;', 'constraint shift_0_0_o[1]=shift_0_0_i[0];'])
         """
@@ -541,8 +541,8 @@ class SHIFT(Component):
             sage: from claasp.cipher_modules.models.milp.milp_models.milp_wordwise_deterministic_truncated_xor_differential_model import MilpWordwiseDeterministicTruncatedXorDifferentialModel
             sage: milp = MilpWordwiseDeterministicTruncatedXorDifferentialModel(cipher)
             sage: milp.init_model_in_sage_milp_class()
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 18, ['plaintext'], [list(range(4))], 4, -4)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 18, ['plaintext'], [list(range(4))], 4, -4)
             sage: variables, constraints = shift_component.milp_wordwise_deterministic_truncated_xor_differential_constraints(milp)
             sage: variables
             [('x_class[plaintext_word_0_class]', x_0),
@@ -697,8 +697,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.sat_constraints()
             (['shift_0_0_0', 'shift_0_0_1'], ['-shift_0_0_0', 'shift_0_0_1 -input_0', 'input_0 -shift_0_0_1'])
         """
@@ -730,7 +730,7 @@ class SHIFT(Component):
         .. SEEALSO::
 
             - :ref:`sat-standard` for the format.
-            - :obj:`sat_constraints() <components.shift_component.SHIFT.sat_constraints>` for the model.
+            - :obj:`sat_constraints() <components.shift_component.Shift.sat_constraints>` for the model.
 
         INPUT:
 
@@ -738,8 +738,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
             (['shift_0_0_0_0', 'shift_0_0_1_0', 'shift_0_0_0_1', 'shift_0_0_1_1'], ['-shift_0_0_0_0', '-shift_0_0_0_1', 'shift_0_0_1_0 -input_0_0', 'input_0_0 -shift_0_0_1_0', 'shift_0_0_1_1 -input_0_1', 'input_0_1 -shift_0_0_1_1'])
         """
@@ -772,7 +772,7 @@ class SHIFT(Component):
         .. SEEALSO::
 
             - :ref:`sat-standard` for the format.
-            - :obj:`sat_constraints() <components.shift_component.SHIFT.sat_constraints>` for the model.
+            - :obj:`sat_constraints() <components.shift_component.Shift.sat_constraints>` for the model.
 
         INPUT:
 
@@ -780,8 +780,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.sat_xor_differential_propagation_constraints()
             (['shift_0_0_0', 'shift_0_0_1'], ['-shift_0_0_0', 'shift_0_0_1 -input_0', 'input_0 -shift_0_0_1'])
         """
@@ -797,7 +797,7 @@ class SHIFT(Component):
         .. SEEALSO::
 
             - :ref:`sat-standard` for the format.
-            - :obj:`sat_constraints() <components.shift_component.SHIFT.sat_constraints>` for the model.
+            - :obj:`sat_constraints() <components.shift_component.Shift.sat_constraints>` for the model.
 
         INPUT:
 
@@ -805,8 +805,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.sat_xor_linear_mask_propagation_constraints()
             (['shift_0_0_0_i', 'shift_0_0_1_i', 'shift_0_0_0_o', 'shift_0_0_1_o'], ['shift_0_0_1_o -shift_0_0_0_i', 'shift_0_0_0_i -shift_0_0_1_o', '-shift_0_0_1_i'])
         """
@@ -844,8 +844,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.smt_constraints()
             (['shift_0_0_0', 'shift_0_0_1'], ['(assert (not shift_0_0_0))', '(assert (= shift_0_0_1 input_0))'])
         """
@@ -875,7 +875,7 @@ class SHIFT(Component):
 
         .. SEEALSO::
 
-            :obj:`smt_constraints() <components.shift_component.SHIFT.smt_constraints>`.
+            :obj:`smt_constraints() <components.shift_component.Shift.smt_constraints>`.
 
         INPUT:
 
@@ -883,8 +883,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.smt_xor_differential_propagation_constraints()
             (['shift_0_0_0', 'shift_0_0_1'], ['(assert (not shift_0_0_0))', '(assert (= shift_0_0_1 input_0))'])
         """
@@ -899,7 +899,7 @@ class SHIFT(Component):
 
         .. SEEALSO::
 
-            :obj:`smt_constraints() <components.shift_component.SHIFT.smt_constraints>`.
+            :obj:`smt_constraints() <components.shift_component.Shift.smt_constraints>`.
 
         INPUT:
 
@@ -907,8 +907,8 @@ class SHIFT(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.shift_component import SHIFT
-            sage: shift_component = SHIFT(0, 0, ['input'], [[0, 1]], 2, 1)
+            sage: from claasp.components.shift_component import Shift
+            sage: shift_component = Shift(0, 0, ['input'], [[0, 1]], 2, 1)
             sage: shift_component.smt_xor_linear_mask_propagation_constraints()
             (['shift_0_0_0_i', 'shift_0_0_1_i', 'shift_0_0_0_o', 'shift_0_0_1_o'], ['(assert (= shift_0_0_1_o shift_0_0_0_i))', '(assert (not shift_0_0_1_i))'])
         """

--- a/claasp/components/xor_component.py
+++ b/claasp/components/xor_component.py
@@ -136,7 +136,7 @@ def get_milp_constraints_from_inequalities(inequalities, input_vars, number_of_i
     return constraints
 
 
-class XOR(Component):
+class Xor(Component):
     """
     Construct an XOR component.
 
@@ -158,15 +158,15 @@ class XOR(Component):
 
     EXAMPLES::
 
-        sage: from claasp.components.xor_component import XOR
-        sage: component = XOR(0, 0, ['input1', 'input2', 'input2'], [[0, 1], [0, 1], [2, 3]], 2)
+        sage: from claasp.components.xor_component import Xor
+        sage: component = Xor(0, 0, ['input1', 'input2', 'input2'], [[0, 1], [0, 1], [2, 3]], 2)
         sage: print(component.id)
         xor_0_0
         sage: print(component.type)
         word_operation
         sage: print(component.description)  # 6 total bits / output_bit_size 2 = 3 operands
         ['XOR', 3]
-        sage: component2 = XOR(0, 1, ['a', 'b'], [[0, 1], [0, 1]], 2)
+        sage: component2 = Xor(0, 1, ['a', 'b'], [[0, 1], [0, 1]], 2)
         sage: print(component2.description)  # 4 total bits / output_bit_size 2 = 2 operands
         ['XOR', 2]
     """
@@ -246,8 +246,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.cms_constraints()
             (['xor_0_0_0', 'xor_0_0_1'],
             ['x -xor_0_0_0 plaintext_0 key_0', 'x -xor_0_0_1 plaintext_1 key_1'])
@@ -278,8 +278,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.cp_constraints()
             ([],
             ['constraint xor_0_0[0] = (plaintext[0] + key[0]) mod 2;',
@@ -326,8 +326,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.cp_deterministic_truncated_xor_differential_constraints()
             ([],
             ['constraint if ((plaintext[0] < 2) /\\ (key[0]< 2)) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 else xor_0_0[0] = 2 endif;',
@@ -359,8 +359,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.cp_hybrid_deterministic_truncated_xor_differential_constraints()
             ([],
              ['constraint if (plaintext[0] < 2) /\\ (key[0] < 2) then xor_0_0[0] = (plaintext[0] + key[0]) mod 2 elseif (plaintext[0] + key[0] = plaintext[0]) then xor_0_0[0] = plaintext[0] elseif (plaintext[0] + key[0] = key[0]) then xor_0_0[0] = key[0] else xor_0_0[0] = 2 endif;',
@@ -582,8 +582,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.cp_xor_linear_mask_propagation_constraints()
             (['array[0..3] of var 0..1: xor_0_0_i;',
             'array[0..1] of var 0..1: xor_0_0_o;'],
@@ -868,7 +868,7 @@ class XOR(Component):
 
         constraints = []
 
-        # if a_i < 2 for all i then b = XOR(a_i, i in range(num_inputs))
+        # if a_i < 2 for all i then b = Xor(a_i, i in range(num_inputs))
         # else b = 2
         a = [
             [x_class[input_vars[i + chunk * input_bit_size]] for chunk in range(num_of_inputs)]
@@ -888,7 +888,7 @@ class XOR(Component):
             all_ai_less_2, constr = milp_utils.milp_generalized_and(model, list_ai_less_2)
             constraints.extend(constr)
 
-            # if all_ai_less_2 == 1 then b = XOR(a_i, i in range(num_inputs))
+            # if all_ai_less_2 == 1 then b = Xor(a_i, i in range(num_inputs))
             # else b = 2
             xor_constr = milp_utils.milp_generalized_xor(a[i], b[i])
             constr = milp_utils.milp_if_then_else(
@@ -904,7 +904,7 @@ class XOR(Component):
         in deterministic truncated XOR differential model.
 
         This does not implement the XOR for more than 2 inputs in a sequential manner.
-        Indeed, if Y = XOR(X_0, X_1, X_2), and the input patterns are:
+        Indeed, if Y = Xor(X_0, X_1, X_2), and the input patterns are:
 
         delta_X_0 = 1
         delta_X_1 = 2
@@ -968,7 +968,7 @@ class XOR(Component):
         in deterministic truncated XOR differential model.
         It should perform the wordwise xor for multiple inputs faster than the
         xor_wordwise_deterministic_truncated_xor_differential_constraints() methods but skips some cases
-        e.g. if DX1 = 1, DX2 = 2, DX3 = 1 and X1 = X3, then DY = XOR(DX1, DX2, DX3) = 2 but this method will
+        e.g. if DX1 = 1, DX2 = 2, DX3 = 1 and X1 = X3, then DY = Xor(DX1, DX2, DX3) = 2 but this method will
         return 3
 
         INPUTS:
@@ -1205,8 +1205,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.sat_constraints()
             (['xor_0_0_0', 'xor_0_0_1'],
             ['-xor_0_0_0 plaintext_0 key_0',
@@ -1236,7 +1236,7 @@ class XOR(Component):
         .. SEEALSO::
 
             - :ref:`sat-standard` for the format.
-            - :obj:`sat_constraints() <components.xor_component.XOR.sat_constraints>` for the model.
+            - :obj:`sat_constraints() <components.xor_component.Xor.sat_constraints>` for the model.
 
         INPUT:
 
@@ -1244,8 +1244,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
             (['xor_0_0_0_0', 'xor_0_0_1_0', 'xor_0_0_0_1', 'xor_0_0_1_1'],
             ['xor_0_0_0_0 -plaintext_0_0',
@@ -1286,7 +1286,7 @@ class XOR(Component):
         .. SEEALSO::
 
             - :ref:`sat-standard` for the format.
-            - :obj:`sat_constraints() <components.xor_component.XOR.sat_constraints>` for the model.
+            - :obj:`sat_constraints() <components.xor_component.Xor.sat_constraints>` for the model.
 
         INPUT:
 
@@ -1294,8 +1294,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.sat_xor_differential_propagation_constraints()
             (['xor_0_0_0', 'xor_0_0_1'],
             ['-xor_0_0_0 plaintext_0 key_0',
@@ -1323,8 +1323,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.sat_xor_linear_mask_propagation_constraints()
             (['xor_0_0_0_i',
             'xor_0_0_1_i',
@@ -1355,7 +1355,7 @@ class XOR(Component):
         Return a variable list and SMT-LIB list asserts representing XOR for SMT CIPHER model
 
         Since the XOR operation is part of the SMT-LIB formalism, the operation can be modeled using the corresponding
-        builtin operation, e.g. ``z = XOR(x, y)`` becomes ``(assert (= z (xor x y)))``.
+        builtin operation, e.g. ``z = Xor(x, y)`` becomes ``(assert (= z (xor x y)))``.
         This method support XOR operation using more than two inputs.
 
         INPUT:
@@ -1364,8 +1364,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.smt_constraints()
             (['xor_0_0_0', 'xor_0_0_1'],
             ['(assert (= xor_0_0_0 (xor plaintext_0 key_0)))',
@@ -1387,7 +1387,7 @@ class XOR(Component):
 
         .. SEEALSO::
 
-            :obj:`smt_constraints() <components.xor_component.XOR.sat_constraints>` for the model.
+            :obj:`smt_constraints() <components.xor_component.Xor.sat_constraints>` for the model.
 
         INPUT:
 
@@ -1395,8 +1395,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.smt_xor_differential_propagation_constraints()
             (['xor_0_0_0', 'xor_0_0_1'],
             ['(assert (= xor_0_0_0 (xor plaintext_0 key_0)))',
@@ -1418,8 +1418,8 @@ class XOR(Component):
 
         EXAMPLES::
 
-            sage: from claasp.components.xor_component import XOR
-            sage: xor_component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+            sage: from claasp.components.xor_component import Xor
+            sage: xor_component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
             sage: xor_component.smt_xor_linear_mask_propagation_constraints()
             (['xor_0_0_0_o',
             'xor_0_0_1_o',
@@ -1497,7 +1497,7 @@ class XOR(Component):
             input_bits = 0
             for input_bit in input_bit_positions:
                 input_bits += len(input_bit)
-            xor_component = XOR("", "", input_id_link, input_bit_positions, input_bits)
+            xor_component = Xor("", "", input_id_link, input_bit_positions, input_bits)
             xor_component.set_description(["XOR", numadd + 1])
             model.list_of_xor_components.append(xor_component)
         cp_constraints = []

--- a/claasp/compound_xor_differential_cipher.py
+++ b/claasp/compound_xor_differential_cipher.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from claasp.components.xor_component import XOR
+from claasp.components.xor_component import Xor
 from claasp.name_mappings import CIPHER_OUTPUT, INTERMEDIATE_OUTPUT
 
 
@@ -49,7 +49,7 @@ def create_xor_component_inputs(old_cipher_inputs_, cipher, round_object):
         input_links = [f"{cipher_input}_pair1", f"{cipher_input}_pair2"]
         current_components_number = round_object.get_number_of_components()
         output_bit_size = cipher.inputs_bit_size[i]
-        new_xor_component = XOR(
+        new_xor_component = Xor(
             0,
             current_components_number,
             input_links,
@@ -66,7 +66,7 @@ def create_xor_component(component1_, component2_, round_object, round_number):
     input_links = [component1_.id, component2_.id]
     current_components_number = round_object.get_number_of_components()
     output_bit_size = component1_.output_bit_size
-    new_xor_component = XOR(
+    new_xor_component = Xor(
         round_number,
         current_components_number,
         input_links,

--- a/claasp/editor.py
+++ b/claasp/editor.py
@@ -19,24 +19,24 @@ import sys
 
 from copy import deepcopy
 
-from claasp.components.and_component import AND
+from claasp.components.and_component import And
 from claasp.components.cipher_output_component import CipherOutput
 from claasp.components.constant_component import Constant
-from claasp.components.fsr_component import FSR
+from claasp.components.fsr_component import Fsr
 from claasp.components.intermediate_output_component import IntermediateOutput
 from claasp.components.linear_layer_component import LinearLayer
 from claasp.components.mix_column_component import MixColumn
-from claasp.components.modadd_component import MODADD
-from claasp.components.modmul_component import MODMUL
-from claasp.components.modsub_component import MODSUB
+from claasp.components.modadd_component import ModAdd
+from claasp.components.modmul_component import ModMul
+from claasp.components.modsub_component import ModSub
 from claasp.components.idea_modmul_component import IdeaModmul
-from claasp.components.not_component import NOT
-from claasp.components.or_component import OR
+from claasp.components.not_component import Not
+from claasp.components.or_component import Or
 from claasp.components.permutation_component import Permutation
 from claasp.components.reverse_component import Reverse
 from claasp.components.rotate_component import Rotate
-from claasp.components.sbox_component import SBOX
-from claasp.components.shift_component import SHIFT
+from claasp.components.sbox_component import Sbox
+from claasp.components.shift_component import Shift
 from claasp.components.shift_rows_component import ShiftRows
 from claasp.components.sigma_component import Sigma
 from claasp.components.theta_gaston_component import ThetaGaston
@@ -45,7 +45,7 @@ from claasp.components.theta_xoodoo_component import ThetaXoodoo
 from claasp.components.variable_rotate_component import VariableRotate
 from claasp.components.variable_shift_component import VariableShift
 from claasp.components.word_permutation_component import WordPermutation
-from claasp.components.xor_component import XOR
+from claasp.components.xor_component import Xor
 from claasp.name_mappings import (
     INTERMEDIATE_OUTPUT,
     CIPHER_OUTPUT,
@@ -59,7 +59,7 @@ CIPHER_ROUND_NOT_FOUND_ERROR = (
 )
 
 
-def add_AND_component(cipher, input_id_links, input_bit_positions, output_bit_size):
+def add_and_component(cipher, input_id_links, input_bit_positions, output_bit_size):
     """
     Use this function to create and add an and component to editor.
 
@@ -76,7 +76,7 @@ def add_AND_component(cipher, input_id_links, input_bit_positions, output_bit_si
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: and_0_0 = cipher.add_AND_component(["input","input"], [[0,1],[2,3]], 2)
+        sage: and_0_0 = cipher.add_and_component(["input","input"], [[0,1],[2,3]], 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -99,7 +99,7 @@ def add_AND_component(cipher, input_id_links, input_bit_positions, output_bit_si
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = AND(
+    new_component = And(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -224,7 +224,7 @@ def add_constant_component(cipher, output_bit_size, value):
     return new_component
 
 
-def add_FSR_component(cipher, input_id_links, input_bit_positions, output_bit_size, description):
+def add_fsr_component(cipher, input_id_links, input_bit_positions, output_bit_size, description):
     """
     Use this function to create and add an lfsr/nlfsr component to editor.
 
@@ -255,7 +255,7 @@ def add_FSR_component(cipher, input_id_links, input_bit_positions, output_bit_si
         sage: from claasp.cipher import Cipher
         sage: cipher = Cipher("cipher_name", "fsr", ["input"], [12], 12)
         sage: cipher.add_round()
-        sage: fsr_0_0 = cipher.add_FSR_component(["input", "input"], [[0,1,2,3,4],[0,1,2,3,4,5,6]], 12, [[
+        sage: fsr_0_0 = cipher.add_fsr_component(["input", "input"], [[0,1,2,3,4],[0,1,2,3,4,5,6]], 12, [[
         ....: [5, [[4], [5], [6, 7]]],  # Register_len:5,  feedback poly: x4 + x5 + x6*x7
         ....: [7, [[0], [8], [1, 2]]]  # Register_len:7, feedback poly: x0 + x1*x2 + x8
         ....: ], 1])
@@ -282,7 +282,7 @@ def add_FSR_component(cipher, input_id_links, input_bit_positions, output_bit_si
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = FSR(
+    new_component = Fsr(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -454,7 +454,7 @@ def add_mix_column_component(cipher, input_id_links, input_bit_positions, output
     return new_component
 
 
-def add_MODADD_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
+def add_modadd_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
     """
     Use this function to create and add a modadd component to editor.
 
@@ -471,7 +471,7 @@ def add_MODADD_component(cipher, input_id_links, input_bit_positions, output_bit
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: modadd_0_0 = cipher.add_MODADD_component(["input","input"], [[0,1],[2,3]], 2)
+        sage: modadd_0_0 = cipher.add_modadd_component(["input","input"], [[0,1],[2,3]], 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -494,7 +494,7 @@ def add_MODADD_component(cipher, input_id_links, input_bit_positions, output_bit
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = MODADD(
+    new_component = ModAdd(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -506,7 +506,7 @@ def add_MODADD_component(cipher, input_id_links, input_bit_positions, output_bit
     return new_component
 
 
-def add_MODMUL_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
+def add_modmul_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
     """
     Use this function to create and add a modmul component to editor.
 
@@ -521,7 +521,7 @@ def add_MODMUL_component(cipher, input_id_links, input_bit_positions, output_bit
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = MODMUL(
+    new_component = ModMul(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -533,7 +533,7 @@ def add_MODMUL_component(cipher, input_id_links, input_bit_positions, output_bit
     return new_component
 
 
-def add_MODSUB_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
+def add_modsub_component(cipher, input_id_links, input_bit_positions, output_bit_size, modulus):
     """
     Use this function to create a modsub component in the editor.
 
@@ -550,7 +550,7 @@ def add_MODSUB_component(cipher, input_id_links, input_bit_positions, output_bit
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: modsub_0_0 = cipher.add_MODSUB_component(["input","input"], [[0,1],[2,3]], 2)
+        sage: modsub_0_0 = cipher.add_modsub_component(["input","input"], [[0,1],[2,3]], 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -573,7 +573,7 @@ def add_MODSUB_component(cipher, input_id_links, input_bit_positions, output_bit
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = MODSUB(
+    new_component = ModSub(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -638,7 +638,7 @@ def add_idea_modmul_component(cipher, input_id_links, input_bit_positions, outpu
     return new_component
 
 
-def add_NOT_component(cipher, input_id_links, input_bit_positions, output_bit_size):
+def add_not_component(cipher, input_id_links, input_bit_positions, output_bit_size):
     """
     Use this function to create a not component in editor.
 
@@ -655,7 +655,7 @@ def add_NOT_component(cipher, input_id_links, input_bit_positions, output_bit_si
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: not_0_0 = cipher.add_NOT_component(["input"], [[0,1,2,3]], 4)
+        sage: not_0_0 = cipher.add_not_component(["input"], [[0,1,2,3]], 4)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -678,7 +678,7 @@ def add_NOT_component(cipher, input_id_links, input_bit_positions, output_bit_si
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = NOT(
+    new_component = Not(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -689,7 +689,7 @@ def add_NOT_component(cipher, input_id_links, input_bit_positions, output_bit_si
     return new_component
 
 
-def add_OR_component(cipher, input_id_links, input_bit_positions, output_bit_size):
+def add_or_component(cipher, input_id_links, input_bit_positions, output_bit_size):
     """
     Use this function to create an or component in editor.
 
@@ -706,7 +706,7 @@ def add_OR_component(cipher, input_id_links, input_bit_positions, output_bit_siz
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: or_0_0 = cipher.add_OR_component(["input","input"], [[0,1],[2,3]], 2)
+        sage: or_0_0 = cipher.add_or_component(["input","input"], [[0,1],[2,3]], 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -729,7 +729,7 @@ def add_OR_component(cipher, input_id_links, input_bit_positions, output_bit_siz
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = OR(
+    new_component = Or(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -1052,7 +1052,7 @@ def add_round_output_component(cipher, input_id_links, input_bit_positions, outp
     return new_component
 
 
-def add_SBOX_component(cipher, input_id_links, input_bit_positions, output_bit_size, description):
+def add_sbox_component(cipher, input_id_links, input_bit_positions, output_bit_size, description):
     """
     Use this function to create and add a sbox component to editor.
 
@@ -1070,7 +1070,7 @@ def add_SBOX_component(cipher, input_id_links, input_bit_positions, output_bit_s
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: sbox_0_0 = cipher.add_SBOX_component(["input"], [[0,1,2,3]], 4,
+        sage: sbox_0_0 = cipher.add_sbox_component(["input"], [[0,1,2,3]], 4,
         ....: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
@@ -1094,7 +1094,7 @@ def add_SBOX_component(cipher, input_id_links, input_bit_positions, output_bit_s
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = SBOX(
+    new_component = Sbox(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -1106,7 +1106,7 @@ def add_SBOX_component(cipher, input_id_links, input_bit_positions, output_bit_s
     return new_component
 
 
-def add_SHIFT_component(cipher, input_id_links, input_bit_positions, output_bit_size, parameter):
+def add_shift_component(cipher, input_id_links, input_bit_positions, output_bit_size, parameter):
     """
     Use this function to create and add a shift component to editor.
 
@@ -1125,7 +1125,7 @@ def add_SHIFT_component(cipher, input_id_links, input_bit_positions, output_bit_
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: shift_0_0 = cipher.add_SHIFT_component(["input"], [[0,1,2,3]], 4, 2)
+        sage: shift_0_0 = cipher.add_shift_component(["input"], [[0,1,2,3]], 4, 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -1148,7 +1148,7 @@ def add_SHIFT_component(cipher, input_id_links, input_bit_positions, output_bit_
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = SHIFT(
+    new_component = Shift(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -1587,7 +1587,7 @@ def add_word_permutation_component(
     return new_component
 
 
-def add_XOR_component(cipher, input_id_links, input_bit_positions, output_bit_size):
+def add_xor_component(cipher, input_id_links, input_bit_positions, output_bit_size):
     """
     Use this function to create and add a xor component to editor.
 
@@ -1604,7 +1604,7 @@ def add_XOR_component(cipher, input_id_links, input_bit_positions, output_bit_si
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: xor_0_0 = cipher.add_XOR_component(["input","input"], [[0,1],[2,3]], 2)
+        sage: xor_0_0 = cipher.add_xor_component(["input","input"], [[0,1],[2,3]], 2)
         sage: cipher.print()
         cipher_id = cipher_name_i4_o4_r1
         cipher_type = permutation
@@ -1627,7 +1627,7 @@ def add_XOR_component(cipher, input_id_links, input_bit_positions, output_bit_si
         print(CIPHER_ROUND_NOT_FOUND_ERROR)
         return None
 
-    new_component = XOR(
+    new_component = Xor(
         cipher.current_round_number,
         cipher.current_round_number_of_components,
         input_id_links,
@@ -2090,9 +2090,9 @@ def sort_cipher(cipher):
         sage: from claasp.name_mappings import PERMUTATION
         sage: cipher = Cipher("cipher_name", PERMUTATION, ["input"], [4], 4)
         sage: cipher.add_round()
-        sage: sbox_that_should_be_second = cipher.add_SBOX_component(["sbox_0_1"], [[0,1,2,3]], 4,
+        sage: sbox_that_should_be_second = cipher.add_sbox_component(["sbox_0_1"], [[0,1,2,3]], 4,
         ....: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
-        sage: sbox_that_should_be_first = cipher.add_SBOX_component(["input"], [[0,1,2,3]], 4,
+        sage: sbox_that_should_be_first = cipher.add_sbox_component(["input"], [[0,1,2,3]], 4,
         ....: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
         sage: cipher.print_as_python_dictionary()
         cipher = {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -414,7 +414,7 @@ person in charge of reviewing your code. If you are the reviewer, make sure that
 We agreed on some specifics that do not follow the convention linked above. These are:
 
 - Both protected/private methods will have the suffix `_`.
-- Component names like AND, OR, etc. inside a method name will always be in capital letters. `add_AND_component()`
+- Component names like AND, OR, etc. inside a method name will always be in capital letters. `add_and_component()`
 - Create a PR to `develp` branch only when the functionality is completed
 
 ## Contributing to the documentation

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -286,7 +286,7 @@ There are plenty of **tools** that can help you to follow this standard. We have
 - Linter: reviews the code and documentation syntax based on the standard *pep8*. We will use *[pycodestyle](https://github.com/PyCQA/pycodestyle) + [pydocstyle](https://github.com/PyCQA/pydocstyle)*
 - Formatter: automatically formats Python code. We will use *[autopep8](https://github.com/hhatto/autopep8)*, which uses the [pycodestyle](https://pypi.org/project/pycodestyle/) utility to determine what parts of the code needs to be formatted to conform to the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
 
-The linter will follow the pep8 standard, but this standard can be slightly modified specifying some configuration in **setup.cfg** file that you can find in the root of your project.
+The linter will follow the pep8 standard, but this standard can be slightly modified by specifying some configuration in **setup.cfg** file that you can find in the root of your project.
 
 Example of the syntax of this file:
 
@@ -301,9 +301,9 @@ Example of the syntax of this file:
 1. Line 1 indicates the linter (for the code) that will be used to analyse the code.
 2. Line 2 (in this example) overrides the default config for the max line length and sets it to 120 chars.
 3. Line 4 indicates the linter for the documentation that will be used to analyse the documentation.
-4. Line 5 tells the linter to ignore some specific [rules](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes) set by default (that how we can customise our analysis to ignore some rules that we disagree with, or we want to ignore for the time being).
+4. Line 5 tells the linter to ignore some specific [rules](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes) set by default (that is how we can customise our analysis to ignore some rules that we disagree with, or we want to ignore for the time being).
 
-In order to be able to run the linter/formatter from the shell, open a new one and follow the instructions below to install them. You have also some examples on how to run each tool in its section.
+To run the linter/formatter from the shell, open a new one and follow the instructions below to install them. You also have some examples on how to run each tool in its section.
 
 ### **pycodestyle**
 
@@ -370,7 +370,7 @@ Flags we use in the command above:
 - *--in-place*: makes changes to files in place.
 - *--aggressive --aggressive:* defines the level of aggressiveness with which we want the analysis to be carried out. (More amount of *-a* = more level of aggressiveness.)
 
-***Note:*** If you have doubts of how to use these tools you can always go to the shell/bash/terminal in your computer and use the *help documentation* in order to see the options you have to add to this setup file. Typing for example:
+***Note:*** If you have doubts about how to use these tools, you can always go to the shell/bash/terminal on your computer and use the *help documentation* in order to see the options you have to add to this setup file. Typing, for example:
 
 ```
 pydocstyle --h
@@ -382,54 +382,54 @@ autopep8 --h
 
 1. Create a new ticket in JIRA
 2. Set the `Project` field to be **Cryptographic Library for Automated Analysis of Symmetric Primitives (CLAASP)**
-3. If the issue created is considered to be collection of many small tasks, then select `Story` as the `Issue Type`.
+3. If the issue created is considered to be a collection of many small tasks, then select `Story` as the `Issue Type`.
    Otherwise, set it to `Task` or a `Bug` depending on the context.
-4. Give short description in the `Summary` in the following format
+4. Give a short description in the `Summary` in the following format
    ```
        <type>: <description>
    ```
-   where `<type>` is either `feature`/`doc`/`bug`/`other`, i.e. "bug: incorrect computation of Walsh transform".
-5. Set the appropriate `Due Date`
-6. Give a clear and concise explanation of the issue in the `Description`
-7. Select the `Fix Version` of the module
-8. Put relevant keywords in the field `Labels`
+   where `<type>` is either `feature`/`doc`/`bug`/`other`, i.e., "bug: incorrect computation of Walsh transform".
+5. Set the appropriate `Due Date`.
+6. Give a clear and concise explanation of the issue in the `Description`.
+7. Select the `Fix Version` of the module.
+8. Put relevant keywords in the field `Labels`.
 9. If it is necessary to link the issue with existing ones, fill both the `Linked issue` and the `Issue` field.
 
-Now suppose that you want to work on a ticket. We must associate the ticket to a specific branch in `claasp`
+Now, suppose that you want to work on a ticket. We must associate the ticket with a specific branch in `claasp`
 repository in the following way
 
-1. Go to the ticket that you want to work on
-2. In the right pane, select `Create branch`. You will be redirected to the GitHub.
-3. Select the `claasp` in the `Repository` field
-4. Choose `Custom` in the `Branch type`
+1. Go to the ticket that you want to work on.
+2. In the right pane, select `Create branch`. You will be redirected to GitHub.
+3. Select the `claasp` in the `Repository` field.
+4. Choose `Custom` in the `Branch type`.
 5. Select the appropriate branch that you want to `Branch from`. Generally, this should be set to `main` or `develop`.
 6. In the `Branch name`, make sure that it is filled with the same ID as the ticket, i.e. `LIBCA-26`.
-7. Click `Create branch`
+7. Click `Create branch`.
 
-You may now work on changes you want to do on that specific branch you just created. Once this is done, create a pull
+You may now work on the changes you want to make on that specific branch you just created. Once this is done, create a pull
 request and assign someone to review the changes. Do not forget to also change the `Assignee` field in the ticket to the 
-person in charge of reviewing your code. If you are the reviewer, make sure that the changes in the pull request follows
+person in charge of reviewing your code. If you are the reviewer, make sure that the changes in the pull request follow
 [SageMath coding convention.](https://doc.sagemath.org/html/en/developer/coding_basics.html)
 
 We agreed on some specifics that do not follow the convention linked above. These are:
 
 - Both protected/private methods will have the suffix `_`.
-- Component names like AND, OR, etc. inside a method name will always be in capital letters. `add_and_component()`
-- Create a PR to `develp` branch only when the functionality is completed
+- Component names like AND, OR, etc., inside a method name should always follow snate_case, e.g., `add_and_component()`.
+- Create a PR to the `develop` branch only when the functionality is completed.
 
 ## Contributing to the documentation
 
-You can add Documentation Strings in your code following the 
+You can add Documentation Strings in your code, following the 
 [SageMath documentation convention](https://doc.sagemath.org/html/en/developer/coding_basics.html#documentation-strings).
 
 We agreed on some specifics that do not follow the convention linked above. These are:
 
-- When specifying the type of input/output do it in bold. 
+- When specifying the type of input/output, do it in bold. 
 Like: ``` ``number_of_rounds`` -- **integer** (default: `1`); number of rounds for the cipher```.
 - When adding an example tag, this needs to be exactly like `EXAMPLES::`, and leave an empty blank line before the 
 example code.
 - When there is no input to a method, ``None`` should be used to specify it 
-- If the line is too long, it can be split in as many lines as needed, but always leaving 2 blank spaces of indentation.
+- If the line is too long, it can be split into as many lines as needed, but always leaving 2 blank spaces of indentation.
 ```
 run_avalanche_dependence_uniform -- **boolean** (default: `True`); if True, add the avalanche dependence
   uniform results to the output dictionary
@@ -519,37 +519,37 @@ This is the current project structure.
 - `develop` is the branch where the latest changes are merged into.
 - `<fix|feature|breaking>/<task-name>` is the branch where a new feature is developed.
 
-> ⚠️ We encourage you to follow this convention when creating new branches even though branches with the naming 
+> ⚠️ We encourage you to follow this convention when creating new branches, even though branches with the naming 
 > convention `<task-name>` are allowed. ⚠️ 
 
 ## Pull Requests Conventions
-- Pull Requests should be made from a `feature-branch` to `develop` and it should be reviewed by at least one person.
-- New branches to development tasks will have `develop` branch as origin. 
-- The only allowed Pull Requests to `main` branch must come from `develop` branch. All other Pull Requests will be 
+- Pull Requests should be made from a `feature-branch` to `develop,` and it should be reviewed by at least one person.
+- New branches to development tasks will have the `develop` branch as origin. 
+- The only allowed Pull Requests to the `main` branch must come from the `develop` branch. All other Pull Requests will be 
 rejected.
 - When a `develop` Pull Request to `main` is merged, a script will be executed to update the project version. See 
 [Changelog versioning](#changelog-versioning) section.
 
 # Best practices for development
-The purposes of implementing these in our daily basis are:
+The purposes of implementing these on a daily basis are:
 - Keep a homogeneous code style throughout the project.
-- Follow most of `PEP8` standard rules.
+- Follow most of the `PEP8` standard rules.
 - Make code easier to read and understand.
-- Reduce tendency to errors.
+- Reduce the tendency to errors.
 - Improve performance.
 
 ## Linter/Formatter
-A best practice while developing is having a `linting` and a `formating` tool to help you follow the standard 
+A best practice while developing is having a `linting` and a `formatting` tool to help you follow the standard 
 guidelines.
 - **Linter**: reviews the code and documentation syntax based on the standard `Pep8`. We will use 
 [pycodestyle](https://github.com/PyCQA/pycodestyle) + [pydocstyle](https://github.com/PyCQA/pydocstyle).
 - **Formatter**: automatically formats Python code. We will use [autopep8](https://github.com/hhatto/autopep8), which 
-uses the [pycodestyle](https://pypi.org/project/pycodestyle/) utility to determine what parts of the code needs to be 
+uses the [pycodestyle](https://pypi.org/project/pycodestyle/) utility to determine what parts of the code need to be 
 formatted to conform to the `PEP8` style guide.
 
 ## Imports
-- `PEP8` states a best practice to separate the end of the imports with the class or module definition by two blank 
-lines. This **improves readability** and clearer knowledge of where the imports start and where they end.
+- `PEP8` states a best practice to separate the end of the imports from the class or module definition by two blank 
+lines. This **improves readability** and provides clearer knowledge of where the imports start and where they end.
 ```python
 import numpy
 
@@ -561,14 +561,14 @@ class Calculator:
 ```python
 from numpy import *
 ```
-These type of imports bring everything that that module/file contains, even its own imports. This makes the cost of 
+These types of imports bring in everything the module/file contains, including its own imports. This makes the cost of 
 executing the code higher as it needs to resolve every import. Imagine that the module you are importing is importing 
-other modules itself with this nomenclature, this can lead to cyclical imports or, in the worst case scenario, to 
-import your hole project in the file without you even knowing. We should only import what we strictly need.
+other modules itself with this nomenclature; this can lead to cyclical imports or, in the worst-case scenario, to 
+import your whole project into the file without you even knowing. We should only import what we strictly need.
 
-- When we need certain imports to make our string code to work, instead to adding them to the global imports, try to 
-**import them where it is required only**. This will help us when we try to understand the code where those imports are 
-really used. If we specify them globally, but they are only used in string code, probably our IDE will point to us that 
+- When we need certain imports to make our string code work, instead of adding them to the global imports, try to 
+**import them only where required**. This will help us when we try to understand the code where those imports are 
+really used. If we specify them globally, but they are only used in string code, probably our IDE will point out to us that 
 those imports are not used when they actually are.
 ```python
 cipher_code_string = ""
@@ -579,7 +579,7 @@ cipher_code_string += "def copy_array(input):\n"
 ```
 This way of adding imports should also follow the recommendations described in this section.
 
-- If we need to add a line of imports that is very long, specify those imports between parenthesis, this will help the 
+- If we need to add a line of imports that is very long, specify those imports between parentheses; this will help the 
 formatter to split the import into multiple lines.
 ```python
 from claasp.name_mappings import (INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, CONSTANT, 
@@ -588,24 +588,24 @@ from claasp.name_mappings import (INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, CONSTANT,
 
 ## File arrangement
 - `PEP8` states a best practice to leave a **blank line at the end of the file**.
-- **Avoid writing infinite lines**. `PEP8` aims to have lines of less than 79 characters, we know that because of 
-the nature of the project this would be nearly impossible to achieve, but we consider that writing lines of no more than 
+- **Avoid writing infinite lines**. `PEP8` aims to keep lines under 79 characters. We know that because of 
+the nature of the project, this would be nearly impossible to achieve, but we consider that writing lines of no more than 
 120 characters can be achievable. This would mean a major improvement in readability.
 
 ## Comments and dead code in the code
 - It is **not recommended to write comments in the code** unless they explain something specific that the code can't 
 explain.
 - It is a **bad practise having commented code**. When a piece of code is not needed, it needs to be removed. 
-In case the programmer wants to recover it, he/she can do it from the version system control (Git).
+If the programmer wants to recover it, they can do so from the version control system (Git).
 
 ## Nomenclature
-- Variables, file names and methods should follow the same nomenclature as specified by `PEP8` 
-[Naming Conventions](https://peps.python.org/pep-0008/#naming-conventions). This means to write them in snake_case 
-avoiding usage of uppercase letters. In this project we have agreed to use uppercase notation for components naming. 
-- On the other hand, for class naming we should use CamelCase avoiding the usage of underscore to separate the words.
+- Variables, file names, and methods should follow the same nomenclature as specified by `PEP8` 
+[Naming Conventions](https://peps.python.org/pep-0008/#naming-conventions). This means to write them in snake_case , 
+avoiding usage of uppercase letters. In this project, we have agreed to use uppercase notation for component naming. 
+- On the other hand, for class naming, we should use CamelCase, avoiding the usage of underscores to separate words.
 
 ## Single quotes VS double quotes
-Below you can find what it is considered best practises, but the most important thing in this case, it is making an 
+Below you can find what is considered best practice, but the most important thing in this case, it is making an 
 agreement among the team in order to use them in the same way, whether following best practises or not. 
 - **Single quotes**: it's a best practice to use them to surround small and short strings, such as string literals or 
 identifiers. But it's not a requirement. You can write entire paragraphs and articles inside single quotes. Example:
@@ -638,33 +638,24 @@ print("My favorite quote from Die Hard is 'Welcome to the party, pal'")
 ```
 
 ## Single underscore VS double underscore
-- The use of single underscore is **related to protected variables and methods**, this means that no other object or 
+- The use of a single underscore is **related to protected variables and methods**, which means that no other object or 
 method is able to reach them unless they are part of a child object (Inheritance).
-- Double underscores are used to state that **methods are private** and no other objets can use them even if they are
+- Double underscores are used to state that **methods are private** and no other objects can use them, even if they are
 children.
-- In this project we have agreed to only use Single underscore notation for both purposes. 
+- In this project, we have agreed to only use Single underscore notation for both purposes. 
 
 ## C-code
 `PEP8` has a specific guideline on how to deal with  C code in the 
 [C implementation of Python](https://peps.python.org/pep-0007/).
 
 # Testing
-## Creating pytests
-The project uses **`Pytest` as it’s testing framework**. We can forget to write the example Docstrings as they will 
-still be part of the documentation.
-Our tests are stored in the `tests` folder that mimics the folder structure of `claasp`.
+## Creating tests
+The project uses **`Pytest`** and **`Doctests`** as its testing framework. 
 
-There are files in our `claasp` folder that are not in the `test` folder, this means that those files does not contain 
-any tests. So every time we create a new file that should have tests in `claasp` we would need to create a new test 
-file. Test files are named exactly the same as our `claasp` files, we just need to add `_test` at the end of the name. 
+### Docstring
 
-As an example `cipher.py` needs a test file called `cipher_test.py`.
+Doctests are meant to show users how to use a method or class.
 
-Once we have created our test file, we need to create the test. The test file works as common Python files. So we need 
-to declare our testing functions and our imports. Our function names follow the structure of 
-`test_{name of the method we want to test}`.
-
-- **Docstring**:
 ```bash
 sage: from claasp.ciphers.block_ciphers.aes_block_cipher import AESBlockCipher
 sage: aes = AESBlockCipher()
@@ -675,7 +666,23 @@ sage: aes.evaluate([key, plaintext]) == ciphertext
 True
 ```
 
-- **Pytest**:
+### Pytest
+
+Pytests can serve as documentation, but they should also ensure coverage.
+
+Our Pytests are stored in the `tests` folder that mimics the folder structure of `claasp`.
+
+There are files in our `claasp` folder that are not in the `test` folder. This means that those files do not contain 
+any tests. So every time we create a new file that should have tests in `claasp` we would need to create a new test 
+file. Test files are named exactly the same as our `claasp` files; we just need to add `_test` at the end of the name. 
+
+As an example, `cipher.py` needs a test file called `cipher_test.py`.
+
+Once we have created our test file, we need to create the test. The test file behaves like a standard Python file. So we need 
+to declare our testing functions and our imports. Our function names follow the structure of 
+`test_{name of the method we want to test}`.
+
+
 ```python
 from claasp.ciphers.block_ciphers.aes_block_cipher import AESBlockCipher
 
@@ -688,11 +695,11 @@ def test_aes_block_cipher():
     assert aes.evaluate([key, plaintext]) == ciphertext
 ```
 
-As you can see above, the `assert` keyword is the one that will check if our result is the one we expected. 
-Apart from that, the structure of the test is very similar.
+As you can see above, the `assert` keyword checks whether our result matches the expected value. 
+Apart from that, the test structure is very similar.
 
 ## Running pytests
-To run all the project test you can run `make pytest` command, but if you want to run specific things you can do:
+To run all the project tests, you can run the `make pytest` command, but if you want to run specific things you can do:
 - **Run specific file:**
 ```bash
 pytest -v tests/cipher_test.py
@@ -701,7 +708,7 @@ pytest -v tests/cipher_test.py
 ```bash
 pytest -v tests/cipher_test.py::test_algebraic_tests
 ```
-- **Run the tests to show full log of error:**
+- **Run the tests to show a full log of errors:**
 ```bash
 pytest -vv tests/cipher_test.py
 ```
@@ -714,8 +721,8 @@ pytest -s tests/cipher_test.py
 pytest -v -n=auto tests/cipher_test.py
  ```
 
-If we want a **specific test to be skipped** we will need to `import pytest` to the top of the file and add this 
-following command with the reason of the test being skipped as the argument `@pytest.mark.skip("Takes to long")`:
+If we want a **specific test to be skipped**, we will need to `import pytest` to the top of the file and add this 
+following command with the reason of the test being skipped as the argument `@pytest.mark.skip("Takes too long")`:
 ```python
 import pytest
 
@@ -730,20 +737,20 @@ def test_aes_block_cipher():
     assert aes.evaluate([key, plaintext]) == ciphertext
 ```
 ## Running doctests
-If you want to run all doctests you need to execute `make test` command. 
+If you want to run all doctests, you need to execute the `make test` command. 
 
-If you want to execute a **specific module** you can execute:
+If you want to execute a **specific module**, you can execute:
 ```bash
 sage -t claasp
 ```
 
-And if you want to execute a **specific file test** you can execute:
+And if you want to execute a **specific file test**, you can execute:
 ```bash
 sage -t claasp/cipher.py
 ```
 
 ## Deprecation warnings
-We might get sometime deprecation warnings. To avoid them we can import `pytest` to the top of the file and add this 
+We might get some deprecation warnings. To avoid them, we can import `pytest` to the top of the file and add the 
 following command `@pytest.mark.filterwarnings("ignore::DeprecationWarning:")`:
 ```python
 import pytest
@@ -760,12 +767,12 @@ def test_aes_block_cipher():
 ```
 
 # Code analysis with SonarCloud
-SonarCloud is a platform to evaluate the quality of the source code of a project detecting errors, vulnerabilities and 
+SonarCloud is a platform to evaluate the quality of the source code of a project, detecting errors, vulnerabilities, and 
 bugs in software. Claasp SonarCloud project can be found 
 [here](https://sonarcloud.io/project/overview?id=Crypto-TII_claasp).
 
 ## Project overview
-SonarCloud is responsible for the analysis of our code once a pull request has been created.
+SonarCloud is responsible for analyzing our code once a pull request has been created.
 
 We have two tabs in the general view:
 - **New Code**: we find a detailed report on the code quality of the last push, taking into account only the new code 
@@ -777,39 +784,39 @@ The coverage of the project is the **percentage of lines of code that are covere
 Clicking on the percentage or the number of lines takes us to the list of files.
 
 ## Security Review
-A security hotspot is a piece of code that is sensitive to the security of the project and must be reviewed and fixed.
+A security hotspot is a piece of code that is sensitive to the project's security and must be reviewed and fixed.
 
 ## Duplications
 When we talk about duplications, we are referring to code already written in the project that is repeated several 
 times. SonarCloud also tells us where these repetitions are occurring and will tell us the percentage of duplicated 
 lines in our code.
-Clicking on the percentage or the number of duplicate lines will take us to the list of files containing duplicate code.
+Clicking the percentage or the number of duplicate lines takes us to the list of files containing duplicate code.
 
 ## Issues
 This section reflects the problems found in our code that we should fix. 
 
-SonarCloud's report provides detailed information on each problem encountered as well as suggestions on how to solve it.
+SonarCloud's report provides detailed information about each problem encountered, along with suggestions for solving it.
 
 The problems are divided into 3 types:
 - **Bugs**: problems that cause the code to behave incorrectly.
-- **Vulnerabilities**: problems that can be exploited by attackers to compromise the confidentiality, integrity or 
+- **Vulnerabilities**: problems that can be exploited by attackers to compromise the confidentiality, integrity, or 
   availability of the software.
 - **Code Smells**: problems that affect the maintainability of the code.
 
-The **severity** of the problems in our code are divided into 5 types:
+The **severity** of the problems in our code is divided into 5 types:
 - **Blocker**: the problem is critical and must be fixed immediately.
 - **Critical**: the problem is critical and must be fixed as soon as possible.
 - **Major**: the problem is important and should be fixed.
 - **Minor**: the problem is not very important and should be fixed if possible.
 - **Info**: the problem is not important and does not need to be fixed.
 
-When the problem has been solved by updating our code, a new push re-runs the analysis process.
+When the problem is solved by updating our code, a new push reruns the analysis process.
 Similarly, when reviewing a problem detected in the SonarCloud report, if we consider that it is not a problem, we can 
 mark it as "Resolved as won't fix".
 
 ## It should be noted that...
-If in the new push there is more than **3% duplicate code** and/or the **test coverage is less than 80%** the pipeline 
-analysis will fail, as well as, if there are new Security Hotspots and/or bugs in the code during a new push.
+If in the new push there is more than **3% duplicate code** and/or the **test coverage is less than 80%**, the pipeline 
+analysis will fail, as well as if there are new Security Hotspots and/or bugs in the code during a new push.
 
 # Changelog versioning
 To automate the project version increment, the script `update_changelog.py` has been created to be executed when a Pull 
@@ -818,7 +825,7 @@ This script analyzes the messages of the commits to determine the type of versio
 should be added to the `CHANGELOG.md`.
 
 > ⚠️ It is important to follow the following rules only in case we want to upgrade the project version at the end of the 
-> task. Otherwise, do not follow the following rules as it will cause an unwanted change in the project version. ⚠️ 
+> task. Otherwise, do not follow the following rules, as it will cause an unwanted change in the project version. ⚠️ 
 
 ## Versioning
 There are three types of versioning changes, as you can check in [Semantic Versioning](https://semver.org/):
@@ -829,19 +836,19 @@ There are three types of versioning changes, as you can check in [Semantic Versi
 
 ## How it works
 The information that is needed in order to update the new version will be taken from the messages of the commits of all 
-the Pull Requests that have been merged into `develop`. This means, we will check the commits between the last two 
+the Pull Requests that have been merged into `develop`. This means we will check the commits between the last two 
 merges from `develop` to `main`. Those merge commits will have a message like this:
 **"Merge pull request #x from Crypto-TII/develop"**.
 
 ### Commits structure for version update
-The start of the commit messages must be created according to this structure, because of that depends on the type of 
+The start of the commit messages must be created according to this structure, because it depends on the type of 
 change for the new version. These are the versioning keywords:
 
 - For **patch** changes: **FIX/**
 - For **minor** changes: **FEATURE/**
 - For **major** changes: **BREAKING/**
 
-We will look in the commits merged into `develop` to obtain the highest version change to be applied.
+We will look at the commits merged into `develop` to determine the highest version change to apply.
 
 ### Commits structure for Changelog update
 The Changelog version sections will have this structure:
@@ -850,8 +857,8 @@ The Changelog version sections will have this structure:
 
 ### Added
 
-- Create new component.
-- Create login form.
+- Create a new component.
+- Create a login form.
 
 ### Changed
 
@@ -900,7 +907,7 @@ Let's see an example of how the versioning works:
 
 - The last version in `CHANGELOG.md` is `4.0.1`.
 - The branch name is `feat/LIBCA-36-login-creation`.
-- We have this list of valid commits messages:
+- We have this list of valid commit messages:
   - **FEATURE/Add: create new component**
   - **Feat: create login form**
   - **BREAKING/Change: update Version variables from destructuring list**
@@ -916,8 +923,8 @@ We will have a new version 5.0.0 with the following information in the `CHANGELO
 
 ### Added
 
-- Create new component.
-- Create login form.
+- Create a new component.
+- Create a login form.
 
 ### Changed
 

--- a/tests/unit/cipher_modules/models/milp/milp_models/Gurobi/monomial_prediction_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/Gurobi/monomial_prediction_test.py
@@ -121,7 +121,7 @@ def test_modmul_modeling_correctness_via_anf_exhaustive():
     n = 3
     cipher = Cipher("test_modmul_3", BLOCK_CIPHER, ["input"], [n * 2], n)
     cipher.add_round()
-    cipher.add_MODMUL_component(
+    cipher.add_modmul_component(
         ["input", "input"],
         [list(range(n)), list(range(n, 2 * n))],
         n,

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_shared_difference_paired_input_differential_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_shared_difference_paired_input_differential_linear_model_test.py
@@ -13,7 +13,7 @@ from claasp.cipher_modules.models.utils import (
 )
 from claasp.ciphers.permutations.chacha_permutation import ChachaPermutation, ROUND_MODE_HALF
 from claasp.components.intermediate_output_component import IntermediateOutput
-from claasp.components.modsub_component import MODSUB
+from claasp.components.modsub_component import ModSub
 
 
 def add_prefix_id_to_inputs(chacha_permutation, prefix):
@@ -31,7 +31,7 @@ def add_ciphertext_and_new_plaintext_to_inputs(chacha_permutation):
     modsub_ids = []
     round_object = chacha_permutation.rounds.round_at(0)
     for i in range(16):
-        new_modsub_component = MODSUB(
+        new_modsub_component = ModSub(
             0,
             round_object.get_number_of_components(),
             ["ciphertext_final", "fake_plaintext"],

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
@@ -5,7 +5,7 @@ from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model impo
 from claasp.cipher_modules.models.sat.solvers import CADICAL_EXT, KISSAT_EXT, PARKISSAT_EXT
 from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
-from claasp.components.modadd_component import MODADD
+from claasp.components.modadd_component import ModAdd
 from claasp.name_mappings import INPUT_KEY, INPUT_PLAINTEXT, SATISFIABLE, XOR_DIFFERENTIAL
 
 
@@ -140,7 +140,7 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_thre
     )
     result = sat.find_one_xor_differential_trail_with_fixed_weight(30, solver_name=CADICAL_EXT)
     speck_components = speck.get_all_components()
-    modadd_objects = list(filter(lambda obj: isinstance(obj, MODADD), speck_components))
+    modadd_objects = list(filter(lambda obj: isinstance(obj, ModAdd), speck_components))
 
     carry_list = compute_modadd_xor(modadd_objects, result["components_values"])
     computed_number_of_full_windows = count_sequences_of_ones(carry_list, window_size)
@@ -171,7 +171,7 @@ def test_find_one_xor_differential_trail_with_fixed_weight_and_with_exactly_one_
     sat.build_xor_differential_trail_model(34, fixed_variables=[plaintext, key])
     result = sat._solve_with_external_sat_solver(XOR_DIFFERENTIAL, PARKISSAT_EXT, ["-c=6"])
     speck_components = speck.get_all_components()
-    modadd_objects = list(filter(lambda obj: isinstance(obj, MODADD), speck_components))
+    modadd_objects = list(filter(lambda obj: isinstance(obj, ModAdd), speck_components))
     carry_list = compute_modadd_xor(modadd_objects, result["components_values"])
     computed_number_of_full_windows = count_sequences_of_ones(carry_list, window_size)
 

--- a/tests/unit/components/and_component_test.py
+++ b/tests/unit/components/and_component_test.py
@@ -1,4 +1,4 @@
-from claasp.components.and_component import AND
+from claasp.components.and_component import And
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.ciphers.single_component_ciphers.and_cipher import AndCipher
 from claasp.components.and_component import cp_xor_differential_probability_ddt, cp_xor_linear_probability_lat
@@ -14,7 +14,7 @@ def test_cp_xor_linear_probability_lat():
 
 
 def test_cp_constraints():
-    and_component = AND(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
+    and_component = And(0, 0, ['input1', 'input2'], [[0, 1], [0, 1]], 2)
     declarations, constraints = and_component.cp_constraints()
 
     assert declarations == []
@@ -27,7 +27,7 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
     class DummyModel:
         word_size = 8
 
-    and_component = AND(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
+    and_component = And(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                         [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                          [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]], 32)
     declarations, constraints = and_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
@@ -54,7 +54,7 @@ def test_cp_xor_linear_mask_propagation_constraints():
 
 
 def test_generic_sign_linear_constraints():
-    and_component = AND(0, 0, ['a', 'b'], [list(range(16)), list(range(16))], 16)
+    and_component = And(0, 0, ['a', 'b'], [list(range(16)), list(range(16))], 16)
     input_constraints = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     output = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
 

--- a/tests/unit/components/modmul_component_test.py
+++ b/tests/unit/components/modmul_component_test.py
@@ -1,7 +1,7 @@
-from claasp.components.modmul_component import MODMUL
+from claasp.components.modmul_component import ModMul
 
 def test_modmul_component_creation():
-    component = MODMUL(
+    component = ModMul(
         current_round_number=1,
         current_round_number_of_components=0,
         input_id_links=["input1", "input2"],

--- a/tests/unit/components/modsub_component_test.py
+++ b/tests/unit/components/modsub_component_test.py
@@ -1,13 +1,13 @@
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
 from claasp.cipher import Cipher
-from claasp.components.modsub_component import MODSUB
+from claasp.components.modsub_component import ModSub
 from claasp.name_mappings import PERMUTATION
 
 
 def test_algebraic_polynomials():
     cipher = Cipher("cipher_name", PERMUTATION, ["input"], [8], 8)
     cipher.add_round()
-    cipher.add_MODSUB_component(["input", "input"], [[0, 1, 2, 3], [4, 5, 6, 7]], 4)
+    cipher.add_modsub_component(["input", "input"], [[0, 1, 2, 3], [4, 5, 6, 7]], 4)
     modsub_component = cipher.get_component_from_id('modsub_0_0')
     algebraic = AlgebraicModel(cipher)
     algebraic_polynomials = modsub_component.algebraic_polynomials(algebraic)
@@ -24,7 +24,7 @@ def test_algebraic_polynomials():
 
 
 def test_cms_constraints():
-    modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
+    modsub_component = ModSub(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     output_bit_ids, constraints = modsub_component.cms_constraints()
 
     assert output_bit_ids[0] == 'temp_carry_plaintext_32'
@@ -37,7 +37,7 @@ def test_cms_constraints():
 
 
 def test_cp_constraints():
-    modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
+    modsub_component = ModSub(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     output_bit_ids, constraints = modsub_component.cp_constraints()
 
     assert output_bit_ids[0] == 'array[0..31] of var 0..1: constant_modsub_0_7= array1d(0..31,[0, 0, 0, 0, 0, 0, 0, ' \
@@ -59,7 +59,7 @@ def test_cp_xor_differential_propagation_constraints():
         component_and_probability = {}
         modadd_twoterms_mant = []
 
-    modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
+    modsub_component = ModSub(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     cp_model = DummyModel()
     output_bit_ids, constraints = modsub_component.cp_xor_differential_propagation_constraints(cp_model)
 
@@ -76,7 +76,7 @@ def test_cp_xor_differential_propagation_constraints():
 
 
 def test_sat_constraints():
-    modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
+    modsub_component = ModSub(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     output_bit_ids, constraints = modsub_component.sat_constraints()
 
     assert output_bit_ids[0] == 'temp_carry_plaintext_32'
@@ -88,7 +88,7 @@ def test_sat_constraints():
 
 
 def test_smt_constraints():
-    modsub_component = MODSUB(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
+    modsub_component = ModSub(0, 7, ['modadd_0_4', 'plaintext'], [list(range(32)), list(range(32, 64))], 32, 2 ** 32)
     output_bit_ids, constraints = modsub_component.smt_constraints()
 
     assert output_bit_ids[0] == 'temp_carry_plaintext_32'

--- a/tests/unit/components/not_component_test.py
+++ b/tests/unit/components/not_component_test.py
@@ -1,4 +1,4 @@
-from claasp.components.not_component import NOT
+from claasp.components.not_component import Not
 from claasp.cipher_modules.models.milp.milp_model import MilpModel
 from claasp.ciphers.single_component_ciphers.not_cipher import NotCipher
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
@@ -20,7 +20,7 @@ def test_algebraic_polynomials():
 
 
 def test_cms_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     output_bit_ids, constraints = not_component.cms_constraints()
 
     assert output_bit_ids[0] == 'not_0_8_0'
@@ -32,7 +32,7 @@ def test_cms_constraints():
 
 
 def test_cp_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     declarations, constraints = not_component.cp_constraints()
 
     assert declarations == []
@@ -42,7 +42,7 @@ def test_cp_constraints():
 
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     declarations, constraints = not_component.cp_deterministic_truncated_xor_differential_constraints()
 
     assert declarations == []
@@ -55,7 +55,7 @@ def test_cp_xor_differential_first_step_constraints():
     class DummyModel:
         word_size = 8
 
-    not_component = NOT(0, 18, ['plaintext', 'key', 'input3', 'input4'],
+    not_component = Not(0, 18, ['plaintext', 'key', 'input3', 'input4'],
                         [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                          [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]], 32)
     declarations, constraints = not_component.cp_xor_differential_first_step_constraints(DummyModel())
@@ -69,7 +69,7 @@ def test_cp_xor_differential_first_step_constraints():
 
 
 def test_cp_xor_differential_propagation_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     declarations, constraints = not_component.cp_xor_differential_propagation_constraints()
 
     assert declarations == []
@@ -79,7 +79,7 @@ def test_cp_xor_differential_propagation_constraints():
 
 
 def test_cp_xor_linear_mask_propagation_constraints():
-    not_component = NOT(0, 5, ['ascon_0_5_i'], [list(range(64))], 64)
+    not_component = Not(0, 5, ['ascon_0_5_i'], [list(range(64))], 64)
     declarations, constraints = not_component.cp_xor_linear_mask_propagation_constraints()
 
     assert declarations == ['array[0..63] of var 0..1:not_0_5_i;', 'array[0..63] of var 0..1:not_0_5_o;']
@@ -89,7 +89,7 @@ def test_cp_xor_linear_mask_propagation_constraints():
 
 
 def test_generic_sign_linear_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     inputs = [0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0]
 
     assert not_component.generic_sign_linear_constraints(inputs) == 1
@@ -150,7 +150,7 @@ def test_milp_xor_linear_mask_propagation_constraints():
 
 
 def test_sat_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     output_bit_ids, constraints = not_component.sat_constraints()
 
     assert output_bit_ids[0] == 'not_0_8_0'
@@ -163,7 +163,7 @@ def test_sat_constraints():
 
 
 def test_sat_bitwise_deterministic_truncated_xor_differential_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     output_bit_ids, constraints = not_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
 
     assert output_bit_ids[0] == 'not_0_8_0_0'
@@ -176,7 +176,7 @@ def test_sat_bitwise_deterministic_truncated_xor_differential_constraints():
 
 
 def test_sat_xor_differential_propagation_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     output_bit_ids, constraints = not_component.sat_xor_differential_propagation_constraints()
 
     assert output_bit_ids[0] == 'not_0_8_0'
@@ -189,7 +189,7 @@ def test_sat_xor_differential_propagation_constraints():
 
 
 def test_sat_xor_linear_mask_propagation_constraints():
-    not_component = NOT(0, 8, ['xor_0_6'], [list(range(32))], 32)
+    not_component = Not(0, 8, ['xor_0_6'], [list(range(32))], 32)
     output_bit_ids, constraints = not_component.sat_xor_linear_mask_propagation_constraints()
 
     assert output_bit_ids[0] == 'not_0_8_0_i'
@@ -202,7 +202,7 @@ def test_sat_xor_linear_mask_propagation_constraints():
 
 
 def test_smt_constraints():
-    not_component = NOT(0, 5, ['xor_0_2'], [list(range(64))], 64)
+    not_component = Not(0, 5, ['xor_0_2'], [list(range(64))], 64)
     output_bit_ids, constraints = not_component.smt_constraints()
 
     assert output_bit_ids[0] == 'not_0_5_0'
@@ -217,7 +217,7 @@ def test_smt_constraints():
 
 
 def test_smt_xor_differential_propagation_constraints():
-    not_component = NOT(0, 5, ['xor_0_2'], [list(range(64))], 64)
+    not_component = Not(0, 5, ['xor_0_2'], [list(range(64))], 64)
     output_bit_ids, constraints = not_component.smt_xor_differential_propagation_constraints()
 
     assert output_bit_ids[0] == 'not_0_5_0'
@@ -232,7 +232,7 @@ def test_smt_xor_differential_propagation_constraints():
 
 
 def test_smt_xor_linear_mask_propagation_constraints():
-    not_component = NOT(0, 5, ['not_0_5_i'], [list(range(64))], 64)
+    not_component = Not(0, 5, ['not_0_5_i'], [list(range(64))], 64)
     output_bit_ids, constraints = not_component.smt_xor_linear_mask_propagation_constraints()
 
     assert output_bit_ids[0] == 'not_0_5_0_i'

--- a/tests/unit/components/or_component_test.py
+++ b/tests/unit/components/or_component_test.py
@@ -1,4 +1,4 @@
-from claasp.components.or_component import OR
+from claasp.components.or_component import Or
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.ciphers.single_component_ciphers.or_cipher import OrCipher
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
@@ -17,7 +17,7 @@ def test_algebraic_polynomials():
 
 
 def test_cp_constraints():
-    or_component = OR(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
+    or_component = Or(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
     declarations, constraints = or_component.cp_constraints()
 
     assert declarations == ['array[0..3] of var 0..1: or_0_0;', 'array[0..3] of var 0..1:pre_or_0_0_0;',
@@ -44,7 +44,7 @@ def test_cp_xor_linear_mask_propagation_constraints():
 
 
 def test_generic_sign_linear_constraints():
-    or_component = OR(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
+    or_component = Or(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
     input_tert = [0, 0, 0, 0, 0, 0, 0, 0]
 
     assert or_component.generic_sign_linear_constraints(input_tert, [0, 0, 0, 0]) == 1
@@ -52,7 +52,7 @@ def test_generic_sign_linear_constraints():
 
 
 def test_sat_constraints():
-    or_component = OR(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
+    or_component = Or(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
     output_bit_ids, constraints = or_component.sat_constraints()
 
     assert output_bit_ids[0] == 'or_0_0_0'
@@ -65,7 +65,7 @@ def test_sat_constraints():
 
 
 def test_smt_constraints():
-    or_component = OR(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
+    or_component = Or(0, 0, ['plaintext', 'key'], [list(range(4)), list(range(4))], 4)
     output_bit_ids, constraints = or_component.smt_constraints()
 
     assert output_bit_ids[0] == 'or_0_0_0'

--- a/tests/unit/components/sbox_component_test.py
+++ b/tests/unit/components/sbox_component_test.py
@@ -11,7 +11,7 @@ from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import 
 from claasp.cipher_modules.models.sat.sat_model import SatModel
 from claasp.cipher_modules.models.smt.smt_model import SmtModel
 from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
-from claasp.components.sbox_component import SBOX
+from claasp.components.sbox_component import Sbox
 
 
 PRESENT_SBOX = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
@@ -28,7 +28,7 @@ def test_algebraic_polynomials():
 
 
 def test_cms_constraints():
-    sbox_component = SBOX(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
+    sbox_component = Sbox(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
     output_bit_ids, constraints = sbox_component.cms_constraints()
 
     assert output_bit_ids == ["sbox_0_2_0", "sbox_0_2_1", "sbox_0_2_2", "sbox_0_2_3"]
@@ -38,7 +38,7 @@ def test_cms_constraints():
 
 def test_cp_constraints():
     sbox = [12, 10, 13, 3, 14, 11, 15, 7, 8, 9, 1, 5, 0, 2, 4, 6]
-    sbox_component = SBOX(0, 5, ["xor_0_1"], [[4, 5, 6, 7]], 4, sbox)
+    sbox_component = Sbox(0, 5, ["xor_0_1"], [[4, 5, 6, 7]], 4, sbox)
     declarations, constraints = sbox_component.cp_constraints([])
 
     assert declarations[0].startswith("array [1..16, 1..8] of int: table_sbox_0_5")
@@ -49,7 +49,7 @@ def test_cp_constraints():
 
 
 def test_cp_deterministic_truncated_xor_differential_constraints():
-    sbox_component = SBOX(0, 1, ["xor_0_0"], [[0, 1, 2, 3]], 4, [1, 2, 3, 4, 0, 7, 6, 5])
+    sbox_component = Sbox(0, 1, ["xor_0_0"], [[0, 1, 2, 3]], 4, [1, 2, 3, 4, 0, 7, 6, 5])
     declarations, constraints, sbox_mant = sbox_component.cp_deterministic_truncated_xor_differential_constraints(
         sbox_mant=[]
     )
@@ -63,7 +63,7 @@ def test_cp_deterministic_truncated_xor_differential_constraints():
 
 
 def test_cp_xor_differential_propagation_constraints():
-    sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
+    sbox_component = Sbox(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
     cp = type("DummyModel", (), {})()
     cp.sbox_mant = []
     cp.component_and_probability = {}
@@ -79,7 +79,7 @@ def test_cp_xor_differential_propagation_constraints():
 
 
 def test_cp_xor_linear_mask_propagation_constraints():
-    sbox_component = SBOX(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
+    sbox_component = Sbox(0, 0, ["plaintext"], [[0, 1, 2]], 3, list(range(8)))
     cp = type("DummyModel", (), {})()
     cp.sbox_mant = []
     cp.component_and_probability = {}
@@ -176,7 +176,7 @@ def test_milp_xor_linear_mask_propagation_constraints():
 
 
 def test_sat_constraints():
-    sbox_component = SBOX(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
+    sbox_component = Sbox(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
     output_bit_ids, constraints = sbox_component.sat_constraints()
 
     assert output_bit_ids == ["sbox_0_2_0", "sbox_0_2_1", "sbox_0_2_2", "sbox_0_2_3"]
@@ -185,7 +185,7 @@ def test_sat_constraints():
 
 
 def test_sat_bitwise_deterministic_truncated_xor_differential_constraints():
-    sbox_component = SBOX(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
+    sbox_component = Sbox(0, 2, ["xor_0_0"], [[4, 5, 6, 7]], 4, PRESENT_SBOX)
     output_bit_ids, constraints = sbox_component.sat_bitwise_deterministic_truncated_xor_differential_constraints()
 
     assert output_bit_ids[0] == "sbox_0_2_0_0"
@@ -241,7 +241,7 @@ def test_sat_xor_linear_mask_propagation_constraints():
 
 
 def test_smt_constraints():
-    component = SBOX(0, 1, ["input"], [[0, 1]], 2, [1, 2, 3, 0])
+    component = Sbox(0, 1, ["input"], [[0, 1]], 2, [1, 2, 3, 0])
     output_bit_ids, constraints = component.smt_constraints()
 
     assert output_bit_ids == ["sbox_0_1_0", "sbox_0_1_1"]

--- a/tests/unit/components/shift_component_test.py
+++ b/tests/unit/components/shift_component_test.py
@@ -1,4 +1,4 @@
-from claasp.components.shift_component import SHIFT
+from claasp.components.shift_component import Shift
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.cipher_modules.models.milp.milp_model import MilpModel
@@ -10,7 +10,7 @@ from claasp.ciphers.single_component_ciphers.shift_cipher import ShiftCipher
 
 
 def make_shift_component(bit_size=32, parameter=4):
-    return SHIFT(0, 0, ['plaintext'], [list(range(bit_size))], bit_size, parameter)
+    return Shift(0, 0, ['plaintext'], [list(range(bit_size))], bit_size, parameter)
 
 
 def test_algebraic_polynomials():
@@ -55,7 +55,7 @@ def test_cp_wordwise_deterministic_truncated_xor_differential_constraints():
     class DummyModel:
         word_size = 8
 
-    shift_component = SHIFT(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
+    shift_component = Shift(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                             [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                              [0, 1, 2, 3, 4, 5, 6, 7]], 32, -8)
     declarations, constraints = shift_component.cp_wordwise_deterministic_truncated_xor_differential_constraints(DummyModel())
@@ -69,7 +69,7 @@ def test_cp_xor_differential_first_step_constraints():
     class DummyModel:
         word_size = 8
 
-    shift_component = SHIFT(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
+    shift_component = Shift(0, 18, ['sbox_0_2', 'sbox_0_6', 'sbox_0_10', 'sbox_0_14'],
                             [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                              [0, 1, 2, 3, 4, 5, 6, 7]], 32, -8)
     declarations, constraints = shift_component.cp_xor_differential_first_step_constraints(DummyModel())
@@ -206,7 +206,7 @@ def test_milp_wordwise_deterministic_truncated_xor_differential_constraints():
     cipher = ShiftCipher(bit_size=32, parameter=-8)
     milp = MilpWordwiseDeterministicTruncatedXorDifferentialModel(cipher)
     milp.init_model_in_sage_milp_class()
-    shift_component = SHIFT(0, 18, ['in0', 'in1', 'in2', 'in3'],
+    shift_component = Shift(0, 18, ['in0', 'in1', 'in2', 'in3'],
                             [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7],
                              [0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]], 32, -8)
     variables, constraints = shift_component.milp_wordwise_deterministic_truncated_xor_differential_constraints(milp)

--- a/tests/unit/components/xor_component_test.py
+++ b/tests/unit/components/xor_component_test.py
@@ -1,7 +1,7 @@
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
 from claasp.ciphers.single_component_ciphers.xor_cipher import XorCipher
 from claasp.cipher_modules.models.algebraic.algebraic_model import AlgebraicModel
-from claasp.components.xor_component import XOR, cp_build_truncated_table, generic_with_constant_sign_linear_constraints
+from claasp.components.xor_component import Xor, cp_build_truncated_table, generic_with_constant_sign_linear_constraints
 from claasp.cipher_modules.models.milp.milp_models.milp_bitwise_deterministic_truncated_xor_differential_model import \
     MilpBitwiseDeterministicTruncatedXorDifferentialModel
 from claasp.cipher_modules.models.milp.milp_models.milp_wordwise_deterministic_truncated_xor_differential_model import \
@@ -67,7 +67,7 @@ def test_cp_xor_differential_propagation_first_step_constraints():
 
 
 def test_smt_constraints():
-    component = XOR(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
+    component = Xor(0, 0, ['plaintext', 'key'], [list(range(2)), list(range(2))], 2)
     output_bit_ids, constraints = component.smt_constraints()
 
     assert output_bit_ids[0] == 'xor_0_0_0'

--- a/tests/unit/editor_test.py
+++ b/tests/unit/editor_test.py
@@ -97,10 +97,10 @@ def test_remove_rotations():
     assert ciphertext == ciphertext_no_rotations
 
 
-def test_add_FSR_component():
+def test_add_fsr_component():
     cipher = Cipher("cipher_name", "fsr", ["input"], [12], 12)
     cipher.add_round()
-    cipher.add_FSR_component(["input", "input"], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4, 5, 6]], 12,
+    cipher.add_fsr_component(["input", "input"], [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4, 5, 6]], 12,
                              [
                                  [
                                      [5, [[4], [5], [6, 7]]],  # Register_len:5,  feedback poly: x4 + x5 + x6*x7


### PR DESCRIPTION
## Summary

This PR removes the legacy uppercase component naming in the CLAASP Python API and aligns the codebase with the naming rules documented in `CONTRIBUTING.md`.

The change is intentionally breaking:
- component builder methods now use snake_case
- component classes now use CamelCase
- downstream cipher implementations, tests, and helper modules were updated accordingly
- the contributing guide was updated to reflect the new method naming rule

## Main changes

- Renamed component builder methods such as:
  - `add_AND_component` -> `add_and_component`
  - `add_XOR_component` -> `add_xor_component`
  - `add_FSR_component` -> `add_fsr_component`
  - `add_MODADD_component` -> `add_modadd_component`
  - `add_MODSUB_component` -> `add_modsub_component`
  - `add_MODMUL_component` -> `add_modmul_component`
  - `add_SBOX_component` -> `add_sbox_component`
  - `add_SHIFT_component` -> `add_shift_component`
  - `add_OR_component` -> `add_or_component`
  - `add_NOT_component` -> `add_not_component`

- Renamed component classes such as:
  - `AND` -> `And`
  - `OR` -> `Or`
  - `NOT` -> `Not`
  - `FSR` -> `Fsr`
  - `MODADD` -> `ModAdd`
  - `MODSUB` -> `ModSub`
  - `MODMUL` -> `ModMul`
  - `SBOX` -> `Sbox`
  - `SHIFT` -> `Shift`
  - `XOR` -> `Xor`

- Propagated the rename through:
  - editor and cipher wrapper APIs
  - component implementations
  - cipher definitions across block ciphers, permutations, stream ciphers, hash functions, MACs, and toy ciphers
  - inverse-cipher and model code
  - unit tests and doctest-style examples
  - documentation in `docs/CONTRIBUTING.md`

## Notes

- This is a clean break by design; no backward-compatibility aliases were added.
- Uppercase semantic operation descriptors such as `"XOR"` and `"MODADD"` were preserved where they are part of component descriptions rather than Python identifiers.

## Impact

Any downstream code importing uppercase component classes or calling uppercase-style builder methods will need to be updated to the new names.