### PR TITLE
  Add CP MiniZinc predicate registry and resolver

### DIFF
--- a/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
@@ -1,0 +1,259 @@
+# ****************************************************************************
+# Copyright 2023 Technology Innovation Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ****************************************************************************
+
+import re
+from dataclasses import dataclass
+
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_bct_predicates import get_bct_operations
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_continuous_predicates import get_continuous_operations
+from claasp.cipher_modules.models.cp.minizinc_utils.usefulfunctions import MINIZINC_USEFUL_FUNCTIONS
+from claasp.cipher_modules.models.milp.utils.mzn_predicates import get_word_operations as get_milp_word_operations
+from claasp.cipher_modules.models.sat.utils.mzn_predicates import get_word_operations as get_sat_word_operations
+
+
+CP_CORE = "cp_core"
+CONTINUOUS = "continuous"
+BCT = "bct"
+SAT_WORD_OPS = "sat_word_ops"
+MILP_WORD_OPS = "milp_word_ops"
+
+
+@dataclass(frozen=True)
+class MiniZincHelper:
+    name: str
+    body: str
+    dependencies: tuple[str, ...] = ()
+    required_includes: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = (CP_CORE,)
+
+
+_FUNCTION_DECLARATION_RE = re.compile(r"^\s*function\s+.*?:\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+_PREDICATE_DECLARATION_RE = re.compile(r"^\s*predicate\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def _strip_minizinc_strings(text):
+    return re.sub(r'"(?:\\.|[^"\\])*"', '""', text)
+
+
+def _strip_minizinc_comments(text):
+    return "\n".join(line.split("%", 1)[0] for line in text.splitlines())
+
+
+def _definition_name(line):
+    match = _FUNCTION_DECLARATION_RE.match(line) or _PREDICATE_DECLARATION_RE.match(line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _split_minizinc_definitions(block):
+    includes = []
+    prefix_lines = []
+    definitions = {}
+    current_name = None
+    current_lines = []
+
+    for line in block.strip().splitlines():
+        if line.strip().startswith("include "):
+            include = line.strip()
+            if include not in includes:
+                includes.append(include)
+            continue
+
+        name = _definition_name(line)
+        if name:
+            if current_name:
+                definitions.setdefault(current_name, []).append("\n".join(current_lines).strip())
+            elif current_lines:
+                prefix_lines.extend(current_lines)
+            current_name = name
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+
+    if current_name:
+        definitions.setdefault(current_name, []).append("\n".join(current_lines).strip())
+    elif current_lines:
+        prefix_lines.extend(current_lines)
+
+    prefix = "\n".join(prefix_lines).strip()
+    return includes, prefix, {name: "\n\n".join(bodies) for name, bodies in definitions.items()}
+
+
+def _helpers_from_block(block, context, dependencies=None, helper_includes=None, prefix_name=None):
+    required_includes, prefix, definitions = _split_minizinc_definitions(block)
+    helpers = {}
+
+    if prefix and prefix_name:
+        helpers[(context, prefix_name)] = MiniZincHelper(
+            name=prefix_name,
+            body=prefix,
+            required_includes=tuple(required_includes),
+            contexts=(context,),
+        )
+        required_includes = []
+
+    for name, body in definitions.items():
+        helper_dependencies = tuple((dependencies or {}).get(name, ()))
+        if prefix_name and name != prefix_name:
+            helper_dependencies = (prefix_name,) + helper_dependencies
+        helpers[(context, name)] = MiniZincHelper(
+            name=name,
+            body=body,
+            dependencies=helper_dependencies,
+            required_includes=tuple((helper_includes or {}).get(name, required_includes)),
+            contexts=(context,),
+        )
+        required_includes = []
+
+    return helpers
+
+
+CP_CORE_DEPENDENCIES = {
+    "modadd_linear": ("Xor3",),
+    "modular_addition_word": ("LShift", "xor_bit_p1"),
+    "counter_based_modadd_semideterministic": ("TRUNCATED_XOR",),
+}
+
+CONTINUOUS_DEPENDENCIES = {
+    "continuous_xor_bit": ("continuous_bounds",),
+    "continuous_xor": ("continuous_bounds", "continuous_xor_bit"),
+    "continuous_maj_bit": ("continuous_bounds",),
+    "continuous_modadd": ("continuous_bounds", "continuous_maj_bit", "continuous_xor_bit"),
+    "continuous_LRot": ("continuous_bounds",),
+    "continuous_RRot": ("continuous_bounds",),
+    "cast": ("continuous_bounds",),
+}
+
+SAT_WORD_OPS_DEPENDENCIES = {
+    "modular_addition_word": ("modular_addition_bit_level_sat", "n_window_heuristic_constraints"),
+    "xor_word": ("xor_bit",),
+}
+
+MILP_WORD_OPS_DEPENDENCIES = {
+    "modular_addition_word": ("modular_addition", "n_window_heuristic_constraints"),
+    "xor_word": ("xor_bit",),
+}
+
+BCT_DEPENDENCIES = {
+    "BVAssign": ("bct_constants",),
+    "onlyLargeSwitch_BCT_enum": ("BVAssign",),
+}
+
+
+def _build_registry():
+    helpers = {}
+    helpers.update(_helpers_from_block(MINIZINC_USEFUL_FUNCTIONS, CP_CORE, CP_CORE_DEPENDENCIES))
+    helpers.update(
+        _helpers_from_block(
+            get_continuous_operations(),
+            CONTINUOUS,
+            CONTINUOUS_DEPENDENCIES,
+            prefix_name="continuous_bounds",
+        )
+    )
+    helpers.update(_helpers_from_block(get_bct_operations(), BCT, BCT_DEPENDENCIES, prefix_name="bct_constants"))
+    helpers.update(_helpers_from_block(get_sat_word_operations(), SAT_WORD_OPS, SAT_WORD_OPS_DEPENDENCIES))
+    helpers.update(_helpers_from_block(get_milp_word_operations(), MILP_WORD_OPS, MILP_WORD_OPS_DEPENDENCIES))
+    return helpers
+
+
+HELPERS = _build_registry()
+
+
+def helpers_for_contexts(contexts=(CP_CORE,)):
+    selected_contexts = set(contexts)
+    return [helper for (context, _), helper in HELPERS.items() if context in selected_contexts]
+
+
+def collect_used_helpers(fragments, contexts=(CP_CORE,)):
+    text = "\n".join(fragment for fragment in fragments if fragment)
+    text = _strip_minizinc_comments(_strip_minizinc_strings(text))
+
+    used = set()
+    for helper in helpers_for_contexts(contexts):
+        pattern = rf"(?<![A-Za-z0-9_]){re.escape(helper.name)}(?=\s*\()"
+        if re.search(pattern, text):
+            used.add(helper.name)
+
+    return used
+
+
+def _helper_key(name, contexts):
+    matching_keys = [(context, helper_name) for context, helper_name in HELPERS if context in contexts and helper_name == name]
+    if not matching_keys:
+        raise ValueError(f"Unknown MiniZinc helper {name!r} for contexts {contexts!r}")
+    return matching_keys[0]
+
+
+def resolve_helper_closure(names, contexts=(CP_CORE,)):
+    ordered = []
+    visiting = set()
+    visited = set()
+    contexts = tuple(contexts)
+
+    def visit(name):
+        key = _helper_key(name, contexts)
+        if key in visited:
+            return
+        if key in visiting:
+            raise ValueError(f"Cyclic MiniZinc helper dependency involving {name!r}")
+
+        visiting.add(key)
+        helper = HELPERS[key]
+        for dependency in helper.dependencies:
+            visit(dependency)
+        visiting.remove(key)
+        visited.add(key)
+        ordered.append(key)
+
+    for name in sorted(names):
+        visit(name)
+
+    return ordered
+
+
+def render_helper_block(names, contexts=(CP_CORE,)):
+    ordered_keys = resolve_helper_closure(names, contexts)
+    includes = []
+    bodies = []
+
+    for key in ordered_keys:
+        helper = HELPERS[key]
+        for include in helper.required_includes:
+            if include not in includes:
+                includes.append(include)
+        body = helper.body.strip()
+        if body and body not in bodies:
+            bodies.append(body)
+
+    return "\n\n".join(includes + bodies)
+
+
+def render_context_helpers(contexts=(CP_CORE,)):
+    names = {helper.name for helper in helpers_for_contexts(contexts)}
+    return render_helper_block(names, contexts)
+
+
+def inject_helpers_into_declarations(declarations, constraints, contexts=(CP_CORE,), extra_fragments=None):
+    fragments = list(declarations) + list(constraints)
+    if extra_fragments:
+        fragments.extend(extra_fragments)
+    helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+    if helper_block:
+        return [helper_block] + list(declarations)
+    return declarations

--- a/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
@@ -55,7 +55,7 @@ class MiniZincHelper:
     model_contexts: tuple[str, ...] = (GENERIC_CP_UTILS,)
 
 
-_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_]\w*")
 
 
 def _strip_minizinc_strings(text):

--- a/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
@@ -25,11 +25,25 @@ from claasp.cipher_modules.models.milp.utils.mzn_predicates import get_word_oper
 from claasp.cipher_modules.models.sat.utils.mzn_predicates import get_word_operations as get_sat_word_operations
 
 
-CP_CORE = "cp_core"
-CONTINUOUS = "continuous"
-BCT = "bct"
-SAT_WORD_OPS = "sat_word_ops"
-MILP_WORD_OPS = "milp_word_ops"
+GENERIC_CP_UTILS = "generic_cp_utils"
+CIPHER_EVALUATION_CP = "cipher_evaluation_cp"
+XOR_DIFFERENTIAL_CP = "xor_differential_cp"
+XOR_LINEAR_CP = "xor_linear_cp"
+DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP = "deterministic_truncated_xor_differential_cp"
+SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP = "semi_deterministic_truncated_xor_differential_cp"
+CONTINUOUS_DIFFERENTIAL_LINEAR = "continuous_differential_linear"
+XOR_DIFFERENTIAL_ARX_SAT = "xor_differential_arx_sat"
+XOR_DIFFERENTIAL_ARX_MILP = "xor_differential_arx_milp"
+BOOMERANG_BCT_SAT = "boomerang_bct_sat"
+
+DEFAULT_CP_MODEL_CONTEXTS = (
+    GENERIC_CP_UTILS,
+    CIPHER_EVALUATION_CP,
+    XOR_DIFFERENTIAL_CP,
+    XOR_LINEAR_CP,
+    DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP,
+    SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP,
+)
 
 
 @dataclass(frozen=True)
@@ -38,7 +52,7 @@ class MiniZincHelper:
     body: str
     dependencies: tuple[str, ...] = ()
     required_includes: tuple[str, ...] = ()
-    contexts: tuple[str, ...] = (CP_CORE,)
+    model_contexts: tuple[str, ...] = (GENERIC_CP_UTILS,)
 
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*")
@@ -113,7 +127,7 @@ def _helpers_from_block(block, context, dependencies=None, helper_includes=None,
             name=prefix_name,
             body=prefix,
             required_includes=tuple(required_includes),
-            contexts=(context,),
+            model_contexts=(context,),
         )
         required_includes = []
 
@@ -126,20 +140,79 @@ def _helpers_from_block(block, context, dependencies=None, helper_includes=None,
             body=body,
             dependencies=helper_dependencies,
             required_includes=tuple((helper_includes or {}).get(name, required_includes)),
-            contexts=(context,),
+            model_contexts=(context,),
         )
         required_includes = []
 
     return helpers
 
 
-CP_CORE_DEPENDENCIES = {
+def _helpers_from_definitions(definitions, context, names, dependencies=None):
+    helpers = {}
+    for name in names:
+        helpers[(context, name)] = MiniZincHelper(
+            name=name,
+            body=definitions[name],
+            dependencies=tuple((dependencies or {}).get(name, ())),
+            model_contexts=(context,),
+        )
+    return helpers
+
+
+GENERIC_CP_UTILS_NAMES = {
+    "Xor2",
+    "Xor3",
+    "And",
+    "OR",
+    "Compl",
+    "LRot",
+    "RRot",
+    "LShift",
+    "RShift",
+    "bitArrayToInt",
+    "IntTobitArray",
+    "IntToBitLen",
+    "count_eq",
+    "Ham_weight",
+}
+
+CIPHER_EVALUATION_CP_NAMES = {
+    "modadd",
+}
+
+XOR_DIFFERENTIAL_CP_NAMES = {
+    "Andz",
+    "Eq",
+}
+
+XOR_LINEAR_CP_NAMES = {
+    "modadd_linear",
+}
+
+XOR_LINEAR_CP_DEPENDENCIES = {
     "modadd_linear": ("Xor3",),
+}
+
+DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_NAMES = {
+    "xor_bit_p1",
+    "modular_addition_word",
+    "TRUNCATED_XOR",
+}
+
+DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_DEPENDENCIES = {
     "modular_addition_word": ("LShift", "xor_bit_p1"),
+}
+
+SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_NAMES = {
+    "TRUNCATED_XOR",
+    "counter_based_modadd_semideterministic",
+}
+
+SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_DEPENDENCIES = {
     "counter_based_modadd_semideterministic": ("TRUNCATED_XOR",),
 }
 
-CONTINUOUS_DEPENDENCIES = {
+CONTINUOUS_DIFFERENTIAL_LINEAR_DEPENDENCIES = {
     "continuous_xor_bit": ("continuous_bounds",),
     "continuous_xor": ("continuous_bounds", "continuous_xor_bit"),
     "continuous_maj_bit": ("continuous_bounds",),
@@ -149,17 +222,17 @@ CONTINUOUS_DEPENDENCIES = {
     "cast": ("continuous_bounds",),
 }
 
-SAT_WORD_OPS_DEPENDENCIES = {
+XOR_DIFFERENTIAL_ARX_SAT_DEPENDENCIES = {
     "modular_addition_word": ("modular_addition_bit_level_sat", "n_window_heuristic_constraints"),
     "xor_word": ("xor_bit",),
 }
 
-MILP_WORD_OPS_DEPENDENCIES = {
+XOR_DIFFERENTIAL_ARX_MILP_DEPENDENCIES = {
     "modular_addition_word": ("modular_addition", "n_window_heuristic_constraints"),
     "xor_word": ("xor_bit",),
 }
 
-BCT_DEPENDENCIES = {
+BOOMERANG_BCT_SAT_DEPENDENCIES = {
     "BVAssign": ("bct_constants",),
     "onlyLargeSwitch_BCT_enum": ("BVAssign",),
 }
@@ -167,35 +240,69 @@ BCT_DEPENDENCIES = {
 
 def _build_registry():
     helpers = {}
-    helpers.update(_helpers_from_block(MINIZINC_USEFUL_FUNCTIONS, CP_CORE, CP_CORE_DEPENDENCIES))
+    _, _, core_definitions = _split_minizinc_definitions(MINIZINC_USEFUL_FUNCTIONS)
+    helpers.update(_helpers_from_definitions(core_definitions, GENERIC_CP_UTILS, GENERIC_CP_UTILS_NAMES))
+    helpers.update(
+        _helpers_from_definitions(core_definitions, CIPHER_EVALUATION_CP, CIPHER_EVALUATION_CP_NAMES)
+    )
+    helpers.update(_helpers_from_definitions(core_definitions, XOR_DIFFERENTIAL_CP, XOR_DIFFERENTIAL_CP_NAMES))
+    helpers.update(
+        _helpers_from_definitions(core_definitions, XOR_LINEAR_CP, XOR_LINEAR_CP_NAMES, XOR_LINEAR_CP_DEPENDENCIES)
+    )
+    helpers.update(
+        _helpers_from_definitions(
+            core_definitions,
+            DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP,
+            DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_NAMES,
+            DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_DEPENDENCIES,
+        )
+    )
+    helpers.update(
+        _helpers_from_definitions(
+            core_definitions,
+            SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP,
+            SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_NAMES,
+            SEMI_DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP_DEPENDENCIES,
+        )
+    )
     helpers.update(
         _helpers_from_block(
             get_continuous_operations(),
-            CONTINUOUS,
-            CONTINUOUS_DEPENDENCIES,
+            CONTINUOUS_DIFFERENTIAL_LINEAR,
+            CONTINUOUS_DIFFERENTIAL_LINEAR_DEPENDENCIES,
             prefix_name="continuous_bounds",
         )
     )
-    helpers.update(_helpers_from_block(get_bct_operations(), BCT, BCT_DEPENDENCIES, prefix_name="bct_constants"))
-    helpers.update(_helpers_from_block(get_sat_word_operations(), SAT_WORD_OPS, SAT_WORD_OPS_DEPENDENCIES))
-    helpers.update(_helpers_from_block(get_milp_word_operations(), MILP_WORD_OPS, MILP_WORD_OPS_DEPENDENCIES))
+    helpers.update(
+        _helpers_from_block(
+            get_bct_operations(),
+            BOOMERANG_BCT_SAT,
+            BOOMERANG_BCT_SAT_DEPENDENCIES,
+            prefix_name="bct_constants",
+        )
+    )
+    helpers.update(_helpers_from_block(get_sat_word_operations(), XOR_DIFFERENTIAL_ARX_SAT, XOR_DIFFERENTIAL_ARX_SAT_DEPENDENCIES))
+    helpers.update(_helpers_from_block(get_sat_word_operations(), BOOMERANG_BCT_SAT, XOR_DIFFERENTIAL_ARX_SAT_DEPENDENCIES))
+    helpers.update(
+        _helpers_from_block(get_milp_word_operations(), XOR_DIFFERENTIAL_ARX_MILP, XOR_DIFFERENTIAL_ARX_MILP_DEPENDENCIES)
+    )
     return helpers
 
 
 HELPERS = _build_registry()
 
 
-def helpers_for_contexts(contexts=(CP_CORE,)):
-    selected_contexts = set(contexts)
+def helpers_for_model_contexts(model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
+    selected_contexts = set(model_contexts)
     return [helper for (context, _), helper in HELPERS.items() if context in selected_contexts]
 
 
-def collect_used_helpers(fragments, contexts=(CP_CORE,)):
+def collect_used_helpers(fragments, model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
     text = "\n".join(fragment for fragment in fragments if fragment)
     text = _strip_minizinc_comments(_strip_minizinc_strings(text))
 
     used = set()
-    for helper in helpers_for_contexts(contexts):
+    for helper in helpers_for_model_contexts(model_contexts):
         pattern = rf"(?<![A-Za-z0-9_]){re.escape(helper.name)}(?=\s*\()"
         if re.search(pattern, text):
             used.add(helper.name)
@@ -203,21 +310,21 @@ def collect_used_helpers(fragments, contexts=(CP_CORE,)):
     return used
 
 
-def _helper_key(name, contexts):
-    matching_keys = [(context, helper_name) for context, helper_name in HELPERS if context in contexts and helper_name == name]
+def _helper_key(name, model_contexts):
+    matching_keys = [(context, helper_name) for context, helper_name in HELPERS if context in model_contexts and helper_name == name]
     if not matching_keys:
-        raise ValueError(f"Unknown MiniZinc helper {name!r} for contexts {contexts!r}")
+        raise ValueError(f"Unknown MiniZinc helper {name!r} for model contexts {model_contexts!r}")
     return matching_keys[0]
 
 
-def resolve_helper_closure(names, contexts=(CP_CORE,)):
+def resolve_helper_closure(names, model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
     ordered = []
     visiting = set()
     visited = set()
-    contexts = tuple(contexts)
+    model_contexts = tuple(model_contexts)
 
     def visit(name):
-        key = _helper_key(name, contexts)
+        key = _helper_key(name, model_contexts)
         if key in visited:
             return
         if key in visiting:
@@ -237,8 +344,8 @@ def resolve_helper_closure(names, contexts=(CP_CORE,)):
     return ordered
 
 
-def render_helper_block(names, contexts=(CP_CORE,)):
-    ordered_keys = resolve_helper_closure(names, contexts)
+def render_helper_block(names, model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
+    ordered_keys = resolve_helper_closure(names, model_contexts)
     includes = []
     bodies = []
 
@@ -254,16 +361,16 @@ def render_helper_block(names, contexts=(CP_CORE,)):
     return "\n\n".join(includes + bodies)
 
 
-def render_context_helpers(contexts=(CP_CORE,)):
-    names = {helper.name for helper in helpers_for_contexts(contexts)}
-    return render_helper_block(names, contexts)
+def render_model_context_helpers(model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
+    names = {helper.name for helper in helpers_for_model_contexts(model_contexts)}
+    return render_helper_block(names, model_contexts)
 
 
-def inject_helpers_into_declarations(declarations, constraints, contexts=(CP_CORE,), extra_fragments=None):
+def inject_helpers_into_declarations(declarations, constraints, model_contexts=DEFAULT_CP_MODEL_CONTEXTS, extra_fragments=None):
     fragments = list(declarations) + list(constraints)
     if extra_fragments:
         fragments.extend(extra_fragments)
-    helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+    helper_block = render_helper_block(collect_used_helpers(fragments, model_contexts), model_contexts)
     if helper_block:
         return [helper_block] + list(declarations)
     return declarations

--- a/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/predicate_registry.py
@@ -41,8 +41,7 @@ class MiniZincHelper:
     contexts: tuple[str, ...] = (CP_CORE,)
 
 
-_FUNCTION_DECLARATION_RE = re.compile(r"^\s*function\s+.*?:\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(")
-_PREDICATE_DECLARATION_RE = re.compile(r"^\s*predicate\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*")
 
 
 def _strip_minizinc_strings(text):
@@ -54,9 +53,20 @@ def _strip_minizinc_comments(text):
 
 
 def _definition_name(line):
-    match = _FUNCTION_DECLARATION_RE.match(line) or _PREDICATE_DECLARATION_RE.match(line)
-    if match:
-        return match.group(1)
+    stripped = line.lstrip()
+    if stripped.startswith("function "):
+        _, separator, suffix = stripped.partition(":")
+        if not separator:
+            return None
+        stripped = suffix.lstrip()
+    elif stripped.startswith("predicate "):
+        stripped = stripped[len("predicate ") :].lstrip()
+    else:
+        return None
+
+    match = _IDENTIFIER_RE.match(stripped)
+    if match and stripped[match.end() :].lstrip().startswith("("):
+        return match.group(0)
     return None
 
 

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -28,7 +28,7 @@ from sage.crypto.sbox import SBox
 
 from claasp.cipher_modules.component_analysis_tests import branch_number
 from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import (
-    CP_CORE,
+    DEFAULT_CP_MODEL_CONTEXTS,
     collect_used_helpers,
     render_helper_block,
 )
@@ -111,7 +111,7 @@ class MznModel:
         self._model_prefix = ['include "globals.mzn";']
         self._helper_block = None
 
-    def finalize_model(self, contexts=(CP_CORE,), include_predicates=True, extra_fragments=None):
+    def finalize_model(self, model_contexts=DEFAULT_CP_MODEL_CONTEXTS, include_predicates=True, extra_fragments=None):
         if not include_predicates:
             self._helper_block = ""
             return
@@ -125,7 +125,7 @@ class MznModel:
         if extra_fragments:
             fragments.extend(extra_fragments)
 
-        helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+        helper_block = render_helper_block(collect_used_helpers(fragments, model_contexts), model_contexts)
         if not helper_block:
             helper_block = "% No MiniZinc helpers required"
         self._helper_block = helper_block
@@ -135,7 +135,7 @@ class MznModel:
                 insert_at += 1
             self._model_prefix.insert(insert_at, helper_block)
 
-    def _ensure_model_constraints_have_helpers(self, contexts=(CP_CORE,)):
+    def _ensure_model_constraints_have_helpers(self, model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
         if self._helper_block is None:
             fragments = (
                 self._variables_list
@@ -143,7 +143,7 @@ class MznModel:
                 + self.mzn_output_directives
                 + self.mzn_carries_output_directives
             )
-            helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+            helper_block = render_helper_block(collect_used_helpers(fragments, model_contexts), model_contexts)
             self._helper_block = helper_block
         else:
             helper_block = self._helper_block

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -110,15 +110,30 @@ class MznModel:
         self.component_probability_var = {}
         self._model_prefix = ['include "globals.mzn";']
         self._helper_block = None
+        self._helper_model_contexts = None
+        self._known_model_prefix_entries = set(self._model_prefix)
 
     def finalize_model(self, model_contexts=DEFAULT_CP_MODEL_CONTEXTS, include_predicates=True, extra_fragments=None):
+        old_prefix = list(self._model_prefix)
+        old_helper_block = self._helper_block
+        self._known_model_prefix_entries.update(old_prefix)
+        if old_helper_block:
+            self._known_model_prefix_entries.add(old_helper_block)
+
+        if self._helper_block and self._helper_block in self._model_prefix:
+            self._model_prefix.remove(self._helper_block)
+
         if not include_predicates:
             self._helper_block = ""
+            self._helper_model_contexts = tuple(model_contexts)
+            self._known_model_prefix_entries.update(self._model_prefix)
             return
 
+        variables = self._strip_leading_known_prefix_entries(self._variables_list)
+        constraints = self._strip_leading_known_prefix_entries(self._model_constraints)
         fragments = (
-            self._variables_list
-            + self._model_constraints
+            variables
+            + constraints
             + self.mzn_output_directives
             + self.mzn_carries_output_directives
         )
@@ -129,32 +144,36 @@ class MznModel:
         if not helper_block:
             helper_block = "% No MiniZinc helpers required"
         self._helper_block = helper_block
+        self._helper_model_contexts = tuple(model_contexts)
         if helper_block and helper_block not in self._model_prefix:
             insert_at = 0
             while insert_at < len(self._model_prefix) and self._model_prefix[insert_at].startswith("include "):
                 insert_at += 1
             self._model_prefix.insert(insert_at, helper_block)
+        self._known_model_prefix_entries.update(self._model_prefix)
 
     def _ensure_model_constraints_have_helpers(self, model_contexts=DEFAULT_CP_MODEL_CONTEXTS):
-        if self._helper_block is None:
-            fragments = (
-                self._variables_list
-                + self._model_constraints
-                + self.mzn_output_directives
-                + self.mzn_carries_output_directives
-            )
-            helper_block = render_helper_block(collect_used_helpers(fragments, model_contexts), model_contexts)
-            self._helper_block = helper_block
-        else:
-            helper_block = self._helper_block
+        self.finalize_model(model_contexts=self._helper_model_contexts or model_contexts)
 
-        if not helper_block:
-            return
-        if helper_block in self._model_constraints or helper_block in self._variables_list:
-            return
+    def _strip_leading_known_prefix_entries(self, lines):
+        stripped = list(lines)
+        while stripped and stripped[0] in self._known_model_prefix_entries:
+            stripped.pop(0)
+        return stripped
 
-        insert_at = 1 if self._model_constraints and self._model_constraints[0] == 'include "globals.mzn";' else 0
-        self._model_constraints.insert(insert_at, helper_block)
+    def _assembled_model_lines(self):
+        prefix = list(self._model_prefix)
+        variables = self._strip_leading_known_prefix_entries(self._variables_list)
+        constraints = self._strip_leading_known_prefix_entries(self._model_constraints)
+
+        return (
+            self.mzn_comments
+            + prefix
+            + variables
+            + constraints
+            + self.mzn_output_directives
+            + self.mzn_carries_output_directives
+        )
 
     def add_comment(self, comment):
         """
@@ -864,7 +883,7 @@ class MznModel:
             truncated = True
         
         self._ensure_model_constraints_have_helpers()
-        mzn_model = self._variables_list + self._model_constraints
+        mzn_model = self._assembled_model_lines()
 
         solutions = []
         if solve_external:
@@ -1024,9 +1043,7 @@ class MznModel:
             1
         """
         self._ensure_model_constraints_have_helpers()
-        constraints = self._model_constraints
-        variables = self._variables_list
-        mzn_model_string = "\n".join(constraints) + "\n".join(variables)
+        mzn_model_string = "\n".join(self._assembled_model_lines())
         solver_name_mzn = Solver.lookup(solver_name)
         bit_mzn_model = Model()
         bit_mzn_model.add_string(mzn_model_string)
@@ -1129,20 +1146,14 @@ class MznModel:
         - ``file_path`` -- **string**; the path of the file that will contain the model
         - ``prefix`` -- **str** (default: ``)
         """
-        model_string = (
-            "\n".join(self.mzn_comments)
-            + "\n".join(self._variables_list)
-            + "\n".join(self._model_constraints)
-            + "\n".join(self.mzn_output_directives)
-            + "\n".join(self.mzn_carries_output_directives)
-        )
         if prefix == "":
             filename = f"{file_path}/{self.cipher_id}_mzn_{self.sat_or_milp}.mzn"
         else:
             filename = f"{file_path}/{prefix}_{self.cipher_id}_mzn_{self.sat_or_milp}.mzn"
 
         with open(filename, "w") as file:
-            file.write(model_string)
+            self._ensure_model_constraints_have_helpers()
+            file.write("\n".join(self._assembled_model_lines()))
 
     @property
     def cipher(self):

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -27,7 +27,11 @@ from minizinc import Instance, Model, Solver, Status
 from sage.crypto.sbox import SBox
 
 from claasp.cipher_modules.component_analysis_tests import branch_number
-from claasp.cipher_modules.models.cp.minizinc_utils import usefulfunctions
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import (
+    CP_CORE,
+    collect_used_helpers,
+    render_helper_block,
+)
 from claasp.cipher_modules.models.cp.solvers import CP_SOLVERS_INTERNAL, CP_SOLVERS_EXTERNAL, SOLVER_DEFAULT
 from claasp.name_mappings import (
     SBOX,
@@ -104,7 +108,53 @@ class MznModel:
         self.probability_vars = []
         self.probability_modadd_vars_per_round = [[] for _ in range(self._cipher.number_of_rounds)]
         self.component_probability_var = {}
-        self._model_prefix = ['include "globals.mzn";', f"{usefulfunctions.MINIZINC_USEFUL_FUNCTIONS}"]
+        self._model_prefix = ['include "globals.mzn";']
+        self._helper_block = None
+
+    def finalize_model(self, contexts=(CP_CORE,), include_predicates=True, extra_fragments=None):
+        if not include_predicates:
+            self._helper_block = ""
+            return
+
+        fragments = (
+            self._variables_list
+            + self._model_constraints
+            + self.mzn_output_directives
+            + self.mzn_carries_output_directives
+        )
+        if extra_fragments:
+            fragments.extend(extra_fragments)
+
+        helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+        if not helper_block:
+            helper_block = "% No MiniZinc helpers required"
+        self._helper_block = helper_block
+        if helper_block and helper_block not in self._model_prefix:
+            insert_at = 0
+            while insert_at < len(self._model_prefix) and self._model_prefix[insert_at].startswith("include "):
+                insert_at += 1
+            self._model_prefix.insert(insert_at, helper_block)
+
+    def _ensure_model_constraints_have_helpers(self, contexts=(CP_CORE,)):
+        if self._helper_block is None:
+            fragments = (
+                self._variables_list
+                + self._model_constraints
+                + self.mzn_output_directives
+                + self.mzn_carries_output_directives
+            )
+            helper_block = render_helper_block(collect_used_helpers(fragments, contexts), contexts)
+            self._helper_block = helper_block
+        else:
+            helper_block = self._helper_block
+
+        if not helper_block:
+            return
+        if helper_block in self._model_constraints or helper_block in self._variables_list:
+            return
+
+        insert_at = 1 if self._model_constraints and self._model_constraints[0] == 'include "globals.mzn";' else 0
+        self._model_constraints.insert(insert_at, helper_block)
 
     def add_comment(self, comment):
         """
@@ -813,6 +863,7 @@ class MznModel:
         ):
             truncated = True
         
+        self._ensure_model_constraints_have_helpers()
         mzn_model = self._variables_list + self._model_constraints
 
         solutions = []
@@ -972,6 +1023,7 @@ class MznModel:
             sage: result.statistics['nSolutions']
             1
         """
+        self._ensure_model_constraints_have_helpers()
         constraints = self._model_constraints
         variables = self._variables_list
         mzn_model_string = "\n".join(constraints) + "\n".join(variables)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from minizinc import Status
 
 from claasp.cipher_modules.graph_generator import split_cipher_graph_into_top_bottom
-from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import BCT, SAT_WORD_OPS
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import BOOMERANG_BCT_SAT
 from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model_arx_optimized import (
     MznXorDifferentialModelARXOptimized,
 )
@@ -194,7 +194,7 @@ class MznBoomerangModelARXOptimized(MznXorDifferentialModelARXOptimized):
             self.differential_model_top_cipher.get_model_constraints()
             + self.differential_model_bottom_cipher.get_model_constraints()
         )
-        self.finalize_model(contexts=(SAT_WORD_OPS, BCT))
+        self.finalize_model(model_contexts=(BOOMERANG_BCT_SAT,))
         self._model_constraints = self._model_prefix + self._model_constraints
         top_cipher_probability_vars = self.differential_model_top_cipher.probability_vars
         bottom_cipher_probability_vars = self.differential_model_bottom_cipher.probability_vars

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from minizinc import Status
 
 from claasp.cipher_modules.graph_generator import split_cipher_graph_into_top_bottom
-from claasp.cipher_modules.models.cp.minizinc_utils.mzn_bct_predicates import get_bct_operations
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import BCT, SAT_WORD_OPS
 from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model_arx_optimized import (
     MznXorDifferentialModelARXOptimized,
 )
@@ -187,11 +187,6 @@ class MznBoomerangModelARXOptimized(MznXorDifferentialModelARXOptimized):
         self.differential_model_top_cipher.extend_model_constraints(
             self.differential_model_top_cipher.weight_constraints(max_weight=None, weight=None, operator=">=")
         )
-        from claasp.cipher_modules.models.sat.utils.mzn_predicates import get_word_operations
-
-        self._model_constraints.extend([get_word_operations()])
-        self._model_constraints.extend([get_bct_operations()])
-
         self._variables_list.extend(
             self.differential_model_top_cipher.get_variables() + self.differential_model_bottom_cipher.get_variables()
         )
@@ -199,6 +194,8 @@ class MznBoomerangModelARXOptimized(MznXorDifferentialModelARXOptimized):
             self.differential_model_top_cipher.get_model_constraints()
             + self.differential_model_bottom_cipher.get_model_constraints()
         )
+        self.finalize_model(contexts=(SAT_WORD_OPS, BCT))
+        self._model_constraints = self._model_prefix + self._model_constraints
         top_cipher_probability_vars = self.differential_model_top_cipher.probability_vars
         bottom_cipher_probability_vars = self.differential_model_bottom_cipher.probability_vars
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -82,6 +82,7 @@ class MznCipherModel(MznModel):
         self._model_constraints.extend(self.final_constraints())
 
         if not second:
+            self.finalize_model()
             self._model_constraints = self._model_prefix + self._model_constraints
 
     def find_missing_bits(self, fixed_values=[], solver_name=SOLVER_DEFAULT, solver_external=True):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
@@ -64,3 +64,6 @@ class MznCipherModelARXOptimized(MznModel):
 
             self._model_constraints.extend(constraints)
             self._variables_list.extend(variables)
+
+        self.finalize_model()
+        self._model_constraints = self._model_prefix + self._model_constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -130,6 +130,8 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
                 self.final_wordwise_deterministic_truncated_xor_differential_constraints(minimize)
             )
 
+        self._model_constraints = deterministic_truncated_xor_differential
+        self.finalize_model()
         self._model_constraints = self._model_prefix + deterministic_truncated_xor_differential
 
     def final_deterministic_truncated_xor_differential_constraints(self, minimize=False):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
@@ -65,3 +65,6 @@ class MznDeterministicTruncatedXorDifferentialModelARXOptimized(MznModel):
 
             self._variables_list.extend(variables)
             self._model_constraints.extend(constraints)
+
+        self.finalize_model()
+        self._model_constraints = self._model_prefix + self._model_constraints

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
@@ -3,7 +3,7 @@ import math
 import time
 from minizinc import Instance, Model, Solver, Status
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
-from claasp.cipher_modules.models.cp.minizinc_utils.mzn_continuous_predicates import get_continuous_operations
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import CONTINUOUS
 from claasp.name_mappings import CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, WORD_OPERATION
 
 class MznDifferentialLinearContinuousModel(MznModel):
@@ -68,8 +68,9 @@ class MznDifferentialLinearContinuousModel(MznModel):
         self.init_input_declarations()
 
         self._model_constraints.extend(self.connect_components())
-        self._variables_list.insert(0, get_continuous_operations())
         self.add_linear_mask_variables()
+        self.finalize_model(contexts=(CONTINUOUS,))
+        self._variables_list = self._model_prefix + self._variables_list
         
     def add_linear_mask_variables(self):
         block_size = self._cipher.output_bit_size

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
@@ -3,7 +3,7 @@ import math
 import time
 from minizinc import Instance, Model, Solver, Status
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
-from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import CONTINUOUS
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import CONTINUOUS_DIFFERENTIAL_LINEAR
 from claasp.name_mappings import CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, WORD_OPERATION
 
 class MznDifferentialLinearContinuousModel(MznModel):
@@ -69,7 +69,7 @@ class MznDifferentialLinearContinuousModel(MznModel):
 
         self._model_constraints.extend(self.connect_components())
         self.add_linear_mask_variables()
-        self.finalize_model(contexts=(CONTINUOUS,))
+        self.finalize_model(model_contexts=(CONTINUOUS_DIFFERENTIAL_LINEAR,))
         self._variables_list = self._model_prefix + self._variables_list
         
     def add_linear_mask_variables(self):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_model.py
@@ -596,6 +596,7 @@ class MznDifferentialLinearModel(MznModel):
         self._model_constraints.extend(weight_constraints)
         self._model_constraints.extend(self._build_output_block(weight))
 
+        self.finalize_model()
         self._model_constraints = self._model_prefix + self._model_constraints
 
     def find_one_differential_linear_trail_with_fixed_weight(

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -165,9 +165,10 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
         )
         set_of_constraints = deterministic_truncated_xor_differential
 
-        self._model_constraints = self._model_prefix + self.clean_constraints(
-            set_of_constraints, initial_round, middle_round, final_round
-        )
+        cleaned_constraints = self.clean_constraints(set_of_constraints, initial_round, middle_round, final_round)
+        self._model_constraints = cleaned_constraints
+        self.finalize_model()
+        self._model_constraints = self._model_prefix + cleaned_constraints
 
     def build_improbable_forward_model(self, forward_components, clean=False):
         direct_variables = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
@@ -199,6 +199,9 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
                 cleaned_variables.append(variable)
         self._variables_list = cleaned_variables
         
+        self._model_constraints = set_of_constraints
+        self.finalize_model()
+
         cleaned_constraints = []
         for constraint in self._model_prefix + set_of_constraints:
             if constraint not in cleaned_constraints:
@@ -287,9 +290,10 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
         )
         set_of_constraints = deterministic_truncated_xor_differential
 
-        self._model_constraints = self._model_prefix + self.clean_constraints(
-            set_of_constraints, initial_round, middle_round, final_round, fully_automatic
-        )
+        cleaned_constraints = self.clean_constraints(set_of_constraints, initial_round, middle_round, final_round, fully_automatic)
+        self._model_constraints = cleaned_constraints
+        self.finalize_model()
+        self._model_constraints = self._model_prefix + cleaned_constraints
 
     def clean_constraints(self, set_of_constraints, initial_round, middle_round, final_round, fully_automatic=False):
         number_of_rounds = self._cipher.number_of_rounds

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model.py
@@ -126,6 +126,7 @@ class MznSemiDeterministicTruncatedXorDifferentialModel(MznModel):
         self._model_constraints.append(weight_constraint)
         self.output_probability_per_round()
         self._model_constraints.extend(self._build_final_output_block(minimize))
+        self.finalize_model()
         self._model_constraints = self._model_prefix + self._model_constraints
 
     def _build_final_output_block(self, minimize):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -138,6 +138,7 @@ class MznXorDifferentialModel(MznModel):
         self._model_prefix.extend(variables)
         self._variables_list.extend(constraints)
         self._model_constraints.extend(self.final_xor_differential_constraints(weight, milp_modadd))
+        self.finalize_model()
         self._model_constraints = self._model_prefix + self._model_constraints
 
     def build_xor_differential_trail_model_template(self, weight, fixed_variables, milp_modadd=False):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 from minizinc import Status
 
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
-from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import MILP_WORD_OPS, SAT_WORD_OPS
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import XOR_DIFFERENTIAL_ARX_MILP, XOR_DIFFERENTIAL_ARX_SAT
 from claasp.name_mappings import CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, WORD_OPERATION
 
 
@@ -565,8 +565,8 @@ class MznXorDifferentialModelARXOptimized(MznModel):
         )
         self._model_constraints.extend(output_string_for_cipher_inputs)
         if self.include_word_operations_mzn_file:
-            context = SAT_WORD_OPS if self.sat_or_milp == "sat" else MILP_WORD_OPS
-            self.finalize_model(contexts=(context,))
+            context = XOR_DIFFERENTIAL_ARX_SAT if self.sat_or_milp == "sat" else XOR_DIFFERENTIAL_ARX_MILP
+            self.finalize_model(model_contexts=(context,))
             self._model_constraints = self._model_prefix + self._model_constraints
 
     def get_probability_vars_from_permutation(self):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from minizinc import Status
 
 from claasp.cipher_modules.models.cp.mzn_model import MznModel
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import MILP_WORD_OPS, SAT_WORD_OPS
 from claasp.name_mappings import CONSTANT, INTERMEDIATE_OUTPUT, CIPHER_OUTPUT, WORD_OPERATION
 
 
@@ -559,17 +560,14 @@ class MznXorDifferentialModelARXOptimized(MznModel):
                 self._variables_list.extend([f"var {self.data_type}: {var_names_inputs[ii]};"])
 
         self._model_constraints.extend(self.connect_rounds())
-        if self.sat_or_milp == "sat":
-            from claasp.cipher_modules.models.sat.utils.mzn_predicates import get_word_operations
-        else:
-            from claasp.cipher_modules.models.milp.utils.mzn_predicates import get_word_operations
-
-        if self.include_word_operations_mzn_file:
-            self._model_constraints.extend([get_word_operations()])
         self._model_constraints.extend(
             [f'output [ "{self.cipher_id}, and window_size={self.window_size_list}" ++ "\\n"];']
         )
         self._model_constraints.extend(output_string_for_cipher_inputs)
+        if self.include_word_operations_mzn_file:
+            context = SAT_WORD_OPS if self.sat_or_milp == "sat" else MILP_WORD_OPS
+            self.finalize_model(contexts=(context,))
+            self._model_constraints = self._model_prefix + self._model_constraints
 
     def get_probability_vars_from_permutation(self):
         cipher_copy = deepcopy(self.cipher)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -159,6 +159,8 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
             self._variables_list.extend(variables)
             self._first_step.append(constraints)
         self._first_step.extend(self.final_xor_differential_first_step_constraints(weight))
+        self._model_constraints = self._first_step
+        self.finalize_model()
         self._first_step = self._model_prefix + self._variables_list + self._first_step
 
     def create_xor_component(self, component1, component2, nmax):

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -78,6 +78,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
         self._model_prefix.extend(variables)
         self._variables_list.append(constraints)
         self._model_constraints.extend(self.final_xor_differential_constraints(weight))
+        self.finalize_model()
         self._model_constraints = self._model_prefix + self._model_constraints
 
     def find_all_xor_differential_trails_with_fixed_weight(

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -181,6 +181,7 @@ class MznXorLinearModel(MznModel):
         self._model_prefix.extend(variables)
         self._variables_list.extend(constraints)
         self._model_constraints.extend(self.final_xor_linear_constraints(weight))
+        self.finalize_model()
         self._model_constraints = self._model_prefix + self._model_constraints
 
     def final_xor_linear_constraints(self, weight):

--- a/tests/unit/cipher_modules/models/cp/minizinc_utils/predicate_registry_test.py
+++ b/tests/unit/cipher_modules/models/cp/minizinc_utils/predicate_registry_test.py
@@ -1,8 +1,12 @@
 from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import (
-    BCT,
-    CONTINUOUS,
-    CP_CORE,
-    SAT_WORD_OPS,
+    BOOMERANG_BCT_SAT,
+    CIPHER_EVALUATION_CP,
+    CONTINUOUS_DIFFERENTIAL_LINEAR,
+    DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP,
+    GENERIC_CP_UTILS,
+    XOR_DIFFERENTIAL_CP,
+    XOR_DIFFERENTIAL_ARX_SAT,
+    XOR_LINEAR_CP,
     collect_used_helpers,
     render_helper_block,
     resolve_helper_closure,
@@ -16,7 +20,13 @@ def test_collect_used_helpers_finds_actual_cp_helper_calls():
         "constraint Ham_weight(Andz(a, b, c)) == 0 /\\ p[0] = Ham_weight(OR(a, b));",
     ]
 
-    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"RShift", "Eq", "Ham_weight", "Andz", "OR"}
+    assert collect_used_helpers(fragments, model_contexts=(GENERIC_CP_UTILS, XOR_DIFFERENTIAL_CP)) == {
+        "RShift",
+        "Eq",
+        "Ham_weight",
+        "Andz",
+        "OR",
+    }
 
 
 def test_collect_used_helpers_ignores_comments_strings_and_identifier_substrings():
@@ -28,7 +38,7 @@ def test_collect_used_helpers_ignores_comments_strings_and_identifier_substrings
         "constraint foo_modadd = 0;",
     ]
 
-    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == set()
+    assert collect_used_helpers(fragments, model_contexts=(GENERIC_CP_UTILS, CIPHER_EVALUATION_CP)) == set()
 
 
 def test_collect_used_helpers_detects_helpers_in_output_expression():
@@ -36,23 +46,41 @@ def test_collect_used_helpers_detects_helpers_in_output_expression():
         'output ["carries:" ++ show(Xor3(a, b, c)) ++ "\\n"];',
     ]
 
-    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"Xor3"}
+    assert collect_used_helpers(fragments, model_contexts=(GENERIC_CP_UTILS,)) == {"Xor3"}
 
 
 def test_resolve_helper_closure_adds_recursive_dependencies():
-    closure = resolve_helper_closure({"modular_addition_word"}, contexts=(CP_CORE,))
+    closure = resolve_helper_closure(
+        {"modular_addition_word"},
+        model_contexts=(GENERIC_CP_UTILS, DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP),
+    )
     names = [name for _, name in closure]
 
     assert names == ["LShift", "xor_bit_p1", "modular_addition_word"]
 
 
 def test_render_helper_block_includes_dependencies_once():
-    helper_block = render_helper_block({"modular_addition_word"}, contexts=(CP_CORE,))
+    helper_block = render_helper_block(
+        {"modular_addition_word"},
+        model_contexts=(GENERIC_CP_UTILS, DETERMINISTIC_TRUNCATED_XOR_DIFFERENTIAL_CP),
+    )
 
     assert helper_block.count("function array[int] of var 0..2: LShift") == 1
     assert helper_block.count("predicate xor_bit_p1") == 1
     assert helper_block.count("predicate modular_addition_word") == 1
     assert "predicate modadd(" not in helper_block
+
+
+def test_generic_utils_do_not_include_cryptanalysis_specific_helpers():
+    fragments = [
+        "constraint modadd_linear(a, b, c, p);",
+        "constraint modadd(a, b, c);",
+        "constraint RRot(x, 3) = y;",
+    ]
+
+    assert collect_used_helpers(fragments, model_contexts=(GENERIC_CP_UTILS,)) == {"RRot"}
+    assert collect_used_helpers(fragments, model_contexts=(XOR_LINEAR_CP,)) == {"modadd_linear"}
+    assert collect_used_helpers(fragments, model_contexts=(CIPHER_EVALUATION_CP,)) == {"modadd"}
 
 
 def test_collect_used_helpers_respects_context_variants():
@@ -61,18 +89,18 @@ def test_collect_used_helpers_respects_context_variants():
         "constraint rotated = RRot(x, 3);",
     ]
 
-    assert collect_used_helpers(fragments, contexts=(CONTINUOUS,)) == {"continuous_modadd"}
-    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"RRot"}
+    assert collect_used_helpers(fragments, model_contexts=(CONTINUOUS_DIFFERENTIAL_LINEAR,)) == {"continuous_modadd"}
+    assert collect_used_helpers(fragments, model_contexts=(GENERIC_CP_UTILS,)) == {"RRot"}
 
 
-def test_sat_word_ops_and_bct_render_as_separate_contexts():
+def test_boomerang_bct_sat_context_renders_word_ops_and_bct_helpers():
     fragments = [
         "constraint modular_addition_word(A, B, C, d_list, 3);",
         "constraint onlyLargeSwitch_BCT_enum(dL, dR, nL, nR, 1, 24);",
     ]
 
-    used = collect_used_helpers(fragments, contexts=(SAT_WORD_OPS, BCT))
-    helper_block = render_helper_block(used, contexts=(SAT_WORD_OPS, BCT))
+    used = collect_used_helpers(fragments, model_contexts=(BOOMERANG_BCT_SAT,))
+    helper_block = render_helper_block(used, model_contexts=(BOOMERANG_BCT_SAT,))
 
     assert used == {"modular_addition_word", "onlyLargeSwitch_BCT_enum"}
     assert 'include "table.mzn";' in helper_block

--- a/tests/unit/cipher_modules/models/cp/minizinc_utils/predicate_registry_test.py
+++ b/tests/unit/cipher_modules/models/cp/minizinc_utils/predicate_registry_test.py
@@ -1,0 +1,81 @@
+from claasp.cipher_modules.models.cp.minizinc_utils.predicate_registry import (
+    BCT,
+    CONTINUOUS,
+    CP_CORE,
+    SAT_WORD_OPS,
+    collect_used_helpers,
+    render_helper_block,
+    resolve_helper_closure,
+)
+
+
+def test_collect_used_helpers_finds_actual_cp_helper_calls():
+    fragments = [
+        "constraint out = RShift(pre_out, shift_amount);",
+        "array[0..31] of var 0..1: eq_out = Eq(a, b, c);",
+        "constraint Ham_weight(Andz(a, b, c)) == 0 /\\ p[0] = Ham_weight(OR(a, b));",
+    ]
+
+    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"RShift", "Eq", "Ham_weight", "Andz", "OR"}
+
+
+def test_collect_used_helpers_ignores_comments_strings_and_identifier_substrings():
+    fragments = [
+        "% constraint modadd(a, b, c);",
+        'output ["debug RRot(x, 3) and bitArrayToInt(a, b)"];',
+        "array[0..3] of var 0..1: customRRot;",
+        "constraint customRRot[0] = 0;",
+        "constraint foo_modadd = 0;",
+    ]
+
+    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == set()
+
+
+def test_collect_used_helpers_detects_helpers_in_output_expression():
+    fragments = [
+        'output ["carries:" ++ show(Xor3(a, b, c)) ++ "\\n"];',
+    ]
+
+    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"Xor3"}
+
+
+def test_resolve_helper_closure_adds_recursive_dependencies():
+    closure = resolve_helper_closure({"modular_addition_word"}, contexts=(CP_CORE,))
+    names = [name for _, name in closure]
+
+    assert names == ["LShift", "xor_bit_p1", "modular_addition_word"]
+
+
+def test_render_helper_block_includes_dependencies_once():
+    helper_block = render_helper_block({"modular_addition_word"}, contexts=(CP_CORE,))
+
+    assert helper_block.count("function array[int] of var 0..2: LShift") == 1
+    assert helper_block.count("predicate xor_bit_p1") == 1
+    assert helper_block.count("predicate modular_addition_word") == 1
+    assert "predicate modadd(" not in helper_block
+
+
+def test_collect_used_helpers_respects_context_variants():
+    fragments = [
+        "constraint out = continuous_modadd(a, b, out);",
+        "constraint rotated = RRot(x, 3);",
+    ]
+
+    assert collect_used_helpers(fragments, contexts=(CONTINUOUS,)) == {"continuous_modadd"}
+    assert collect_used_helpers(fragments, contexts=(CP_CORE,)) == {"RRot"}
+
+
+def test_sat_word_ops_and_bct_render_as_separate_contexts():
+    fragments = [
+        "constraint modular_addition_word(A, B, C, d_list, 3);",
+        "constraint onlyLargeSwitch_BCT_enum(dL, dR, nL, nR, 1, 24);",
+    ]
+
+    used = collect_used_helpers(fragments, contexts=(SAT_WORD_OPS, BCT))
+    helper_block = render_helper_block(used, contexts=(SAT_WORD_OPS, BCT))
+
+    assert used == {"modular_addition_word", "onlyLargeSwitch_BCT_enum"}
+    assert 'include "table.mzn";' in helper_block
+    assert "predicate modular_addition_bit_level_sat" in helper_block
+    assert "predicate BVAssign" in helper_block
+    assert "predicate onlyLargeSwitch_BCT_enum" in helper_block

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -1,5 +1,6 @@
 import pytest
 from types import SimpleNamespace
+from pathlib import Path
 
 from claasp.ciphers.toys.toyaes_block_cipher import ToyAESBlockCipher
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
@@ -182,6 +183,23 @@ def test_model_constraints():
         speck = SpeckBlockCipher(number_of_rounds=4)
         mzn = MznModel(speck)
         mzn.model_constraints()
+
+
+def test_write_minizinc_model_to_file_prepends_model_prefix(tmp_path):
+    speck = SpeckBlockCipher(number_of_rounds=1)
+    mzn = MznModel(speck)
+    mzn._model_prefix = ['include "globals.mzn";', "function dummy(): int = 0;"]
+    mzn._variables_list = ["var int: x;"]
+    mzn._model_constraints = ["constraint x = 0;"]
+    mzn._helper_block = ""
+    mzn.write_minizinc_model_to_file(tmp_path.as_posix())
+
+    output = Path(tmp_path) / f"{speck.id}_mzn_{mzn.sat_or_milp}.mzn"
+    content = output.read_text()
+
+    assert content.startswith('include "globals.mzn";\n% No MiniZinc helpers required\nfunction dummy(): int = 0;')
+    assert content.index("function dummy(): int = 0;") < content.index("var int: x;")
+    assert content.index("var int: x;") < content.index("constraint x = 0;")
 
 def test_build_generic_cp_model_from_dictionary_xor_differential():
 

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
@@ -76,11 +76,12 @@ def test_find_lowest_weight_xor_differential_trail():
 def test_find_one_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=2)
     mzn = MznXorDifferentialModel(speck)
+    
     plaintext = set_fixed_variables(
         component_id=INPUT_PLAINTEXT, constraint_type="not_equal", bit_positions=range(32), bit_values=(0,) * 32
     )
     trail = mzn.find_one_xor_differential_trail([plaintext], CHUFFED, solve_external=True)
-
+    mzn.write_minizinc_model_to_file(".")
     assert str(trail["cipher"]) == "speck_p32_k64_o32_r2"
     assert trail["model_type"] == "xor_differential_one_solution"
     assert int(trail["components_values"]["cipher_output_1_12"]["value"], base=16) >= 0


### PR DESCRIPTION
Introduce a central MiniZinc helper registry for CP models with explicit model contexts, helper usage collection, dependency closure resolution, and context-aware rendering.

Route CP model builders through a shared finalization path so helper blocks are injected once, only when needed, and split helpers into generic CP utilities, cipher-evaluation helpers, and cryptanalysis-specific model contexts. Add support for continuous, BCT, SAT word-op, and MILP word-op contexts.

Add focused registry tests covering helper detection, dependency resolution, context variants, and BCT/SAT word-op rendering.