### PR TITLE
FIX/refactor: centralize CP MiniZinc model assembly

### DIFF
--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import time
 from copy import deepcopy
+from dataclasses import dataclass, field
 from datetime import timedelta
 
 from minizinc import Instance, Model, Solver, Status
@@ -50,6 +51,18 @@ from claasp.cipher_modules.models.utils import write_model_to_file, convert_solv
 
 SOLVE_SATISFY = "solve satisfy;"
 CONSTRAINT_TYPE_ERROR = "Constraint type not defined"
+
+
+@dataclass
+class MiniZincModelParts:
+    prefix: list[str] = field(default_factory=list)
+    variables: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    outputs: list[str] = field(default_factory=list)
+    carries_outputs: list[str] = field(default_factory=list)
+
+    def lines(self):
+        return self.prefix + self.variables + self.constraints + self.outputs + self.carries_outputs
 
 
 class MznModel:
@@ -105,6 +118,20 @@ class MznModel:
         self.probability_modadd_vars_per_round = [[] for _ in range(self._cipher.number_of_rounds)]
         self.component_probability_var = {}
         self._model_prefix = ['include "globals.mzn";', f"{usefulfunctions.MINIZINC_USEFUL_FUNCTIONS}"]
+
+    def current_model_parts(self):
+        return MiniZincModelParts(
+            variables=list(self._variables_list),
+            constraints=list(self._model_constraints),
+            outputs=list(self.mzn_output_directives),
+            carries_outputs=list(self.mzn_carries_output_directives),
+        )
+
+    def assemble_model_lines(self, parts=None):
+        return (parts or self.current_model_parts()).lines()
+
+    def assemble_model(self, parts=None):
+        return "\n".join(self.assemble_model_lines(parts)) + "\n"
 
     def add_comment(self, comment):
         """
@@ -813,8 +840,6 @@ class MznModel:
         ):
             truncated = True
         
-        mzn_model = self._variables_list + self._model_constraints
-
         solutions = []
         if solve_external:
             command = self.get_command_for_solver_process(
@@ -824,7 +849,7 @@ class MznModel:
                 timeout_in_seconds_,
                 intermediate_solutions=intermediate_solutions_,
             )
-            model = "\n".join(mzn_model)
+            model = self.assemble_model()
             start = time.time()
             solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
             end = time.time()
@@ -832,7 +857,7 @@ class MznModel:
             if solver_process.returncode >= 0:
                 solver_output = solver_process.stdout.splitlines()
         else:
-            mzn_model_string = "\n".join(mzn_model)
+            mzn_model_string = self.assemble_model()
             solver_name_mzn = Solver.lookup(solver_name)
             bit_mzn_model = Model()
             bit_mzn_model.add_string(mzn_model_string)
@@ -972,9 +997,12 @@ class MznModel:
             sage: result.statistics['nSolutions']
             1
         """
-        constraints = self._model_constraints
-        variables = self._variables_list
-        mzn_model_string = "\n".join(constraints) + "\n".join(variables)
+        mzn_model_string = self.assemble_model(
+            MiniZincModelParts(
+                variables=list(self._model_constraints),
+                constraints=list(self._variables_list),
+            )
+        )
         solver_name_mzn = Solver.lookup(solver_name)
         bit_mzn_model = Model()
         bit_mzn_model.add_string(mzn_model_string)
@@ -1077,20 +1105,22 @@ class MznModel:
         - ``file_path`` -- **string**; the path of the file that will contain the model
         - ``prefix`` -- **str** (default: ``)
         """
-        model_string = (
-            "\n".join(self.mzn_comments)
-            + "\n".join(self._variables_list)
-            + "\n".join(self._model_constraints)
-            + "\n".join(self.mzn_output_directives)
-            + "\n".join(self.mzn_carries_output_directives)
-        )
         if prefix == "":
             filename = f"{file_path}/{self.cipher_id}_mzn_{self.sat_or_milp}.mzn"
         else:
             filename = f"{file_path}/{prefix}_{self.cipher_id}_mzn_{self.sat_or_milp}.mzn"
 
         with open(filename, "w") as file:
-            file.write(model_string)
+            file.write(
+                self.assemble_model(
+                    MiniZincModelParts(
+                        variables=self.mzn_comments + list(self._variables_list),
+                        constraints=list(self._model_constraints),
+                        outputs=list(self.mzn_output_directives),
+                        carries_outputs=list(self.mzn_carries_output_directives),
+                    )
+                )
+            )
 
     @property
     def cipher(self):

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -5,7 +5,7 @@ from claasp.ciphers.toys.toyaes_block_cipher import ToyAESBlockCipher
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.ciphers.block_ciphers.midori_block_cipher import MidoriBlockCipher
 import claasp.cipher_modules.models.cp.mzn_model as mzn_model_module
-from claasp.cipher_modules.models.cp.mzn_model import MznModel
+from claasp.cipher_modules.models.cp.mzn_model import MiniZincModelParts, MznModel
 from claasp.ciphers.block_ciphers.raiden_block_cipher import RaidenBlockCipher
 from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model import MznXorDifferentialModel
 from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model_arx_optimized import (
@@ -26,6 +26,40 @@ class _FakeDuration:
 
     def total_seconds(self):
         return self._seconds
+
+
+def test_assemble_model_preserves_legacy_order():
+    speck = SpeckBlockCipher(number_of_rounds=1)
+    model = MznModel(speck)
+    model._variables_list = ["var int: x;"]
+    model._model_constraints = ["constraint x = 1;", "solve satisfy;"]
+    model.mzn_output_directives = ['output ["x=", show(x)];']
+
+    assert model.assemble_model() == (
+        "var int: x;\n"
+        "constraint x = 1;\n"
+        "solve satisfy;\n"
+        'output ["x=", show(x)];\n'
+    )
+
+
+def test_assemble_model_accepts_explicit_parts():
+    speck = SpeckBlockCipher(number_of_rounds=1)
+    model = MznModel(speck)
+    parts = MiniZincModelParts(
+        prefix=['include "globals.mzn";'],
+        variables=["var int: x;"],
+        constraints=["constraint x = 1;", "solve satisfy;"],
+        outputs=['output ["x=", show(x)];'],
+    )
+
+    assert model.assemble_model(parts) == (
+        'include "globals.mzn";\n'
+        "var int: x;\n"
+        "constraint x = 1;\n"
+        "solve satisfy;\n"
+        'output ["x=", show(x)];\n'
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# CP MiniZinc Model Parts Standardization

CLAASP has many CP model generators. These generators turn MiniZinc fragments into full MiniZinc models. The fragments come from several sources:

1. Component MiniZinc generators, which emit MiniZinc declarations and constraints.
2. MiniZinc includes, for example:

```minizinc
include "globals.mzn";
```

3. Custom MiniZinc predicates/functions used by component constraints.
4. MiniZinc output directives, for example:

```minizinc
output ["plaintext = " ++ show(plaintext) ++ "\n"];
```

Currently there are several structural problems.

## 1. Fragment Names Are Not Consistent

Different models use different attributes for the same conceptual fragment.

Example: in `claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py`, the first-step model stores generated constraints in:

```python
constraints = self.fix_variables_value_constraints(fixed_variables, "first_step")
self._first_step = constraints
```

But the second-step model stores generated constraints in:

```python
self._model_constraints.extend(self.final_xor_differential_constraints(weight))
```

So the same kind of fragment, MiniZinc constraints, is stored under two different names depending on the sub-model.

A clearer design would use explicit model parts:

```python
self.first_step_parts.constraints
self.second_step_parts.constraints
```

## 2. `_model_prefix` Has Multiple Meanings

Many models use:

```python
self._model_prefix
```

but it does not always mean only "prefix".

In the base model, it starts as MiniZinc includes and helper predicates/functions:

```python
self._model_prefix = [
    'include "globals.mzn";',
    usefulfunctions.MINIZINC_USEFUL_FUNCTIONS,
]
```

But some models also add declarations to it.

Example from `mzn_xor_differential_model.py`:

```python
variables, constraints = self.input_xor_differential_constraints()
self._model_prefix.extend(variables)
```

Here `variables` contains declarations such as:

```minizinc
array[0..31] of var 0..1: plaintext;
array[0..63] of var 0..1: key;
```

So `_model_prefix` becomes:

```text
includes + helper predicates/functions + declarations
```

A cleaner contract would be:

```text
prefix       = includes + helper predicates/functions/constants
variables    = declarations
constraints  = constraints + solve directive
outputs      = output directives
```

## 3. Some Attributes Change Meaning During Build

Some attributes start as one kind of fragment and later become a full MiniZinc model.

Example from the first-step model:

```python
self._first_step = constraints
```

At this point:

```python
self._first_step
```

means:

```text
first-step constraints
```

Later:

```python
self._first_step = self._model_prefix + self._variables_list + self._first_step
```

Now:

```python
self._first_step
```

means:

```text
full first-step MiniZinc model
```

The same happens with `_model_constraints`.

Example from `mzn_cipher_model.py`:

```python
self._model_constraints = constraints
```

At this point it means constraints only.

Later:

```python
self._model_constraints = self._model_prefix + self._model_constraints
```

Now it means:

```text
full MiniZinc model prefix + constraints
```

## 4. Model Assembly Order Is Not Uniform

Different models assemble MiniZinc text in different ways.

First-step model example from `mzn_xor_differential_number_of_active_sboxes_model.py`:

```python
self._first_step = self._model_prefix + self._variables_list + self._first_step
```

Order:

```text
prefix + variables + constraints
```

Other models copy only the prefix into `_model_constraints`.

Example from `mzn_cipher_model.py`:

```python
self._model_constraints = self._model_prefix + self._model_constraints
```

Example from `mzn_xor_differential_model.py`:

```python
self._model_constraints = self._model_prefix + self._model_constraints
```

Example from `mzn_xor_linear_model.py`:

```python
self._model_constraints = self._model_prefix + self._model_constraints
```

Order:

```text
prefix + constraints
```

Some solve paths then assemble with:

```python
self._variables_list + self._model_constraints
```

For example, in the base `solve()` path:

```python
mzn_model = self._variables_list + self._model_constraints
```

This works only because many builders already copied the prefix into `_model_constraints`.

That makes the final MiniZinc model dependent on hidden assumptions about whether `_model_constraints` is raw constraints or already a full model.

A cleaner design would use one assembly method:

```python
def assemble_model(parts):
    return (
        parts.prefix
        + parts.variables
        + parts.constraints
        + parts.outputs
    )
```

## 5. Two-Step Models Are Multiple Self-Contained Models

The two-step flow is not one model. It has at least:

```text
first-step MiniZinc model
second-step MiniZinc model
```

Currently the first one is stored in:

```python
self._first_step
```

and the second one is stored using the normal model fields:

```python
self._variables_list
self._model_constraints
```

But both are self-contained MiniZinc models.

A clearer representation would be:

```python
self.first_step_parts = MiniZincModelParts(...)
self.second_step_parts = MiniZincModelParts(...)
```

Then both models follow the same structure:

```text
prefix
variables
constraints
outputs
```

The intention of this PR is only to introduce MiniZincModelParts as the new way to manage MiniZinc model parts. This class provides the assemble_model flow, which for now preserves the existing behavior even when the current fragments still mix variable declarations with constraints, or declarations with includes.

In other words, this PR does not fully reorganize every CP model yet. Its goal is to introduce the structure and give reviewers a clear view of the new direction for managing MiniZinc fragments. In the next PR, we will inspect the models one by one and move each fragment into the correct part. 

Note:
The issues described above were revealed and confirmed while working on PR #444: https://github.com/Crypto-TII/claasp/pull/444. That PR aims to ensure CP models do not include MiniZinc predicates/functions that they do not actually use.

