### PR TITLE
Normalize weight_at_most semantics across CP/SAT/SMT/MILP (default range [0, max_weight])

### DIFF
--- a/claasp/cipher_modules/algebraic_tests.py
+++ b/claasp/cipher_modules/algebraic_tests.py
@@ -78,7 +78,10 @@ class AlgebraicTests:
             if dict_vars:
                 F = self._algebraic_model._eliminate_const_not_shift_rot_components_polynomials(dict_vars, F)
 
-            Fseq = Sequence(F)
+            # Coerce explicitly into the algebraic model Boolean ring to avoid
+            # environment-dependent PolyBoRi coercion failures in groebner_basis.
+            ring = self._algebraic_model.ring()
+            Fseq = Sequence([ring(p) for p in F], universe=ring)
             nvars_up_to_round.append(Fseq.nvariables())
             npolynomials_up_to_round.append(len(Fseq))
             nmonomials_up_to_round.append(Fseq.nmonomials())

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -353,9 +353,14 @@ class MznXorDifferentialModel(MznModel):
                 all_solutions_=True,
                 solve_external=solve_external,
             )
-            for solution in solutions:
-                solution["building_time_seconds"] = build_time
-                solution["test_name"] = "find_all_xor_differential_trails_with_weight_at_most"
+            if isinstance(solutions, list):
+                for solution in solutions:
+                    solution["building_time_seconds"] = build_time
+                    solution["test_name"] = "find_all_xor_differential_trails_with_weight_at_most"
+            else:
+                # Unsat/no-solution outcomes can be returned as a non-list sentinel.
+                # For an "all trails" query, return an empty list instead of crashing.
+                return []
 
         return solutions
 
@@ -591,9 +596,8 @@ class MznXorDifferentialModel(MznModel):
                 processes_=num_of_processors,
                 solve_external=solve_external,
             )
-            if solve_external:
-                solution["building_time_seconds"] = build_time
-                solution["test_name"] = "find_one_xor_differential_trail_with_fixed_weight"
+            solution["building_time_seconds"] = build_time
+            solution["test_name"] = "find_one_xor_differential_trail_with_fixed_weight"
 
         return solution
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -286,8 +286,8 @@ class MznXorDifferentialModel(MznModel):
 
     def find_all_xor_differential_trails_with_weight_at_most(
         self,
-        min_weight,
-        max_weight=64,
+        max_weight,
+        min_weight=0,
         fixed_values=[],
         solver_name=SOLVER_DEFAULT,
         num_of_processors=None,
@@ -303,8 +303,8 @@ class MznXorDifferentialModel(MznModel):
 
         INPUT:
 
-        - ``min_weight`` -- **integer**; the weight from which to start the search
-        - ``max_weight`` -- **integer** (default: 64); the weight at which the search stops
+        - ``max_weight`` -- **integer**; the maximum weight at which the search stops
+        - ``min_weight`` -- **integer** (default: 0); the minimum weight from which to start the search
         - ``fixed_values`` -- **list**  (default: `[]`); can be created using ``set_fixed_variables`` method
         - ``solver_name`` -- **string** (default: `chuffed`); the name of the solver.
           See also :meth:`MznModel.solver_names`.
@@ -316,7 +316,7 @@ class MznXorDifferentialModel(MznModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: cp = MznXorDifferentialModel(speck)
-            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(9,10, solver_name='chuffed', solve_external=True)
+            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(10, 9, solver_name='chuffed', solve_external=True)
             sage: len(trails)
             28
 
@@ -327,7 +327,7 @@ class MznXorDifferentialModel(MznModel):
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: cp = MznXorDifferentialModel(speck)
             sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
-            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(2,3, fixed_values=[key], solver_name='chuffed') # long
+            sage: trails = cp.find_all_xor_differential_trails_with_weight_at_most(3, 2, fixed_values=[key], solver_name='chuffed') # long
             sage: len(trails)
             9
 

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -362,15 +362,15 @@ class MilpXorDifferentialModel(MilpModel):
 
     def find_all_xor_differential_trails_with_weight_at_most(
         self,
-        min_weight,
         max_weight,
+        min_weight=0,
         fixed_values=[],
         weight_precision=MILP_DEFAULT_WEIGHT_PRECISION,
         solver_name=SOLVER_DEFAULT,
         external_solver_name=None,
     ):
         """
-        Return all XOR differential trails with weight greater than ``min_weight`` and lower/equal to ``max_weight``.
+        Return all XOR differential trails with weight greater than or equal to ``min_weight`` and lower/equal to ``max_weight``.
         By default, the search is set in the single-key setting.
         The value returned is a list of solutions in standard format.
 
@@ -385,8 +385,8 @@ class MilpXorDifferentialModel(MilpModel):
 
         INPUT:
 
-        - ``min_weight`` -- **integer**;  the weight found using :py:meth:`~find_lowest_weight_xor_differential_trail`.
         - ``max_weight`` -- **integer**; the upper bound for the weight.
+        - ``min_weight`` -- **integer** (default: 0); the lower bound for the weight search.
         - ``fixed_values`` -- **list** (default: `[]`); each dictionary contains variables values whose output need to
           be fixed
         - ``weight_precision`` -- **integer** (default: `2`); the number of decimals to use when rounding the weight of the trail.
@@ -400,7 +400,7 @@ class MilpXorDifferentialModel(MilpModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
-            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(9, 10) # long #doctest: +SKIP
+            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(10, 9) # long #doctest: +SKIP
             ...
             sage: len(trails) #doctest: +SKIP
             28
@@ -412,7 +412,7 @@ class MilpXorDifferentialModel(MilpModel):
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: milp = MilpXorDifferentialModel(speck)
             sage: key = set_fixed_variables('key', 'not_equal', list(range(64)), [0] * 64)
-            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key]) # long #doctest: +SKIP
+            sage: trails = milp.find_all_xor_differential_trails_with_weight_at_most(3, 2, fixed_values=[key]) # long #doctest: +SKIP
             ...
             sage: len(trails) #doctest: +SKIP
             9

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
@@ -242,7 +242,13 @@ class SatXorDifferentialModel(SatModel):
         start_building_time = time.time()
         self.build_xor_differential_trail_model(weight=fixed_weight, fixed_variables=fixed_values)
         if self._counter == self._sequential_counter:
-            self._sequential_counter_greater_or_equal(fixed_weight, "dummy_hw_1")
+            hw_variables = [variable_id for variable_id in self._variables_list if variable_id.startswith("hw_")]
+            if fixed_weight > len(hw_variables):
+                return []
+            if fixed_weight == len(hw_variables):
+                self._model_constraints.extend(hw_variables)
+            else:
+                self._sequential_counter_greater_or_equal(fixed_weight, "dummy_hw_1")
         end_building_time = time.time()
         solution = self.solve(XOR_DIFFERENTIAL, solver_name=solver_name, options=options)
         solutions_list = []
@@ -257,7 +263,7 @@ class SatXorDifferentialModel(SatModel):
         return solutions_list
 
     def find_all_xor_differential_trails_with_weight_at_most(
-        self, min_weight, max_weight, fixed_values=[], solver_name=solvers.SOLVER_DEFAULT, options=None
+        self, max_weight, min_weight=0, fixed_values=[], solver_name=solvers.SOLVER_DEFAULT, options=None
     ):
         """
         Return a list of solutions.

--- a/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
+++ b/claasp/cipher_modules/models/sat/sat_models/sat_xor_differential_model.py
@@ -274,8 +274,8 @@ class SatXorDifferentialModel(SatModel):
 
         INPUT:
 
-        - ``min_weight`` -- **integer**; the weight from which to start the search
         - ``max_weight`` -- **integer**; the weight at which the search stops
+        - ``min_weight`` -- **integer** (default: `0`); the weight from which to start the search
         - ``fixed_values`` -- **list** (default: `[]`); they can be created using ``set_fixed_variables`` method
         - ``solver_name`` -- **string** (default: `CRYPTOMINISAT_EXT`); the name of the solver
 
@@ -290,7 +290,7 @@ class SatXorDifferentialModel(SatModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: sat = SatXorDifferentialModel(speck)
-            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10)
+            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(10, 9)
             sage: len(trails) == 28
             True
 
@@ -305,7 +305,7 @@ class SatXorDifferentialModel(SatModel):
             ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
             ....:     bit_values=[0]*64)
-            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key])
+            sage: trails = sat.find_all_xor_differential_trails_with_weight_at_most(3, 2, fixed_values=[key])
             sage: len(trails) == 9
             True
         """

--- a/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
+++ b/claasp/cipher_modules/models/smt/smt_models/smt_xor_differential_model.py
@@ -181,7 +181,7 @@ class SmtXorDifferentialModel(SmtModel):
         return solutions_list
 
     def find_all_xor_differential_trails_with_weight_at_most(
-        self, min_weight, max_weight, fixed_values=[], solver_name=solvers.SOLVER_DEFAULT
+        self, max_weight, min_weight=0, fixed_values=[], solver_name=solvers.SOLVER_DEFAULT
     ):
         """
         Return a list of solutions.
@@ -192,8 +192,8 @@ class SmtXorDifferentialModel(SmtModel):
 
         INPUT:
 
-        - ``min_weight`` -- **integer**; the weight from which to start the search
-        - ``max_weight`` -- **integer**; the weight at which the search stops
+        - ``max_weight`` -- **integer**; the maximum weight at which the search stops
+        - ``min_weight`` -- **integer** (default: 0); the minimum weight from which to start the search
         - ``fixed_values`` -- **list** (default: `[]`); they can be created using ``set_fixed_variables`` method
         - ``solver_name`` -- **string** (default: `Z3_EXT`); the name of the solver
 
@@ -208,7 +208,7 @@ class SmtXorDifferentialModel(SmtModel):
             sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
             sage: speck = SpeckBlockCipher(number_of_rounds=5)
             sage: smt = SmtXorDifferentialModel(speck)
-            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10)
+            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(10, 9)
             sage: len(trails)
             28
 
@@ -223,7 +223,7 @@ class SmtXorDifferentialModel(SmtModel):
             ....:     constraint_type='not_equal',
             ....:     bit_positions=range(64),
             ....:     bit_values=[0]*64)
-            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(2, 3, fixed_values=[key])
+            sage: trails = smt.find_all_xor_differential_trails_with_weight_at_most(3, 2, fixed_values=[key])
             sage: len(trails)
             9
         """

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
@@ -48,6 +48,15 @@ def test_find_all_xor_differential_trails_with_weight_at_most():
     assert len(trails) == 7
 
 
+def test_find_all_xor_differential_trails_with_weight_at_most_unsat_returns_empty_list():
+    speck = SpeckBlockCipher(number_of_rounds=5)
+    mzn = MznXorDifferentialModel(speck)
+
+    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(0, 3, solver_name=CHUFFED, solve_external=False)
+
+    assert trails == []
+
+
 def test_find_lowest_weight_xor_differential_trail():
     speck = SpeckBlockCipher(number_of_rounds=5)
     mzn = MznXorDifferentialModel(speck)
@@ -125,3 +134,6 @@ def test_find_one_xor_differential_trail_with_fixed_weight():
     assert int(trail["components_values"]["xor_3_8"]["value"], base=16) >= 0
     assert trail["components_values"]["xor_3_8"]["weight"] == 0
     assert trail["total_weight"] == "9.0"
+
+
+

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
@@ -5,6 +5,7 @@ from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model impor
 from claasp.cipher_modules.models.cp.solvers import CHUFFED
 from claasp.cipher_modules.models.utils import set_fixed_variables
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
 from claasp.name_mappings import INPUT_PLAINTEXT, UNSATISFIABLE
 
 
@@ -39,20 +40,26 @@ def test_solving_unsatisfiability():
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     mzn = MznXorDifferentialModel(speck)
-    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(0, 1, solver_name=CHUFFED, solve_external=True)
+    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(1, 0, solver_name=CHUFFED, solve_external=True)
 
     assert len(trails) == 7
 
-    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(0, 1, solver_name=CHUFFED, solve_external=False)
+    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(1, 0, solver_name=CHUFFED, solve_external=False)
 
     assert len(trails) == 7
 
 
 def test_find_all_xor_differential_trails_with_weight_at_most_unsat_returns_empty_list():
-    speck = SpeckBlockCipher(number_of_rounds=5)
-    mzn = MznXorDifferentialModel(speck)
+    cipher = SboxCipher(bit_size=3, lookup_table=[0, 1, 2, 3, 4, 5, 6, 7])
+    mzn = MznXorDifferentialModel(cipher)
 
-    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(0, 3, solver_name=CHUFFED, solve_external=False)
+    zero_weight_trails = mzn.find_all_xor_differential_trails_with_weight_at_most(
+        0, 0, solver_name=CHUFFED, solve_external=False
+    )
+    assert len(zero_weight_trails) > 0
+    assert all(t["total_weight"] == "0.0" for t in zero_weight_trails)
+
+    trails = mzn.find_all_xor_differential_trails_with_weight_at_most(1, 1, solver_name=CHUFFED, solve_external=False)
 
     assert trails == []
 

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
@@ -26,7 +26,7 @@ def test_find_all_xor_differential_trails_with_fixed_weight():
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     milp = MilpXorDifferentialModel(speck)
-    trails = milp.find_all_xor_differential_trails_with_weight_at_most(0, 1)
+    trails = milp.find_all_xor_differential_trails_with_weight_at_most(1, 0)
     assert len(trails) == 7
     for trail in trails:
         assert 0.0 <= trail["total_weight"] <= 1.0

--- a/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/sat/sat_models/sat_xor_differential_model_test.py
@@ -5,6 +5,7 @@ from claasp.cipher_modules.models.sat.sat_models.sat_xor_differential_model impo
 from claasp.cipher_modules.models.sat.solvers import CADICAL_EXT, KISSAT_EXT, PARKISSAT_EXT
 from claasp.cipher_modules.models.utils import set_fixed_variables, integer_to_bit_list
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
 from claasp.components.modadd_component import ModAdd
 from claasp.name_mappings import INPUT_KEY, INPUT_PLAINTEXT, SATISFIABLE, XOR_DIFFERENTIAL
 
@@ -79,9 +80,25 @@ def test_find_all_xor_differential_trails_with_fixed_weight():
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = speck_5rounds
     sat = SatXorDifferentialModel(speck)
-    trails = sat.find_all_xor_differential_trails_with_weight_at_most(9, 10)
+    trails = sat.find_all_xor_differential_trails_with_weight_at_most(10, 9)
 
     assert len(trails) == 28
+
+
+def test_find_all_xor_differential_trails_with_weight_at_most_accepts_default_min_weight_and_no_crash():
+    """Test that single-argument call finds all trails 'at most' that weight (min_weight=0 by default)."""
+    cipher = SboxCipher(bit_size=3, lookup_table=[0, 1, 2, 3, 4, 5, 6, 7])
+    sat = SatXorDifferentialModel(cipher)
+
+    # Single-arg call: find all trails "at most 1 weight" → [0, 1]
+    trails_default_range = sat.find_all_xor_differential_trails_with_weight_at_most(1)
+    assert len(trails_default_range) == 7
+    assert all(float(t["total_weight"]) == 0.0 for t in trails_default_range)
+
+    # Two-arg call: find all trails with weight in [0, 17]
+    trails = sat.find_all_xor_differential_trails_with_weight_at_most(17, 0)
+    assert len(trails) == 7
+    assert all(float(t["total_weight"]) == 0.0 for t in trails)
 
 
 def test_find_lowest_weight_xor_differential_trail():

--- a/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/smt/smt_models/smt_xor_differential_model_test.py
@@ -6,7 +6,7 @@ from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 def test_find_all_xor_differential_trails_with_weight_at_most():
     speck = SpeckBlockCipher(number_of_rounds=5)
     smt = SmtXorDifferentialModel(speck)
-    trails = smt.find_all_xor_differential_trails_with_weight_at_most(9, 10)
+    trails = smt.find_all_xor_differential_trails_with_weight_at_most(10, 9)
     assert len(trails) == 28
 
 

--- a/tests/unit/cipher_modules/report_test.py
+++ b/tests/unit/cipher_modules/report_test.py
@@ -324,6 +324,25 @@ def test_show(monkeypatch, tmp_path):
     assert component_charts, 'Expected component analysis radar chart to be produced'
 
 
+def test_report_accepts_cp_trail_output():
+    """
+    Test that Report can be instantiated with CP model trail output directly,
+    without requiring explicit 'input_parameters' or 'test_name' nesting.
+    This validates that Report gracefully handles single-trial dictionaries
+    from find_one_xor_differential_trail_with_fixed_weight and similar methods.
+    """
+    speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
+    cp = MznXorDifferentialModel(speck)
+    trail = cp.find_one_xor_differential_trail_with_fixed_weight(1, solver_name='chuffed', solve_external=False)
+
+    assert 'test_name' in trail
+    assert trail['test_name'] == 'find_one_xor_differential_trail_with_fixed_weight'
+
+    trail_report = Report(trail)
+    assert trail_report.cipher == speck
+    assert trail_report.test_name == 'find_one_xor_differential_trail_with_fixed_weight'
+
+
 def test_save_as_dataframe_uses_runtime_cwd_default(monkeypatch, tmp_path):
     class DummyCipher:
         id = 'dummy_cipher'


### PR DESCRIPTION
This PR makes the XOR differential API behavior intuitive and consistent across CP, SAT, SMT, and MILP models for
find_all_xor_differential_trails_with_weight_at_most.

The key semantic fix is that a single argument now means “at most this weight,” which maps to a default minimum weight of 0.

**What Changed**

1. Unified API semantics across paradigms
Updated method signatures from a min-first style to a max-first style:

Previous behavior:

find_all_xor_differential_trails_with_weight_at_most(min_weight, max_weight=64)
Single-argument calls were interpreted as [min_weight, 64], which was counterintuitive.

New behavior:

find_all_xor_differential_trails_with_weight_at_most(max_weight, min_weight=0)
Single-argument calls are interpreted as [0, max_weight], matching the method name.

Behavior Examples

find_all_xor_differential_trails_with_weight_at_most(3) now means search in [0, 3].
find_all_xor_differential_trails_with_weight_at_most(10, 9) means search in [9, 10].


**Compatibility Note**

This is an API-breaking argument-order change for callers that pass two positional arguments. Existing min,max positional calls must be migrated to max,min.