### PR TITLE
Refactor/mzn model assembly standardization

### DIFF
--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_boomerang_model_arx_optimized.py
@@ -21,6 +21,7 @@ from minizinc import Status
 from claasp.cipher_modules.graph_generator import split_cipher_graph_into_top_bottom
 from claasp.cipher_modules.models.cp.minizinc_utils.mzn_bct_predicates import get_bct_operations
 from claasp.cipher_modules.models.cp.minizinc_utils.utils import group_strings_by_pattern
+from claasp.cipher_modules.models.cp.mzn_model import MiniZincModelParts
 from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model_arx_optimized import (
     MznXorDifferentialModelARXOptimized,
 )
@@ -206,12 +207,11 @@ class MznBoomerangModelARXOptimized(MznXorDifferentialModelARXOptimized):
         self.probability_vars = top_cipher_probability_vars + bottom_cipher_probability_vars
 
     def write_minizinc_model_to_file(self, file_path, prefix=""):
-        model_string_top = "\n".join(self.differential_model_top_cipher.mzn_comments) + "\n".join(
-            self.differential_model_top_cipher.mzn_output_directives
-        )
-
-        model_string_bottom = "\n".join(self.differential_model_bottom_cipher.mzn_comments) + "\n".join(
-            self.differential_model_bottom_cipher.mzn_output_directives
+        output_directives = (
+            self.differential_model_top_cipher.mzn_comments
+            + self.differential_model_top_cipher.mzn_output_directives
+            + self.differential_model_bottom_cipher.mzn_comments
+            + self.differential_model_bottom_cipher.mzn_output_directives
         )
         if prefix == "":
             filename = f"{file_path}/{self.original_cipher.id}_mzn_{self.differential_model_top_cipher.sat_or_milp}.mzn"
@@ -221,17 +221,13 @@ class MznBoomerangModelARXOptimized(MznXorDifferentialModelARXOptimized):
             filename += f"{self.differential_model_top_cipher.sat_or_milp}.mzn"
             self.filename = filename
 
-        f = open(filename, "w")
-        f.write(
-            model_string_top
-            + "\n"
-            + model_string_bottom
-            + "\n"
-            + "\n".join(self._variables_declarations)
-            + "\n"
-            + "\n".join(self._model_constraints)
+        parts = MiniZincModelParts(
+            prefix=output_directives,
+            variables=list(self._variables_declarations),
+            constraints=list(self._model_constraints),
         )
-        f.close()
+        with open(filename, "w") as file:
+            file.write(self.assemble_model(parts))
 
     def parse_components_with_solution(self, result, solution):
         dict_of_component_value = {}

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
@@ -276,9 +276,7 @@ class MznDifferentialLinearContinuousModel(MznModel):
         return val
 
     def solve_for_ARX(self, solver_name="scip", timeout_in_seconds_=30, processes_=4):
-        constraints = self._model_constraints
-        variables = self._variables_declarations
-        mzn_model_string =  "\n".join(variables) + "\n".join(constraints) 
+        mzn_model_string = self.assemble_model()
         solver_name_mzn = Solver.lookup(solver_name)
         bit_mzn_model = Model()
         bit_mzn_model.add_string(mzn_model_string)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -836,7 +836,7 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
         if final_round is None:
             final_round = self._cipher.number_of_rounds
         command = self.get_command_for_solver_process(model_type, solver_name, processes_, timeout_in_seconds_)
-        model = "\n".join(self._model_prefix + self._variables_declarations + self._model_constraints) + "\n"
+        model = self.assemble_model()
         solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
         if solver_process.returncode >= 0:
             solutions = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
@@ -1414,7 +1414,7 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
             number_of_rounds = self._cipher.number_of_rounds
             final_round = self._cipher.number_of_rounds
         command = self.get_command_for_solver_process(model_type, solver_name, processes_, timeout_in_seconds_)
-        model = "\n".join(self._model_prefix + self._variables_declarations + self._model_constraints) + "\n"
+        model = self.assemble_model()
         start = time.time()
         solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
         end = time.time()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -18,7 +18,7 @@
 
 from copy import deepcopy
 
-from claasp.cipher_modules.models.cp.mzn_model import SOLVE_SATISFY, MznModel
+from claasp.cipher_modules.models.cp.mzn_model import SOLVE_SATISFY, MiniZincModelParts, MznModel
 from claasp.component import Component
 from claasp.input import Input
 from claasp.name_mappings import (
@@ -175,7 +175,13 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
             self._variables_declarations.extend(variables)
             self._first_step.append(constraints)
         self._first_step.extend(self.final_xor_differential_first_step_constraints(weight))
-        self._first_step = self._model_prefix + self._variables_declarations + self._first_step
+        self._first_step = self.assemble_model_lines(
+            MiniZincModelParts(
+                prefix=list(self._model_prefix),
+                variables=list(self._variables_declarations),
+                constraints=list(self._first_step),
+            )
+        )
 
     def create_xor_component(self, component1, component2, nmax):
         """

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -480,7 +480,9 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             for key in command_options["format"]:
                 command.extend(command_options[key])
 
-            model = "\n".join(self._model_prefix) + "\n" + table_of_solutions + "\n".join(self._variables_declarations) + "\n".join(self._model_constraints) + "\n"
+            parts = self.current_model_parts()
+            parts.prefix = parts.prefix + [table_of_solutions]
+            model = self.assemble_model(parts)
             solver_process = subprocess.run(command, input=model, capture_output=True, text=True)
             if solver_process.returncode < 0:
                 raise ValueError("something went wrong with solver subprocess... sorry!")
@@ -546,7 +548,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             if model_type == "xor_differential_first_step":
                 model = "\n".join(self._first_step) + "\n"
             else:
-                model = "\n".join(self._model_prefix + self._variables_declarations + self._model_constraints) + "\n"
+                model = self.assemble_model()
         if num_of_processors is not None:
             command_options["options"].insert(0, f"-p {num_of_processors}")
         if timelimit is not None:


### PR DESCRIPTION

## Summary

Standardizes MiniZinc model assembly for the remaining single-step and two-step CP models by replacing ad-hoc string concatenation with the shared `MiniZincModelParts` / `assemble_model` flow.

This follows the base model assembly standardization from #464 and keeps model sections consistently separated into prefix, variables, constraints, and outputs.

## Changes

- Standardized single-step model solve paths for impossible, hybrid impossible, and differential-linear continuous models.
- Standardized two-step active-S-box search model assembly.
- Reused base assembly helpers instead of manually joining MiniZinc fragments.

## Tests

- Targeted CP MiniZinc pytest suites passed.
- Doctest command run for touched MiniZinc model modules; no doctests discovered.
