### PR TITLE
Refactor: uniform round outputs components

### DIFF
--- a/claasp/ciphers/block_ciphers/aes_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/aes_block_cipher.py
@@ -445,14 +445,12 @@ class AESBlockCipher(Cipher):
                                              [list(range(self.CIPHER_BLOCK_SIZE))],
                                              self.CIPHER_BLOCK_SIZE)
         else:
-            self.add_intermediate_output_component([state_component.id],
-                                                   [list(range(self.CIPHER_BLOCK_SIZE))],
-                                                   self.CIPHER_BLOCK_SIZE,
-                                                   f"state_after_round_{round_number}")
-    
+            self.add_round_output_component([state_component.id],
+                                            [list(range(self.CIPHER_BLOCK_SIZE))],
+                                            self.CIPHER_BLOCK_SIZE)
+
     def add_keyschedule_round_output(self, w):
         """Output the round key schedule."""
-        self.add_intermediate_output_component([w[i].id for i in range(self.NUM_ROWS)],
-                                              [list(range(self.WORD_BIT_SIZE)) for _ in range(self.NUM_ROWS)],
-                                              self.CIPHER_BLOCK_SIZE,
-                                              "round_key_output")
+        self.add_round_key_output_component([w[i].id for i in range(self.NUM_ROWS)],
+                                            [list(range(self.WORD_BIT_SIZE)) for _ in range(self.NUM_ROWS)],
+                                            self.CIPHER_BLOCK_SIZE)

--- a/claasp/ciphers/block_ciphers/bea1_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/bea1_block_cipher.py
@@ -485,11 +485,10 @@ class BEA1BlockCipher(Cipher):
                     for i in range(4)
                 ]
 
-                self.add_intermediate_output_component(
+                self.add_round_output_component(
                     [mx1.id, mx2.id],
                     [list(range(self.sbox_bit_size * 4))] * 2,
                     self.sbox_bit_size * 8,
-                    "round_output",
                 )
             else:
                 # shift rows

--- a/claasp/ciphers/block_ciphers/des_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/des_block_cipher.py
@@ -427,7 +427,7 @@ class DESBlockCipher(Cipher):
                     self.cipher_block_size,
                     list(range(self.cipher_block_size)),
                 )
-                self.add_intermediate_output_component(
-                    [state.id], [list(range(self.cipher_block_size))], self.cipher_block_size, "round_output"
+                self.add_round_output_component(
+                    [state.id], [list(range(self.cipher_block_size))], self.cipher_block_size
                 )
                 self.add_round()

--- a/claasp/ciphers/block_ciphers/des_exact_key_length_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/des_exact_key_length_block_cipher.py
@@ -434,7 +434,7 @@ class DESExactKeyLengthBlockCipher(Cipher):
                     list(range(self.cipher_block_size)),
                 )
                 state = output
-                self.add_intermediate_output_component(
-                    [state.id], [list(range(self.cipher_block_size))], self.cipher_block_size, "round_output"
+                self.add_round_output_component(
+                    [state.id], [list(range(self.cipher_block_size))], self.cipher_block_size
                 )
                 self.add_round()

--- a/claasp/ciphers/block_ciphers/rijndael_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/rijndael_block_cipher.py
@@ -186,7 +186,7 @@ class RijndaelBlockCipher(Cipher):
             if round_index == self.rounds_count - 1:
                 self._emit_cipher_output(state)
             else:
-                self._emit_round_output(state, round_index)
+                self._emit_round_output(state)
 
     def _expand_key_schedule(self):
         total_words = self.state_columns * (self.rounds_count + 1)
@@ -340,20 +340,18 @@ class RijndaelBlockCipher(Cipher):
         )
         return ComponentState([round_state.id], [list(range(self.block_bit_size))])
 
-    def _emit_round_output(self, state, round_index):
-        self.add_intermediate_output_component(
+    def _emit_round_output(self, state):
+        self.add_round_output_component(
             state.id,
             state.input_bit_positions,
             self.block_bit_size,
-            f"state_after_round_{round_index}",
         )
 
     def _emit_round_key_output(self, round_key):
-        self.add_intermediate_output_component(
+        self.add_round_key_output_component(
             round_key.id,
             round_key.input_bit_positions,
             self.block_bit_size,
-            "round_key_output",
         )
 
     def _emit_cipher_output(self, state):

--- a/claasp/ciphers/block_ciphers/twofish_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/twofish_block_cipher.py
@@ -308,11 +308,10 @@ class TwofishBlockCipher(Cipher):
                     self.cipher_block_size,
                 )
             else:
-                self.add_intermediate_output_component(
+                self.add_round_output_component(
                     [state[i].id for i in range(4)],
                     [list(range(32)) for _ in range(4)],
                     self.cipher_block_size,
-                    "round_output",
                 )
                 self.add_round()
 

--- a/claasp/ciphers/toys/fancy_block_cipher.py
+++ b/claasp/ciphers/toys/fancy_block_cipher.py
@@ -113,11 +113,10 @@ class FancyBlockCipher(Cipher):
                 type1_key_schedule_and = self.add_and_component_to_even_round(
                     key_bit_size, round_number, type1_key_schedule_xor, type2_key_schedule_and
                 )
-                self.add_intermediate_output_component(
+                self.add_round_key_output_component(
                     [type1_key_schedule_xor.id, type1_key_schedule_and.id],
                     [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]],
                     key_bit_size,
-                    "round_key_output",
                 )
                 constant = self.add_constant_component(block_bit_size, 0xFEDCBA)
                 type1_xor_with_key = self.add_xor_component(
@@ -137,11 +136,10 @@ class FancyBlockCipher(Cipher):
                         block_bit_size,
                     )
                 else:
-                    self.add_intermediate_output_component(
+                    self.add_round_output_component(
                         [type1_xor_with_key.id],
                         [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]],
                         block_bit_size,
-                        "round_output",
                     )
 
             else:
@@ -164,11 +162,10 @@ class FancyBlockCipher(Cipher):
                     [list(range(int(key_bit_size / 2))) for _ in range(2)],
                     int(key_bit_size / 2),
                 )
-                self.add_intermediate_output_component(
+                self.add_round_key_output_component(
                     [type2_key_schedule_xor.id, type2_key_schedule_and.id],
                     [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]],
                     key_bit_size,
-                    "round_key_output",
                 )
 
                 # Modular addition 8
@@ -251,11 +248,10 @@ class FancyBlockCipher(Cipher):
                         block_bit_size,
                     )
                 else:
-                    self.add_intermediate_output_component(
+                    self.add_round_output_component(
                         [type2_modadd1.id, type2_xor1.id, type2_modadd2.id, type2_xor2.id],
                         [[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]],
                         block_bit_size,
-                        "round_output",
                     )
 
     def add_sbox_components_layer_in_even_rounds(

--- a/claasp/ciphers/toys/toyaes_block_cipher.py
+++ b/claasp/ciphers/toys/toyaes_block_cipher.py
@@ -216,11 +216,10 @@ class ToyAESBlockCipher(Cipher):
             remaining_xors, xor1 = self.create_xor_components(
                 constant, key_sboxes_components, remaining_xors, xor1, round_number
             )
-            self.add_intermediate_output_component(
+            self.add_round_key_output_component(
                 [remaining_xors[i].id for i in range(self.num_rows)],
                 [list(range(self.row_size)) for _ in range(self.num_rows)],
                 self.key_block_size,
-                "round_key_output",
             )
             add_round_key = self.create_round_key(
                 mix_column_components, remaining_xors, round_number, shift_row_components
@@ -387,7 +386,7 @@ class ToyAESBlockCipher(Cipher):
                 [add_round_key.id], [list(range(self.cipher_block_size))], self.cipher_block_size
             )
         else:
-            self.add_intermediate_output_component(
-                [add_round_key.id], [list(range(self.cipher_block_size))], self.cipher_block_size, "round_output"
+            self.add_round_output_component(
+                [add_round_key.id], [list(range(self.cipher_block_size))], self.cipher_block_size
             )
             self.add_round()


### PR DESCRIPTION
This PR improves consistency across ciphers by using the dedicated `add_round_output_component` and `add_round_key_output_component` methods for round outputs and round keys, replacing `add_intermediate_output_component` calls that relied on a manual tag.