### PR TITLE
FIX: handle parallel thread output ordering in parkissat

### DIFF
--- a/claasp/cipher_modules/models/sat/solvers.py
+++ b/claasp/cipher_modules/models/sat/solvers.py
@@ -176,7 +176,7 @@ SAT_SOLVERS_EXTERNAL = [
         "keywords": {
             "command": {
                 "executable": "parkissat",
-                "options": ["-shr-sleep=500000", "-shr-lit=1500", "-initshuffle"],
+                "options": ["-c=1", "-shr-sleep=500000", "-shr-lit=1500", "-initshuffle"],
                 "input_file": "",
                 "solve": "",
                 "output_file": "",

--- a/claasp/cipher_modules/models/sat/utils/utils.py
+++ b/claasp/cipher_modules/models/sat/utils/utils.py
@@ -832,15 +832,22 @@ def run_parkissat(solver_specs, options, dimacs_input, input_file_name):
     solver_output = solver_process.stdout.splitlines()
     solver_time = end - start
     solver_memory = 0
-    status = solver_output[0].split()[1]
+    # ParKissat is a parallel solver: comment lines (c ...) may appear before the
+    # status line in any order depending on thread scheduling.
+    status_line = next((line for line in solver_output if line.startswith("s ")), None)
+    if status_line is None:
+        raise RuntimeError(
+            f"parkissat produced no status line.\n"
+            f"stdout: {solver_process.stdout[:500]}\n"
+            f"stderr: {solver_process.stderr[:500]}"
+        )
+    status = status_line.split()[1]
     values = ""
     if status == "SATISFIABLE":
-        solver_output = solver_output[1:]
-        solver_output = [s.replace("v ", "") for s in solver_output]
+        value_lines = [line[2:] for line in solver_output if line.startswith("v ")]
         values = []
-        for element in solver_output:
-            substrings = element.split()
-            values.extend(substrings)
+        for element in value_lines:
+            values.extend(element.split())
     os.remove(input_file_name)
 
     return status, solver_time, solver_memory, values


### PR DESCRIPTION
## Summary

- Fix `run_parkissat` to scan for the status line (`s ...`) instead of assuming `solver_output[0]` is it — parallel worker threads emit comment lines (`c ...`) in non-deterministic order before the status line
- Filter value lines by `v ` prefix rather than relying on position after the status line
- Add a clear `RuntimeError` if no status line is found
- Add `-c=1` to the default parkissat command options

## Test plan

- [x] Run a SAT model with parkissat solver and verify it returns a result without crashing
- [x] Run `pytest -v tests/` to check no regressions