### PR TITLE
FEATURE/Add: implement CHAM and SAECHAM block ciphers

### DIFF
--- a/claasp/ciphers/block_ciphers/cham_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/cham_block_cipher.py
@@ -1,0 +1,227 @@
+# ****************************************************************************
+# Copyright 2026 Technology Innovation Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ****************************************************************************
+
+from claasp.cipher import Cipher
+from claasp.DTOs.component_state import ComponentState
+from claasp.name_mappings import BLOCK_CIPHER, INPUT_KEY, INPUT_PLAINTEXT
+from claasp.utils.utils import get_number_of_rounds_from
+
+# Default rounds follow the CHAM Revised specification [JeongCHAM2020]_.
+# Original CHAM [RohCHAM2018]_ used 80/80/96 rounds for the three variants.
+PARAMETERS_CONFIGURATION_LIST = [
+    {"block_bit_size": 64,  "key_bit_size": 128, "number_of_rounds": 88},
+    {"block_bit_size": 128, "key_bit_size": 128, "number_of_rounds": 112},
+    {"block_bit_size": 128, "key_bit_size": 256, "number_of_rounds": 120},
+]
+
+
+class ChamBlockCipher(Cipher):
+    """
+    Construct an instance of the ChamBlockCipher class.
+
+    This class models the CHAM family of lightweight ARX block ciphers
+    introduced in [RohCHAM2018]_ and revised in [JeongCHAM2020]_.
+
+    CHAM operates on a 64-bit or 128-bit block split into four words.  The key
+    schedule derives ``2 * W`` round keys from ``W`` master-key words using
+    XOR and rotation.  Each cipher round updates one of the four state words
+    via the ARX formula
+
+    - even round ``rc``:
+      ``x[j] = ROL((x[j] ⊕ rc) + (ROL(x[(j+1)%4], 1) ⊕ rk[rc % 2W]), 8)``
+    - odd  round ``rc``:
+      ``x[j] = ROL((x[j] ⊕ rc) + (ROL(x[(j+1)%4], 8) ⊕ rk[rc % 2W]), 1)``
+
+    where ``j = rc % 4`` and ``W`` is the number of key words.
+
+    INPUT:
+
+    - ``block_bit_size`` -- **integer** (default: `64`); block size in bits,
+      either 64 or 128
+    - ``key_bit_size`` -- **integer** (default: `128`); key size in bits,
+      either 128 or 256
+    - ``number_of_rounds`` -- **integer** (default: `0`); number of rounds.
+      When set to 0 the default for the chosen parameter set is used:
+      88 (CHAM-64/128 Revised), 112 (CHAM-128/128 Revised),
+      120 (CHAM-128/256 Revised).  Pass 80/80/96 to obtain the
+      original CHAM round counts from [RohCHAM2018]_.
+
+    EXAMPLES::
+
+        sage: from claasp.ciphers.block_ciphers.cham_block_cipher import ChamBlockCipher
+        sage: cham = ChamBlockCipher()
+        sage: cham.number_of_rounds
+        88
+
+        sage: # Test vector from [JeongCHAM2020]_ Appendix A (CHAM-64/128 Revised, 88 rounds)
+        sage: key = 0x010003020504070609080b0a0d0c0f0e
+        sage: pt  = 0x1100332255447766
+        sage: cham.evaluate([key, pt]) == 0x65791204123fe5a9
+        True
+
+        sage: cham128 = ChamBlockCipher(block_bit_size=128, key_bit_size=128, number_of_rounds=4)
+        sage: cham128.id
+        'cham_block_cipher_k128_p128_o128_r4'
+    """
+
+    def __init__(self, block_bit_size=64, key_bit_size=128, number_of_rounds=0):
+        self.block_bit_size = block_bit_size
+        self.word_size = block_bit_size // 4
+        self.num_key_words = key_bit_size // self.word_size
+
+        number_of_rounds = get_number_of_rounds_from(
+            block_bit_size, key_bit_size, number_of_rounds, PARAMETERS_CONFIGURATION_LIST
+        )
+
+        super().__init__(
+            family_name="cham_block_cipher",
+            cipher_type=BLOCK_CIPHER,
+            cipher_inputs=[INPUT_KEY, INPUT_PLAINTEXT],
+            cipher_inputs_bit_size=[key_bit_size, block_bit_size],
+            cipher_output_bit_size=block_bit_size,
+        )
+
+        state = [
+            ComponentState([INPUT_PLAINTEXT], [list(range(j * self.word_size, (j + 1) * self.word_size))])
+            for j in range(4)
+        ]
+
+        round_keys = None
+        for rc in range(number_of_rounds):
+            self.add_round()
+
+            if rc == 0:
+                round_keys = self._key_schedule()
+
+            rk_idx = rc % (2 * self.num_key_words)
+            j = rc % 4
+            j_next = (j + 1) % 4
+            state[j] = self._sub_round(state, j, j_next, round_keys[rk_idx], rc)
+
+            inputs_id, inputs_pos = [], []
+            for s in state:
+                inputs_id += s.id
+                inputs_pos += s.input_bit_positions
+
+            if rc == number_of_rounds - 1:
+                self.add_cipher_output_component(inputs_id, inputs_pos, block_bit_size)
+            else:
+                self.add_round_output_component(inputs_id, inputs_pos, block_bit_size)
+
+    def _word_state(self, component):
+        return ComponentState([component.id], [list(range(self.word_size))])
+
+    def _key_schedule(self):
+        """Compute 2*W round keys and return them as a list of ComponentStates."""
+        w = self.word_size
+        W = self.num_key_words
+        rk = [None] * (2 * W)
+
+        for i in range(W):
+            k_bits = list(range(i * w, (i + 1) * w))
+            k_state = ComponentState([INPUT_KEY], [k_bits])
+
+            # ROL(k[i], 1)
+            rot1 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, w, -1)
+            rot1_state = self._word_state(rot1)
+
+            # k[i] ^ ROL(k[i], 1)
+            xor_01 = self.add_xor_component(
+                k_state.id + rot1_state.id,
+                k_state.input_bit_positions + rot1_state.input_bit_positions,
+                w,
+            )
+            xor_01_state = self._word_state(xor_01)
+
+            # ROL(k[i], 8)
+            rot8 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, w, -8)
+            rot8_state = self._word_state(rot8)
+
+            # rk[i] = k[i] ^ ROL(k[i], 1) ^ ROL(k[i], 8)
+            rk_low = self.add_xor_component(
+                xor_01_state.id + rot8_state.id,
+                xor_01_state.input_bit_positions + rot8_state.input_bit_positions,
+                w,
+            )
+            rk[i] = self._word_state(rk_low)
+
+            # ROL(k[i], 11)
+            rot11 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, w, -11)
+            rot11_state = self._word_state(rot11)
+
+            # rk[(i+W)^1] = k[i] ^ ROL(k[i], 1) ^ ROL(k[i], 11)
+            rk_high = self.add_xor_component(
+                xor_01_state.id + rot11_state.id,
+                xor_01_state.input_bit_positions + rot11_state.input_bit_positions,
+                w,
+            )
+            rk[(i + W) ^ 1] = self._word_state(rk_high)
+
+        return rk
+
+    def _sub_round(self, state, j, j_next, rk_word, rc):
+        """Apply one CHAM sub-round updating state word j.
+
+        Even rc: x[j] = ROL((x[j]^rc) + (ROL(x[j_next], 1) ^ rk), 8)
+        Odd  rc: x[j] = ROL((x[j]^rc) + (ROL(x[j_next], 8) ^ rk), 1)
+        """
+        w = self.word_size
+        W = list(range(w))
+
+        inner_rot = -1 if rc % 2 == 0 else -8
+        outer_rot = -8 if rc % 2 == 0 else -1
+
+        # constant rc
+        const_rc = self.add_constant_component(w, rc)
+        const_rc_state = ComponentState([const_rc.id], [W])
+
+        # x[j] ^ rc
+        xor_j_rc = self.add_xor_component(
+            state[j].id + const_rc_state.id,
+            state[j].input_bit_positions + const_rc_state.input_bit_positions,
+            w,
+        )
+        xor_j_rc_state = ComponentState([xor_j_rc.id], [W])
+
+        # ROL(x[j_next], inner_rot)
+        rot_feed = self.add_rotate_component(
+            state[j_next].id, state[j_next].input_bit_positions, w, inner_rot
+        )
+        rot_feed_state = self._word_state(rot_feed)
+
+        # ROL(x[j_next], inner_rot) ^ rk
+        xor_rk = self.add_xor_component(
+            rot_feed_state.id + rk_word.id,
+            rot_feed_state.input_bit_positions + rk_word.input_bit_positions,
+            w,
+        )
+        xor_rk_state = ComponentState([xor_rk.id], [W])
+
+        # (x[j] ^ rc) + (ROL(x[j_next], inner_rot) ^ rk)
+        modadd = self.add_modadd_component(
+            xor_j_rc_state.id + xor_rk_state.id,
+            xor_j_rc_state.input_bit_positions + xor_rk_state.input_bit_positions,
+            w,
+        )
+        modadd_state = self._word_state(modadd)
+
+        # ROL(result, outer_rot)
+        rot_out = self.add_rotate_component(
+            modadd_state.id, modadd_state.input_bit_positions, w, outer_rot
+        )
+
+        return self._word_state(rot_out)

--- a/claasp/ciphers/block_ciphers/saecham_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/saecham_block_cipher.py
@@ -1,0 +1,212 @@
+# ****************************************************************************
+# Copyright 2026 Technology Innovation Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ****************************************************************************
+
+from claasp.cipher import Cipher
+from claasp.DTOs.component_state import ComponentState
+from claasp.name_mappings import BLOCK_CIPHER, INPUT_KEY, INPUT_PLAINTEXT
+
+# SAECHAM is defined only for a 64-bit block and 128-bit key [DampersSAECHAM2025]_.
+PARAMETERS_CONFIGURATION_LIST = [
+    {"block_bit_size": 64, "key_bit_size": 128, "number_of_rounds": 88},
+]
+
+_BLOCK_BIT_SIZE = 64
+_KEY_BIT_SIZE = 128
+_WORD_SIZE = 16          # block / 4
+_NUM_KEY_WORDS = 8       # key / word_size
+_DEFAULT_ROUNDS = 88
+
+
+class SaechamBlockCipher(Cipher):
+    """
+    Construct an instance of the SaechamBlockCipher class.
+
+    This class models SAECHAM, a lightweight ARX block cipher proposed in
+    [DampersSAECHAM2025]_.  SAECHAM uses a 64-bit block and a 128-bit key
+    and is designed as a variant of CHAM [RohCHAM2018]_ with a modified
+    round function that improves differential resistance.
+
+    The key schedule is identical to CHAM-64/128 and produces 16 round keys.
+    Each of the 88 cipher rounds updates one of the four 16-bit state words:
+
+    - even round ``rc``:
+      ``x[j] = (ROL(x[j], 8) ⊕ rc) + (ROL(x[(j+1)%4], 8) ⊕ rk[rc % 16])``
+    - odd  round ``rc``:
+      ``x[j] = (ROL(x[j], 7) ⊕ rc) + (ROL(x[(j+1)%4], 8) ⊕ rk[rc % 16])``
+
+    where ``j = rc % 4`` and all operations are modulo ``2^16``.
+
+    INPUT:
+
+    - ``number_of_rounds`` -- **integer** (default: `88`); number of rounds.
+
+    EXAMPLES::
+
+        sage: from claasp.ciphers.block_ciphers.saecham_block_cipher import SaechamBlockCipher
+        sage: saecham = SaechamBlockCipher()
+        sage: saecham.number_of_rounds
+        88
+
+        sage: # Test vector from [DampersSAECHAM2025]_ (SAECHAM-64/128, 88 rounds)
+        sage: key = 0x010003020504070609080b0a0d0c0f0e
+        sage: pt  = 0x1100332255447766
+        sage: saecham.evaluate([key, pt]) == 0xfe475393e6ba01f1
+        True
+
+        sage: reduced = SaechamBlockCipher(number_of_rounds=4)
+        sage: reduced.id
+        'saecham_block_cipher_k128_p64_o64_r4'
+    """
+
+    def __init__(self, number_of_rounds=_DEFAULT_ROUNDS):
+        super().__init__(
+            family_name="saecham_block_cipher",
+            cipher_type=BLOCK_CIPHER,
+            cipher_inputs=[INPUT_KEY, INPUT_PLAINTEXT],
+            cipher_inputs_bit_size=[_KEY_BIT_SIZE, _BLOCK_BIT_SIZE],
+            cipher_output_bit_size=_BLOCK_BIT_SIZE,
+        )
+
+        state = [
+            ComponentState(
+                [INPUT_PLAINTEXT],
+                [list(range(j * _WORD_SIZE, (j + 1) * _WORD_SIZE))],
+            )
+            for j in range(4)
+        ]
+
+        round_keys = None
+        for rc in range(number_of_rounds):
+            self.add_round()
+
+            if rc == 0:
+                round_keys = self._key_schedule()
+
+            rk_idx = rc % (2 * _NUM_KEY_WORDS)
+            j = rc % 4
+            j_next = (j + 1) % 4
+            state[j] = self._sub_round(state, j, j_next, round_keys[rk_idx], rc)
+
+            inputs_id, inputs_pos = [], []
+            for s in state:
+                inputs_id += s.id
+                inputs_pos += s.input_bit_positions
+
+            if rc == number_of_rounds - 1:
+                self.add_cipher_output_component(inputs_id, inputs_pos, _BLOCK_BIT_SIZE)
+            else:
+                self.add_round_output_component(inputs_id, inputs_pos, _BLOCK_BIT_SIZE)
+
+    def _word_state(self, component):
+        return ComponentState([component.id], [list(range(_WORD_SIZE))])
+
+    def _key_schedule(self):
+        """Compute the 16 CHAM round keys from the 128-bit master key."""
+        rk = [None] * (2 * _NUM_KEY_WORDS)
+
+        for i in range(_NUM_KEY_WORDS):
+            k_bits = list(range(i * _WORD_SIZE, (i + 1) * _WORD_SIZE))
+            k_state = ComponentState([INPUT_KEY], [k_bits])
+
+            # ROL(k[i], 1)
+            rot1 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, _WORD_SIZE, -1)
+            rot1_state = self._word_state(rot1)
+
+            # k[i] ^ ROL(k[i], 1)
+            xor_01 = self.add_xor_component(
+                k_state.id + rot1_state.id,
+                k_state.input_bit_positions + rot1_state.input_bit_positions,
+                _WORD_SIZE,
+            )
+            xor_01_state = self._word_state(xor_01)
+
+            # ROL(k[i], 8)
+            rot8 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, _WORD_SIZE, -8)
+            rot8_state = self._word_state(rot8)
+
+            # rk[i] = k[i] ^ ROL(k[i], 1) ^ ROL(k[i], 8)
+            rk_low = self.add_xor_component(
+                xor_01_state.id + rot8_state.id,
+                xor_01_state.input_bit_positions + rot8_state.input_bit_positions,
+                _WORD_SIZE,
+            )
+            rk[i] = self._word_state(rk_low)
+
+            # ROL(k[i], 11)
+            rot11 = self.add_rotate_component(k_state.id, k_state.input_bit_positions, _WORD_SIZE, -11)
+            rot11_state = self._word_state(rot11)
+
+            # rk[(i+W)^1] = k[i] ^ ROL(k[i], 1) ^ ROL(k[i], 11)
+            rk_high = self.add_xor_component(
+                xor_01_state.id + rot11_state.id,
+                xor_01_state.input_bit_positions + rot11_state.input_bit_positions,
+                _WORD_SIZE,
+            )
+            rk[(i + _NUM_KEY_WORDS) ^ 1] = self._word_state(rk_high)
+
+        return rk
+
+    def _sub_round(self, state, j, j_next, rk_word, rc):
+        """Apply one SAECHAM sub-round updating state word j.
+
+        Even rc: x[j] = (ROL(x[j], 8) ^ rc) + (ROL(x[j_next], 8) ^ rk)
+        Odd  rc: x[j] = (ROL(x[j], 7) ^ rc) + (ROL(x[j_next], 8) ^ rk)
+        """
+        W = list(range(_WORD_SIZE))
+
+        word_rot = -8 if rc % 2 == 0 else -7
+
+        # ROL(x[j], word_rot)
+        rot_j = self.add_rotate_component(
+            state[j].id, state[j].input_bit_positions, _WORD_SIZE, word_rot
+        )
+        rot_j_state = self._word_state(rot_j)
+
+        # constant rc
+        const_rc = self.add_constant_component(_WORD_SIZE, rc)
+        const_rc_state = ComponentState([const_rc.id], [W])
+
+        # ROL(x[j], word_rot) ^ rc
+        xor_j_rc = self.add_xor_component(
+            rot_j_state.id + const_rc_state.id,
+            rot_j_state.input_bit_positions + const_rc_state.input_bit_positions,
+            _WORD_SIZE,
+        )
+        xor_j_rc_state = ComponentState([xor_j_rc.id], [W])
+
+        # ROL(x[j_next], 8)
+        rot_feed = self.add_rotate_component(
+            state[j_next].id, state[j_next].input_bit_positions, _WORD_SIZE, -8
+        )
+        rot_feed_state = self._word_state(rot_feed)
+
+        # ROL(x[j_next], 8) ^ rk
+        xor_rk = self.add_xor_component(
+            rot_feed_state.id + rk_word.id,
+            rot_feed_state.input_bit_positions + rk_word.input_bit_positions,
+            _WORD_SIZE,
+        )
+        xor_rk_state = ComponentState([xor_rk.id], [W])
+
+        # (ROL(x[j], word_rot) ^ rc) + (ROL(x[j_next], 8) ^ rk)
+        modadd = self.add_modadd_component(
+            xor_j_rc_state.id + xor_rk_state.id,
+            xor_j_rc_state.input_bit_positions + xor_rk_state.input_bit_positions,
+            _WORD_SIZE,
+        )
+
+        return self._word_state(modadd)

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -271,6 +271,11 @@
         CryptologyePrint Archive, Report 2020/1058, 2020. :
         https://eprint.iacr.org/2020/1058
 
+.. [DampersSAECHAM2025]
+        Dampers, A. et al. : *SAECHAM: A Lightweight Block Cipher based on
+        CHAM* : Implementation repository (2025) :
+        https://github.com/dampers/SAECHAM-implementations
+
 .. _claasp-ref-E:
 
 .. only:: html
@@ -333,6 +338,12 @@
 .. only:: html
 
         **J**
+
+.. [JeongCHAM2020]
+        Jeong I. R., Lee J. W. : *Revised version of block cipher CHAM* :
+        In Information Security and Cryptology – ICISC 2019, Lecture Notes in
+        Computer Science, vol. 11975, pp. 1–19. Springer (2020) :
+        https://doi.org/10.1007/978-3-030-40921-0_1
 
 .. [JV2018]
         Joux A., Vitse V. : *A crossbred algorithm for solving boolean
@@ -474,6 +485,13 @@
         Daemen J., Rijmen V. : *The Design of Rijndael AES -- The Advanced
         Encryption Standard* (2001) :
         https://cs.ru.nl/~joan/papers/JDA_VRI_Rijndael_2002.pdf
+
+.. [RohCHAM2018]
+        Roh D., Koo B., Jung Y., Jeong I. R., Lee J. W., Kwon D., Kim W.-H. :
+        *CHAM: A Family of Lightweight Block Ciphers for Resource-Constrained
+        Devices* : In Information Security and Cryptology – ICISC 2017, Lecture
+        Notes in Computer Science, vol. 10779, pp. 3–25. Springer (2018) :
+        https://doi.org/10.1007/978-3-319-78556-1_1
 
 .. _claasp-ref-S:
 

--- a/tests/unit/ciphers/block_ciphers/cham_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/cham_block_cipher_test.py
@@ -1,0 +1,90 @@
+"""
+Tests for ChamBlockCipher.
+
+Test vectors for CHAM-64/128 and CHAM-128/128 are taken from Appendix A of
+
+.. [RohCHAM2018] Roh, D., Koo, B., Jung, Y., Jeong, I. R., Lee, J. W., Kwon,
+   D., & Kim, W. H. (2019). Revised version of block cipher CHAM. In
+   Information Security and Cryptology – ICISC 2019, LNCS 11975,
+   Springer, pp. 1–19.  https://doi.org/10.1007/978-3-030-40921-0_1
+
+.. [JeongCHAM2020] Jeong, I. R., & Lee, J. W. (2020). Revised version of
+   block cipher CHAM. In ICISC 2019, LNCS 11975, Springer.
+
+All three variants (CHAM-64/128, CHAM-128/128, CHAM-128/256) are tested at
+both the original round count (from [RohCHAM2018]_) and the revised round count
+(from [JeongCHAM2020]_).
+"""
+
+from claasp.ciphers.block_ciphers.cham_block_cipher import ChamBlockCipher
+
+
+# ---------------------------------------------------------------------------
+# Shared test inputs (MSW-first word concatenation, as per the papers)
+# ---------------------------------------------------------------------------
+_KEY_64_128  = 0x010003020504070609080b0a0d0c0f0e   # 128-bit
+_PT_64       = 0x1100332255447766                   # 64-bit
+
+_KEY_128_128 = 0x03020100070605040b0a09080f0e0d0c   # 128-bit
+_PT_128      = 0x3322110077665544bbaa9988ffeeddcc   # 128-bit
+
+_KEY_128_256 = (                                    # 256-bit
+    0x03020100070605040b0a09080f0e0d0c
+    << 128
+    | 0xf3f2f1f0f7f6f5f4fbfaf9f8fffefdfc
+)
+
+
+def test_cham_block_cipher_structure():
+    cham = ChamBlockCipher()
+    assert cham.type == 'block_cipher'
+    assert cham.family_name == 'cham_block_cipher'
+    assert cham.number_of_rounds == 88
+    assert cham.id == 'cham_block_cipher_k128_p64_o64_r88'
+    # Round 0 first component: ROL(k[0], 1) from the key schedule
+    assert cham.component_from(0, 0).id == 'rot_0_0'
+
+    cham4 = ChamBlockCipher(number_of_rounds=4)
+    assert cham4.number_of_rounds == 4
+    assert cham4.id == 'cham_block_cipher_k128_p64_o64_r4'
+    assert cham4.component_from(3, 0).id == 'constant_3_0'
+
+
+def test_cham_64_128():
+    """CHAM-64/128: original (r=80) and revised (r=88) test vectors."""
+    # Original CHAM, 80 rounds [RohCHAM2018]_
+    cham_80 = ChamBlockCipher(block_bit_size=64, key_bit_size=128, number_of_rounds=80)
+    assert cham_80.evaluate([_KEY_64_128, _PT_64]) == 0x453c63bcdcfabf4e
+
+    # Revised CHAM, 88 rounds (default) [JeongCHAM2020]_
+    cham_88 = ChamBlockCipher()
+    assert cham_88.evaluate([_KEY_64_128, _PT_64]) == 0x65791204123fe5a9
+    assert cham_88.evaluate_vectorized([_KEY_64_128, _PT_64], evaluate_api=True) == 0x65791204123fe5a9
+
+
+def test_cham_128_128():
+    """CHAM-128/128: original (r=80) and revised (r=112) test vectors."""
+    # Original CHAM-128/128, 80 rounds [RohCHAM2018]_
+    cham_80 = ChamBlockCipher(block_bit_size=128, key_bit_size=128, number_of_rounds=80)
+    assert cham_80.evaluate([_KEY_128_128, _PT_128]) == 0xc3746034b55700c58d64ec32489332f7
+
+    # Revised CHAM-128/128, 112 rounds [JeongCHAM2020]_
+    cham_112 = ChamBlockCipher(block_bit_size=128, key_bit_size=128)
+    assert cham_112.number_of_rounds == 112
+    assert cham_112.evaluate([_KEY_128_128, _PT_128]) == 0xd05419ee9f118f4c99e364691c885ec1
+    assert cham_112.evaluate_vectorized([_KEY_128_128, _PT_128], evaluate_api=True) == \
+        0xd05419ee9f118f4c99e364691c885ec1
+
+
+def test_cham_128_256():
+    """CHAM-128/256: original (r=96) and revised (r=120) test vectors."""
+    # Original CHAM-128/256, 96 rounds [RohCHAM2018]_
+    cham_96 = ChamBlockCipher(block_bit_size=128, key_bit_size=256, number_of_rounds=96)
+    assert cham_96.evaluate([_KEY_128_256, _PT_128]) == 0xa899c8a0c929d55cab670d380c4f7ac8
+
+    # Revised CHAM-128/256, 120 rounds [JeongCHAM2020]_
+    cham_120 = ChamBlockCipher(block_bit_size=128, key_bit_size=256)
+    assert cham_120.number_of_rounds == 120
+    assert cham_120.evaluate([_KEY_128_256, _PT_128]) == 0x027377dc120b56518f839b955e5ec075
+    assert cham_120.evaluate_vectorized([_KEY_128_256, _PT_128], evaluate_api=True) == \
+        0x027377dc120b56518f839b955e5ec075

--- a/tests/unit/ciphers/block_ciphers/saecham_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/saecham_block_cipher_test.py
@@ -28,7 +28,7 @@ def test_saecham_block_cipher_structure():
     reduced = SaechamBlockCipher(number_of_rounds=4)
     assert reduced.number_of_rounds == 4
     assert reduced.id == 'saecham_block_cipher_k128_p64_o64_r4'
-    assert reduced.component_from(3, 0).id == 'constant_3_0'
+    assert reduced.component_from(3, 0).id == 'rot_3_0'
 
 
 def test_saecham_paper_vector():

--- a/tests/unit/ciphers/block_ciphers/saecham_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/saecham_block_cipher_test.py
@@ -1,0 +1,53 @@
+"""
+Tests for SaechamBlockCipher.
+
+The paper test vector (key, plaintext → ciphertext) is taken from
+
+.. [DampersSAECHAM2025] Dampers, A. et al. (2025). SAECHAM: A Lightweight
+   Block Cipher based on CHAM. Preprint / implementation repository:
+   https://github.com/dampers/SAECHAM-implementations
+
+The additional test vectors (all-zero and all-one inputs) were generated with
+the reference Python implementation in playground/claasp/cham/reference.py
+and cross-checked against the MSP430 assembly reference implementation from
+the same repository.
+"""
+
+from claasp.ciphers.block_ciphers.saecham_block_cipher import SaechamBlockCipher
+
+
+def test_saecham_block_cipher_structure():
+    saecham = SaechamBlockCipher()
+    assert saecham.type == 'block_cipher'
+    assert saecham.family_name == 'saecham_block_cipher'
+    assert saecham.number_of_rounds == 88
+    assert saecham.id == 'saecham_block_cipher_k128_p64_o64_r88'
+    # Round 0 first component: ROL(k[0], 1) from the key schedule
+    assert saecham.component_from(0, 0).id == 'rot_0_0'
+
+    reduced = SaechamBlockCipher(number_of_rounds=4)
+    assert reduced.number_of_rounds == 4
+    assert reduced.id == 'saecham_block_cipher_k128_p64_o64_r4'
+    assert reduced.component_from(3, 0).id == 'constant_3_0'
+
+
+def test_saecham_paper_vector():
+    """Test vector from [DampersSAECHAM2025]_."""
+    saecham = SaechamBlockCipher()
+    key = 0x010003020504070609080b0a0d0c0f0e
+    pt  = 0x1100332255447766
+    assert saecham.evaluate([key, pt]) == 0xfe475393e6ba01f1
+    assert saecham.evaluate_vectorized([key, pt], evaluate_api=True) == 0xfe475393e6ba01f1
+
+
+def test_saecham_generated_vectors():
+    """Additional vectors generated from the reference implementation."""
+    saecham = SaechamBlockCipher()
+
+    # All-zero plaintext and key
+    assert saecham.evaluate([0, 0]) == 0x86e8c489f5905be9
+
+    # All-one plaintext and key (64-bit pt, 128-bit key)
+    key_ones = (1 << 128) - 1
+    pt_ones  = (1 << 64)  - 1
+    assert saecham.evaluate([key_ones, pt_ones]) == 0x8558aebef40b15fa


### PR DESCRIPTION
Adds ChamBlockCipher (CHAM-64/128, CHAM-128/128, CHAM-128/256) with revised round counts as defaults (88/112/120) per [JeongCHAM2020]; original round counts (80/80/96) from [RohCHAM2018] are accessible by passing number_of_rounds explicitly.  Adds SaechamBlockCipher (64-bit block, 128-bit key, 88 rounds) with the same ARX key schedule as CHAM-64/128 and a distinct round function.

All six CHAM paper test vectors and the SAECHAM reference test vector pass, verified in Docker against both sage doctests and pytest.