### PR TITLE
FEATURE: support native arm64 builds in Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ rundockerhub:
 builddocker-m1:
 	docker build -f docker/Dockerfile --platform linux/x86_64 --target claasp-base -t $(DOCKER_IMG_NAME) .
 
+builddocker-native-m1:
+	docker build -f docker/Dockerfile --platform linux/arm64 --target claasp-base -t $(DOCKER_IMG_NAME) .
+
 rundocker-m1: builddocker-m1
 	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,18 @@ rundockerhub:
 	docker run -i -p 8887:8887 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 
-builddocker-m1:
+# Build for x86_64/amd64. On an arm64 host (e.g. Apple Silicon) this image runs
+# under QEMU emulation, which is slower but ensures full compatibility with
+# x86_64-only dependencies (e.g. MathSat).
+builddocker-x86_64:
 	docker build -f docker/Dockerfile --platform linux/x86_64 --target claasp-base -t $(DOCKER_IMG_NAME) .
 
-builddocker-native-m1:
+# Build for arm64. Runs natively on arm64 hosts (e.g. Apple Silicon); on an
+# x86_64 host this image runs under QEMU emulation.
+builddocker-arm64:
 	docker build -f docker/Dockerfile --platform linux/arm64 --target claasp-base -t $(DOCKER_IMG_NAME) .
 
-rundocker-m1: builddocker-m1
+rundocker-m1: builddocker-x86_64
 	docker run -i -p 8888:8888 --mount type=bind,source=`pwd`,target=/home/sage/tii-claasp -t $(DOCKER_IMG_NAME) \
 	sh -c "cd /home/sage/tii-claasp && make install && cd /home/sage/tii-claasp && exec /bin/bash"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,10 +143,21 @@ RUN cd /opt/sts-2.1.2/sts-2.1.2 \
 
 
 # Installing Minizinc
-RUN wget https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.4/MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz \
-    && pwd && tar -xf MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz 
-RUN mv MiniZincIDE-2.9.4-bundle-linux-x86_64 /MiniZinc \
-    && rm MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz
+# No official Linux arm64 bundle exists for 2.9.4, so on arm64 we build from source
+# and install under /MiniZinc to keep all downstream path references identical.
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        wget https://github.com/MiniZinc/libminizinc/archive/refs/tags/2.9.4.tar.gz \
+        && tar -xf 2.9.4.tar.gz \
+        && rm 2.9.4.tar.gz \
+        && cmake -B libminizinc-2.9.4/build -S libminizinc-2.9.4 -DCMAKE_INSTALL_PREFIX=/MiniZinc \
+        && cmake --build libminizinc-2.9.4/build -j$(nproc) \
+        && cmake --install libminizinc-2.9.4/build; \
+    else \
+        wget https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.4/MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz \
+        && tar -xf MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz \
+        && mv MiniZincIDE-2.9.4-bundle-linux-x86_64 /MiniZinc \
+        && rm MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz; \
+    fi
 
 # Copy all MiniZinc components to system locations
 RUN cp /MiniZinc/bin/* /usr/local/bin/
@@ -259,10 +270,12 @@ RUN cd glucose-syrup/parallel \
 
 ENV PATH="/opt/glucose-syrup/simp:/opt/glucose-syrup/parallel:${PATH}"
 
-# Installing MathSat
-RUN wget https://mathsat.fbk.eu/release/mathsat-5.6.11-linux-x86_64.tar.gz \
-    && tar -xf mathsat-5.6.11-linux-x86_64.tar.gz \
-    && rm mathsat-5.6.11-linux-x86_64.tar.gz
+# Installing MathSat (x86_64 only — no Linux arm64 binary available from the vendor)
+RUN if [ "$TARGETARCH" != "arm64" ]; then \
+        wget https://mathsat.fbk.eu/release/mathsat-5.6.11-linux-x86_64.tar.gz \
+        && tar -xf mathsat-5.6.11-linux-x86_64.tar.gz \
+        && rm mathsat-5.6.11-linux-x86_64.tar.gz; \
+    fi
 
 ENV PATH="/opt/mathsat-5.6.11-linux-x86_64/bin:${PATH}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -151,7 +151,8 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         && rm 2.9.4.tar.gz \
         && cmake -B libminizinc-2.9.4/build -S libminizinc-2.9.4 -DCMAKE_INSTALL_PREFIX=/MiniZinc \
         && cmake --build libminizinc-2.9.4/build -j$(nproc) \
-        && cmake --install libminizinc-2.9.4/build; \
+        && cmake --install libminizinc-2.9.4/build \
+        && rm -rf libminizinc-2.9.4; \
     else \
         wget https://github.com/MiniZinc/MiniZincIDE/releases/download/2.9.4/MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz \
         && tar -xf MiniZincIDE-2.9.4-bundle-linux-x86_64.tgz \
@@ -274,10 +275,9 @@ ENV PATH="/opt/glucose-syrup/simp:/opt/glucose-syrup/parallel:${PATH}"
 RUN if [ "$TARGETARCH" != "arm64" ]; then \
         wget https://mathsat.fbk.eu/release/mathsat-5.6.11-linux-x86_64.tar.gz \
         && tar -xf mathsat-5.6.11-linux-x86_64.tar.gz \
-        && rm mathsat-5.6.11-linux-x86_64.tar.gz; \
+        && rm mathsat-5.6.11-linux-x86_64.tar.gz \
+        && ln -sf /opt/mathsat-5.6.11-linux-x86_64/bin/* /usr/local/bin/; \
     fi
-
-ENV PATH="/opt/mathsat-5.6.11-linux-x86_64/bin:${PATH}"
 
 # Installing Minisat
 RUN wget https://github.com/stp/minisat/archive/refs/tags/releases/2.2.1.zip \
@@ -314,15 +314,17 @@ RUN cd cadical-rel-1.5.3 \
 ENV PATH="/opt/cadical-rel-1.5.3/build:${PATH}"
 
 # Installing Yices
+# The build output directory name is derived from the host triple (e.g.
+# x86_64-pc-linux-gnu-release or aarch64-unknown-linux-gnu-release), so we
+# symlink the built binaries into /usr/local/bin instead of hard-coding it.
 RUN wget https://github.com/SRI-CSL/yices2/archive/refs/tags/yices-2.7.0.tar.gz \
     && tar -xf yices-2.7.0.tar.gz \
     && rm yices-2.7.0.tar.gz \
     && cd yices2-yices-2.7.0 \
     && autoconf \
     && ./configure --enable-thread-safety \
-    && make -j4
-
-ENV PATH="/opt/yices2-yices-2.7.0/build/x86_64-pc-linux-gnu-release/dist/bin:${PATH}"
+    && make -j4 \
+    && ln -sf /opt/yices2-yices-2.7.0/build/*/dist/bin/* /usr/local/bin/
 
 COPY required_dependencies/sage_numerical_backends_gurobi-9.3.1.tar.gz /opt/
 RUN cd /opt/ && sage -pip install sage_numerical_backends_gurobi-9.3.1.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -211,6 +211,53 @@ RUN echo '\
 }\
 ' > /usr/local/share/minizinc/solvers/choco.msc
 
+# Installing OR-Tools (CP-SAT backend for MiniZinc)
+# Google ships one release tarball per platform; each already bundles a
+# MiniZinc solver descriptor, but under an id/tags that don't match the
+# "cp-sat" name claasp uses everywhere (see cipher_modules/models/cp/solvers.py),
+# so we register our own descriptor pointing at the extracted files instead.
+ARG ORTOOLS_VERSION=9.9.3963
+RUN set -eux; \
+    cd /opt; \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -q "https://github.com/google/or-tools/releases/download/v9.9/or-tools_arm64_debian-11_cpp_v${ORTOOLS_VERSION}.tar.gz" -O or-tools.tar.gz; \
+        tar -xzf or-tools.tar.gz; \
+        rm or-tools.tar.gz; \
+        mv "or-tools_aarch64_Debian-11_cpp_v${ORTOOLS_VERSION}" or-tools; \
+    else \
+        wget -q "https://github.com/google/or-tools/releases/download/v9.9/or-tools_amd64_ubuntu-22.04_cpp_v${ORTOOLS_VERSION}.tar.gz" -O or-tools.tar.gz; \
+        tar -xzf or-tools.tar.gz; \
+        rm or-tools.tar.gz; \
+        mv "or-tools_x86_64_Ubuntu-22.04_cpp_v${ORTOOLS_VERSION}" or-tools; \
+    fi; \
+    cp /opt/or-tools/bin/fzn-cp-sat /usr/local/bin/; \
+    chmod +x /usr/local/bin/fzn-cp-sat; \
+    mkdir -p /usr/local/lib/or-tools; \
+    cp /opt/or-tools/lib/*.so* /usr/local/lib/or-tools/; \
+    echo "/usr/local/lib/or-tools" > /etc/ld.so.conf.d/or-tools.conf; \
+    ldconfig; \
+    mkdir -p /usr/local/share/minizinc/cpsat; \
+    cp -r /opt/or-tools/share/minizinc/cpsat/* /usr/local/share/minizinc/cpsat/; \
+    rm -rf /opt/or-tools
+
+RUN mkdir -p /usr/local/share/minizinc/solvers \
+  && printf '%s\n' \
+  '{' \
+  '  "name": "OR-Tools CP-SAT",' \
+  "  \"version\": \"${ORTOOLS_VERSION}\"," \
+  '  "id": "cp-sat",' \
+  '  "executable": "/usr/local/bin/fzn-cp-sat",' \
+  '  "mznlib": "/usr/local/share/minizinc/cpsat",' \
+  '  "tags": ["cp-sat", "ortools", "cp", "int", "lcg"],' \
+  '  "stdFlags": ["-a", "-f", "-p", "-r", "-s", "-v"],' \
+  '  "supportsMzn": false,' \
+  '  "supportsFzn": true,' \
+  '  "needsSolns2Out": true,' \
+  '  "needsMznExecutable": false,' \
+  '  "needsStdlibDir": false,' \
+  '  "isGUIApplication": false' \
+  '}' > /usr/local/share/minizinc/solvers/cp-sat.msc
+
 # Installing CryptoMiniSat
 # explicit commits are used instead of releases because
 # no semantic versioning is used for cadical and cadiback


### PR DESCRIPTION
## Summary

- Make `docker/Dockerfile` architecture-aware for arm64 (Apple Silicon / M1/M2/M3) builds, following the same pattern already used for Gurobi
- **MiniZinc**: no official Linux arm64 bundle exists for 2.9.4, so on arm64 `libminizinc` is built from source with `cmake` and installed under `/MiniZinc` to keep all downstream path references identical to the x86_64 bundle layout
- **MathSat**: skipped on arm64 with a comment — no Linux arm64 binary is available from the vendor
- Add `builddocker-native-m1` Makefile target (`--platform linux/arm64`) alongside the existing emulated `builddocker-m1` (`--platform linux/x86_64`)

## Test plan

- [ ] Run `make builddocker-native-m1` on an Apple Silicon Mac and verify the image builds without errors
- [ ] Confirm no emulation warning in Docker Desktop for the resulting image
- [ ] Verify `minizinc --version` works inside the container
- [ ] Run `make builddocker-m1` and confirm x86_64 build still works unchanged