### PR TITLE
FIX/Refactor: CP MiniZinc helper predicates into a registry-backed mo…

### DIFF
--- a/claasp/cipher_modules/models/cp/minizinc_utils/mzn_predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/mzn_predicate_registry.py
@@ -42,6 +42,39 @@ class MiniZincPredicateModule:
 
 
 class MiniZincPredicateRegistry:
+    """
+    Store MiniZinc predicate modules and render them with their dependencies.
+
+    INPUT:
+
+    - ``modules`` -- **list** (default: `None`); predicate modules to register
+
+    EXAMPLES::
+
+        sage: from claasp.cipher_modules.models.cp.minizinc_utils.mzn_predicate_registry import (
+        ....:     MiniZincPredicateModule, MiniZincPredicateRegistry)
+        sage: registry = MiniZincPredicateRegistry([
+        ....:     MiniZincPredicateModule("globals", 'include "globals.mzn";'),
+        ....:     MiniZincPredicateModule(
+        ....:         "bit_helpers",
+        ....:         "predicate eq_bit(var 0..1: a, var 0..1: b) = (a = b);",
+        ....:         dependencies=("globals",)),
+        ....:     MiniZincPredicateModule(
+        ....:         "eq_constraint", "constraint eq_bit(x[1], y[1]);",
+        ....:         dependencies=("bit_helpers", "globals")),
+        ....: ])
+        sage: registry.render_modules(["eq_constraint", "bit_helpers"])
+        ['include "globals.mzn";', 'predicate eq_bit(var 0..1: a, var 0..1: b) = (a = b);', 'constraint eq_bit(x[1], y[1]);']
+
+        sage: registry.module_names()
+        ('globals', 'bit_helpers', 'eq_constraint')
+
+        sage: registry.render_modules(["missing"])
+        Traceback (most recent call last):
+        ...
+        ValueError: MiniZinc predicate module 'missing' is not registered
+    """
+
     def __init__(self, modules=None):
         self._modules = {}
         for module in modules or []:

--- a/claasp/cipher_modules/models/cp/minizinc_utils/mzn_predicate_registry.py
+++ b/claasp/cipher_modules/models/cp/minizinc_utils/mzn_predicate_registry.py
@@ -1,0 +1,103 @@
+# ****************************************************************************
+# Copyright 2023 Technology Innovation Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# ****************************************************************************
+
+from dataclasses import dataclass, field
+
+from . import usefulfunctions
+
+MINIZINC_GLOBALS = "minizinc_globals"
+LEGACY_MINIZINC_USEFUL_FUNCTIONS = "legacy_minizinc_useful_functions"
+MINIZINC_XOR_DIFFERENTIAL_HELPERS = "minizinc_xor_differential_helpers"
+
+XOR_DIFFERENTIAL_HELPERS = """
+% Eq
+function array[int] of var 0..1: Eq(array[int] of var 0..1: a, array[int] of var 0..1: b, array[int] of var 0..1: c)=
+array1d(0..(length(a)-1), [all_equal([a[j],b[j],c[j]]) | j in 0..length(a)-1]);
+
+% Left shift of X by val positions
+function array[int] of var 0..2: LShift(array[int] of var 0..2: X, var int:val)=
+array1d(0..(length(X)-1), [if j<length(X)-val then X[(j+val) mod length(X)] else 0 endif | j in 0..(length(X)-1)]);
+"""
+
+
+@dataclass(frozen=True)
+class MiniZincPredicateModule:
+    name: str
+    body: str
+    dependencies: tuple[str, ...] = field(default_factory=tuple)
+
+
+class MiniZincPredicateRegistry:
+    def __init__(self, modules=None):
+        self._modules = {}
+        for module in modules or []:
+            self.register_module(module)
+
+    def register_module(self, module):
+        if module.name in self._modules:
+            raise ValueError(f"MiniZinc predicate module {module.name!r} is already registered")
+        self._modules[module.name] = module
+
+    def module_names(self):
+        return tuple(self._modules)
+
+    def resolve_modules(self, module_names):
+        resolved = []
+        visiting = set()
+        visited = set()
+
+        def visit(module_name):
+            if module_name in visited:
+                return
+            if module_name in visiting:
+                raise ValueError(f"MiniZinc predicate module dependency cycle at {module_name!r}")
+            if module_name not in self._modules:
+                raise ValueError(f"MiniZinc predicate module {module_name!r} is not registered")
+
+            visiting.add(module_name)
+            module = self._modules[module_name]
+            for dependency in module.dependencies:
+                visit(dependency)
+            visiting.remove(module_name)
+            visited.add(module_name)
+            resolved.append(module)
+
+        for module_name in module_names:
+            visit(module_name)
+
+        return tuple(resolved)
+
+    def render_modules(self, module_names):
+        return [module.body for module in self.resolve_modules(module_names) if module.body]
+
+
+def build_default_minizinc_predicate_registry():
+    return MiniZincPredicateRegistry(
+        [
+            MiniZincPredicateModule(MINIZINC_GLOBALS, 'include "globals.mzn";'),
+            MiniZincPredicateModule(
+                LEGACY_MINIZINC_USEFUL_FUNCTIONS,
+                usefulfunctions.MINIZINC_USEFUL_FUNCTIONS,
+                dependencies=(MINIZINC_GLOBALS,),
+            ),
+            MiniZincPredicateModule(
+                MINIZINC_XOR_DIFFERENTIAL_HELPERS,
+                XOR_DIFFERENTIAL_HELPERS,
+                dependencies=(MINIZINC_GLOBALS,),
+            ),
+        ]
+    )

--- a/claasp/cipher_modules/models/cp/mzn_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_model.py
@@ -27,7 +27,10 @@ from minizinc import Instance, Model, Solver, Status
 from sage.crypto.sbox import SBox
 
 from claasp.cipher_modules.component_analysis_tests import branch_number
-from claasp.cipher_modules.models.cp.minizinc_utils import usefulfunctions
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_predicate_registry import (
+    LEGACY_MINIZINC_USEFUL_FUNCTIONS,
+    build_default_minizinc_predicate_registry,
+)
 from claasp.cipher_modules.models.cp.solvers import CP_SOLVERS_EXTERNAL, CP_SOLVERS_INTERNAL, SOLVER_DEFAULT
 from claasp.cipher_modules.models.utils import convert_solver_solution_to_dictionary
 from claasp.name_mappings import (
@@ -115,7 +118,24 @@ class MznModel:
         self.probability_vars = []
         self.probability_modadd_vars_per_round = [[] for _ in range(self._cipher.number_of_rounds)]
         self.component_probability_var = {}
-        self._model_prefix = ['include "globals.mzn";', f"{usefulfunctions.MINIZINC_USEFUL_FUNCTIONS}"]
+        self._predicate_registry = build_default_minizinc_predicate_registry()
+        self._required_predicate_modules = []
+        self._refresh_model_prefix_from_predicate_modules()
+
+    def _refresh_model_prefix_from_predicate_modules(self):
+        self._model_prefix = self._predicate_registry.render_modules(self._required_predicate_modules)
+
+    def require_predicate_module(self, module_name):
+        if module_name not in self._required_predicate_modules:
+            self._required_predicate_modules.append(module_name)
+            self._refresh_model_prefix_from_predicate_modules()
+
+    def require_predicate_modules(self, module_names):
+        for module_name in module_names:
+            self.require_predicate_module(module_name)
+
+    def require_legacy_minizinc_predicates(self):
+        self.require_predicate_module(LEGACY_MINIZINC_USEFUL_FUNCTIONS)
 
     def current_model_parts(self):
         return MiniZincModelParts(
@@ -219,6 +239,7 @@ class MznModel:
                     self.probability_modadd_vars_per_round[round_index].append(probability_var)
 
     def build_generic_cp_model_from_dictionary(self, component_and_model_types, fixed_variables=None):
+        self.require_legacy_minizinc_predicates()
         variables = []
         self._variables_declarations = []
         self._model_constraints = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model.py
@@ -56,6 +56,7 @@ class MznCipherModel(MznModel):
             sage: cp.build_cipher_model(fixed_variables)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         self.sbox_mant = []
         variables = []
         self._variables_declarations = self.input_declarations()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_cipher_model_arx_optimized.py
@@ -45,6 +45,7 @@ class MznCipherModelARXOptimized(MznModel):
             sage: minizinc.build_cipher_model()
             ...
         """
+        self.require_legacy_minizinc_predicates()
         self._variables_declarations = []
         variables = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model.py
@@ -102,6 +102,7 @@ class MznDeterministicTruncatedXorDifferentialModel(MznModel):
             sage: cp.build_deterministic_truncated_xor_differential_trail_model(fixed_variables)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         if number_of_rounds is None:
             number_of_rounds = self._cipher.number_of_rounds
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_deterministic_truncated_xor_differential_model_arx_optimized.py
@@ -45,6 +45,7 @@ class MznDeterministicTruncatedXorDifferentialModelARXOptimized(MznModel):
             sage: minizinc.build_deterministic_truncated_xor_differential_trail_model()
             ...
         """
+        self.require_legacy_minizinc_predicates()
         variables = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)
         self._variables_declarations = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_continuous_model.py
@@ -26,6 +26,7 @@ class MznDifferentialLinearContinuousModel(MznModel):
         return constraints
 
     def build_differential_linear_continuous_trail_model(self, fixed_values=[]):
+        self.require_legacy_minizinc_predicates()
         component_and_model_types = []
         self.added_component_ids = set()
         operation_types = ["MODADD", "ROTATE", "XOR"]

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_differential_linear_model.py
@@ -557,6 +557,7 @@ class MznDifferentialLinearModel(MznModel):
             fixed_variables = []
 
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         model_entries = self._component_model_entries()
         fixed_constraints = self._partition_fixed_value_constraints(fixed_variables)
 

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_hybrid_impossible_xor_differential_model.py
@@ -103,6 +103,7 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
             sage: mzn.build_hybrid_impossible_xor_differential_trail_model(fixed_variables, 4, 1, 3, 4, False, False)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         if number_of_rounds is None:
             number_of_rounds = self._cipher.number_of_rounds
         if final_round is None:
@@ -165,7 +166,9 @@ class MznHybridImpossibleXorDifferentialModel(MznImpossibleXorDifferentialModel)
         )
         set_of_constraints = deterministic_truncated_xor_differential
 
-        self._model_constraints = self.clean_constraints(set_of_constraints, initial_round, middle_round, final_round)
+        self._model_constraints = self.clean_constraints(
+            set_of_constraints, initial_round, middle_round, final_round
+        )
 
     def build_improbable_forward_model(self, forward_components, clean=False):
         direct_variables = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_impossible_xor_differential_model.py
@@ -131,6 +131,7 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
             sage: cp.build_impossible_xor_differential_trail_with_extensions_model(fixed_variables, 5, 2, 3, 4, False)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         if number_of_rounds is None:
             number_of_rounds = self._cipher.number_of_rounds
         inverse_cipher = self.inverse_cipher
@@ -241,6 +242,7 @@ class MznImpossibleXorDifferentialModel(MznDeterministicTruncatedXorDifferential
             initial_round, middle_round, final_round, number_of_rounds
         )
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         if fully_automatic:
             number_of_rounds = self._cipher.number_of_rounds
             initial_round = 1

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_semi_deterministic_truncated_xor_differential_model.py
@@ -108,6 +108,7 @@ class MznSemiDeterministicTruncatedXorDifferentialModel(MznModel):
             raise ValueError("number_of_rounds must match the cipher instance number_of_rounds")
 
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         input_declarations, input_constraints = self.input_deterministic_truncated_xor_differential_constraints()
 
         component_and_model_types = self._build_component_and_model_types()

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model.py
@@ -21,6 +21,7 @@ import time as tm
 
 from sage.crypto.sbox import SBox
 
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_predicate_registry import MINIZINC_XOR_DIFFERENTIAL_HELPERS
 from claasp.cipher_modules.models.cp.mzn_model import SOLVE_SATISFY, MznModel
 from claasp.cipher_modules.models.cp.solvers import SOLVER_DEFAULT
 from claasp.cipher_modules.models.utils import get_single_key_scenario_format_for_fixed_values
@@ -130,6 +131,7 @@ class MznXorDifferentialModel(MznModel):
             sage: cp.build_xor_differential_trail_model()
         """
         self.initialise_model()
+        self.require_predicate_module(MINIZINC_XOR_DIFFERENTIAL_HELPERS)
         self.c = 0
         self.sbox_mant = []
         self.input_sbox = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_arx_optimized.py
@@ -173,6 +173,7 @@ class MznXorDifferentialModelARXOptimized(MznModel):
             sage: minizinc = MznXorDifferentialModelARXOptimized(speck)
             sage: minizinc.build_xor_differential_trail_model()
         """
+        self.require_legacy_minizinc_predicates()
         variables = []
         self._variables_declarations = []
         constraints = self.fix_variables_value_constraints_for_ARX(fixed_variables)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_number_of_active_sboxes_model.py
@@ -133,6 +133,7 @@ class MznXorDifferentialNumberOfActiveSboxesModel(MznModel):
             sage: cp.build_xor_differential_trail_first_step_model(-1, fixed_variables)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         variables = []
         self.list_of_xor_all_inputs = []
         self.list_of_xor_components = []

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_differential_trail_search_fixing_number_of_active_sboxes_model.py
@@ -68,6 +68,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
             ....: integer_to_bit_list(0, 128, 'little'))]
             sage: cp.build_xor_differential_trail_second_step_model(-1, fixed_variables)
         """
+        self.require_legacy_minizinc_predicates()
         self.c = 0
         self.sbox_mant = []
         self.component_and_probability = {}
@@ -433,6 +434,7 @@ class MznXorDifferentialFixingNumberOfActiveSboxesModel(
              'building_time': 3.7489726543426514}
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         possible_sboxes = 0
         if weight > 0:
             possible_sboxes = self.find_possible_number_of_active_sboxes(weight)

--- a/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
+++ b/claasp/cipher_modules/models/cp/mzn_models/mzn_xor_linear_model.py
@@ -136,6 +136,7 @@ class MznXorLinearModel(MznModel):
             sage: cp.build_xor_linear_trail_model(-1, fixed_variables)
         """
         self.initialise_model()
+        self.require_legacy_minizinc_predicates()
         self.sbox_mant = []
         self.c = 0
         self._variables_declarations = []

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -260,7 +260,7 @@ def test_fix_variables_value_constraints():
 
 
 def test_model_constraints():
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="No model generated"):
         speck = SpeckBlockCipher(number_of_rounds=4)
         mzn = MznModel(speck)
         mzn.model_constraints()

--- a/tests/unit/cipher_modules/models/cp/mzn_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_model_test.py
@@ -4,6 +4,12 @@ import pytest
 from minizinc import Status
 
 import claasp.cipher_modules.models.cp.mzn_model as mzn_model_module
+from claasp.cipher_modules.models.cp.minizinc_utils import usefulfunctions
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_predicate_registry import (
+    LEGACY_MINIZINC_USEFUL_FUNCTIONS,
+    MiniZincPredicateModule,
+    MiniZincPredicateRegistry,
+)
 from claasp.cipher_modules.models.cp.mzn_model import MiniZincModelParts, MznModel
 from claasp.cipher_modules.models.cp.mzn_models.mzn_cipher_model_arx_optimized import MznCipherModelARXOptimized
 from claasp.cipher_modules.models.cp.mzn_models.mzn_deterministic_truncated_xor_differential_model_arx_optimized import (
@@ -60,6 +66,48 @@ def test_minizinc_model_parts_lines_concatenates_in_order():
         "solve satisfy;",
         'output ["x=", show(x)];',
     ]
+
+
+def test_minizinc_predicate_registry_orders_dependencies_and_deduplicates():
+    registry = MiniZincPredicateRegistry(
+        [
+            MiniZincPredicateModule("base", "% base"),
+            MiniZincPredicateModule("middle", "% middle", dependencies=("base",)),
+            MiniZincPredicateModule("top", "% top", dependencies=("middle", "base")),
+        ]
+    )
+
+    assert registry.render_modules(["top", "middle"]) == ["% base", "% middle", "% top"]
+
+
+def test_minizinc_predicate_registry_rejects_unknown_modules():
+    registry = MiniZincPredicateRegistry()
+
+    with pytest.raises(ValueError, match="not registered"):
+        registry.render_modules(["missing"])
+
+
+def test_mzn_model_starts_without_required_predicate_modules():
+    speck = SpeckBlockCipher(number_of_rounds=1)
+    model = MznModel(speck)
+
+    assert model._required_predicate_modules == []
+    assert model._model_prefix == []
+
+
+def test_mzn_model_requires_legacy_predicates_through_registry():
+    speck = SpeckBlockCipher(number_of_rounds=1)
+    model = MznModel(speck)
+
+    model.require_legacy_minizinc_predicates()
+
+    assert model._required_predicate_modules == [LEGACY_MINIZINC_USEFUL_FUNCTIONS]
+    assert model._model_prefix == ['include "globals.mzn";', usefulfunctions.MINIZINC_USEFUL_FUNCTIONS]
+
+    model.require_predicate_module(LEGACY_MINIZINC_USEFUL_FUNCTIONS)
+
+    assert model._required_predicate_modules == [LEGACY_MINIZINC_USEFUL_FUNCTIONS]
+    assert model._model_prefix == ['include "globals.mzn";', usefulfunctions.MINIZINC_USEFUL_FUNCTIONS]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/cp/mzn_models/mzn_xor_differential_model_test.py
@@ -2,6 +2,8 @@ from claasp.cipher_modules.models.cp.mzn_models.mzn_xor_differential_model impor
     MznXorDifferentialModel,
     and_xor_differential_probability_ddt,
 )
+from claasp.cipher_modules.models.cp.minizinc_utils.mzn_predicate_registry import MINIZINC_XOR_DIFFERENTIAL_HELPERS
+from claasp.cipher_modules.models.cp.minizinc_utils.usefulfunctions import MINIZINC_USEFUL_FUNCTIONS
 from claasp.cipher_modules.models.cp.solvers import CHUFFED
 from claasp.cipher_modules.models.utils import set_fixed_variables
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
@@ -13,11 +15,23 @@ def test_and_xor_differential_probability_ddt():
     assert and_xor_differential_probability_ddt(2) == [4, 0, 2, 2, 2, 2, 2, 2]
 
 
+def test_build_xor_differential_trail_model_uses_selective_predicate_module():
+    speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=1)
+    mzn = MznXorDifferentialModel(speck)
+
+    mzn.build_xor_differential_trail_model()
+
+    assert mzn._required_predicate_modules == [MINIZINC_XOR_DIFFERENTIAL_HELPERS]
+    assert MINIZINC_USEFUL_FUNCTIONS not in mzn._model_prefix
+    assert mzn._model_prefix[0] == 'include "globals.mzn";'
+    assert "function array[int] of var 0..1: Eq" in mzn._model_prefix[1]
+    assert "function array[int] of var 0..2: LShift" in mzn._model_prefix[1]
+
+
 def test_find_all_xor_differential_trails_with_fixed_weight():
     speck = SpeckBlockCipher(block_bit_size=8, key_bit_size=16, number_of_rounds=2)
     mzn = MznXorDifferentialModel(speck)
     trails = mzn.find_all_xor_differential_trails_with_fixed_weight(1, solver_name=CHUFFED, solve_external=True)
-
     assert len(trails) == 6
 
     trails = mzn.find_all_xor_differential_trails_with_fixed_weight(1, solver_name=CHUFFED, solve_external=False)


### PR DESCRIPTION
This PR continues the CP MiniZinc model cleanup started in PRs 445, 446, 464, and 465.

It introduces a MiniZincPredicateRegistry to manage MiniZinc helper predicates explicitly. Each helper is represented by a MiniZincPredicateModule, which defines its name, MiniZinc body, and dependencies.

For now, most CP models still request the legacy helper module to preserve the previous behavior. As a first selective example, the XOR differential model now requests only its specific helper module.

The goal is to validate the registry approach before extending selective helper dependencies to the rest of the CP models.