### PR TITLE
FIX/Fix: isolate SNOW3G instance state

### DIFF
--- a/claasp/ciphers/stream_ciphers/snow3g_stream_cipher.py
+++ b/claasp/ciphers/stream_ciphers/snow3g_stream_cipher.py
@@ -59,11 +59,6 @@ SBoxQ = [
 
 WORD_NUM = 16
 WORD_SIZE = 32
-LFSR_S = [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
-LFSR_P = [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
-FSM_R = []
-FSM_P = []
-
 LFSR_DESCR = [
     [
         [16, [[1, [0]], [1, [2]], [1, [11]]]]  # Register len =16, feedback poly=alpha*x0 + x2 + alpha^(-1)*x11
@@ -99,6 +94,10 @@ class Snow3GStreamCipher(Cipher):
         self.key_bit_size = key_bit_size
         self.iv_bit_size = iv_bit_size
         self.number_of_initialization_clocks = number_of_initialization_clocks
+        self.lfsr_s = [None] * WORD_NUM
+        self.lfsr_p = [None] * WORD_NUM
+        self.fsm_r = []
+        self.fsm_p = []
 
         super().__init__(
             family_name="snow3g_stream_cipher",
@@ -148,17 +147,17 @@ class Snow3GStreamCipher(Cipher):
                 [list(range(i * WORD_SIZE, (i + 1) * WORD_SIZE)), list(range(WORD_SIZE))],
                 WORD_SIZE,
             )
-            LFSR_S[i] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-            LFSR_P[i] = [list(range(WORD_SIZE))]
+            self.lfsr_s[i] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+            self.lfsr_p[i] = [list(range(WORD_SIZE))]
         # lfsr cells-5th to 8th:  k_0, k_1, k_2, k_3
         for i in range(4):
-            LFSR_S[i + 4] = [key.id[0]]
-            LFSR_P[i + 4] = [list(range(i * WORD_SIZE, (i + 1) * WORD_SIZE))]
+            self.lfsr_s[i + 4] = [key.id[0]]
+            self.lfsr_p[i + 4] = [list(range(i * WORD_SIZE, (i + 1) * WORD_SIZE))]
 
         # lfsr[8]: k0+1
         self.add_xor_component([key.id[0]] + const_1, [list(range(WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE)
-        LFSR_S[8] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[8] = [list(range(WORD_SIZE))]
+        self.lfsr_s[8] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[8] = [list(range(WORD_SIZE))]
 
         # lfsr[9]: k1+1+iv3
         self.add_xor_component(
@@ -166,8 +165,8 @@ class Snow3GStreamCipher(Cipher):
             [list(range(WORD_SIZE, 2 * WORD_SIZE)), list(range(WORD_SIZE)), list(range(3 * WORD_SIZE, 4 * WORD_SIZE))],
             WORD_SIZE,
         )
-        LFSR_S[9] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[9] = [list(range(WORD_SIZE))]
+        self.lfsr_s[9] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[9] = [list(range(WORD_SIZE))]
 
         # lfsr[10] :k2+1+iv2
         self.add_xor_component(
@@ -179,58 +178,58 @@ class Snow3GStreamCipher(Cipher):
             ],
             WORD_SIZE,
         )
-        LFSR_S[10] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[10] = [list(range(WORD_SIZE))]
+        self.lfsr_s[10] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[10] = [list(range(WORD_SIZE))]
 
         # lfsr[11]: k3+1
         self.add_xor_component(
             [key.id[0]] + const_1, [list(range(3 * WORD_SIZE, 4 * WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE
         )
-        LFSR_S[11] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[11] = [list(range(WORD_SIZE))]
+        self.lfsr_s[11] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[11] = [list(range(WORD_SIZE))]
 
         # lfsr[12] : k0+iv1
         self.add_xor_component(
             [key.id[0], iv[0][0]], [list(range(WORD_SIZE)), list(range(WORD_SIZE, 2 * WORD_SIZE))], WORD_SIZE
         )
-        LFSR_S[12] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[12] = [list(range(WORD_SIZE))]
+        self.lfsr_s[12] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[12] = [list(range(WORD_SIZE))]
 
         # lfsr[13, 14]: k1+0, k2+0
         for i in range(2):
-            LFSR_S[12 + i + 1] = [key.id[0]]
-            LFSR_P[12 + i + 1] = [list(range((i + 1) * WORD_SIZE, (i + 2) * WORD_SIZE))]
+            self.lfsr_s[12 + i + 1] = [key.id[0]]
+            self.lfsr_p[12 + i + 1] = [list(range((i + 1) * WORD_SIZE, (i + 2) * WORD_SIZE))]
 
         # s15=k3+iv0
         self.add_xor_component(
             [key.id[0], iv[0][0]], [list(range(3 * WORD_SIZE, 4 * WORD_SIZE)), list(range(WORD_SIZE))], WORD_SIZE
         )
-        LFSR_S[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[15] = [list(range(WORD_SIZE))]
+        self.lfsr_s[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[15] = [list(range(WORD_SIZE))]
 
         for i in range(3):
-            FSM_R.append([const_0.id[0]])
-            FSM_P.append([list(range(WORD_SIZE))])
-        FSM_R[1] = FSM_R[1] + FSM_R[1] + FSM_R[1] + FSM_R[1]
-        FSM_P[1] = [list(range(8))] * 4
+            self.fsm_r.append([const_0.id[0]])
+            self.fsm_p.append([list(range(WORD_SIZE))])
+        self.fsm_r[1] = self.fsm_r[1] + self.fsm_r[1] + self.fsm_r[1] + self.fsm_r[1]
+        self.fsm_p[1] = [list(range(8))] * 4
 
     def clock_fsm(self, const_0):
-        self.add_modadd_component(LFSR_S[15] + FSM_R[0], LFSR_P[15] + FSM_P[0], WORD_SIZE)
+        self.add_modadd_component(self.lfsr_s[15] + self.fsm_r[0], self.lfsr_p[15] + self.fsm_p[0], WORD_SIZE)
         F = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_xor_component(F + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
+        self.add_xor_component(F + self.fsm_r[1], [list(range(WORD_SIZE))] + self.fsm_p[1], WORD_SIZE)
         F = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_xor_component(FSM_R[2] + LFSR_S[5], FSM_P[2] + LFSR_P[5], WORD_SIZE)
+        self.add_xor_component(self.fsm_r[2] + self.lfsr_s[5], self.fsm_p[2] + self.lfsr_p[5], WORD_SIZE)
         r = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        self.add_modadd_component(r + FSM_R[1], [list(range(WORD_SIZE))] + FSM_P[1], WORD_SIZE)
+        self.add_modadd_component(r + self.fsm_r[1], [list(range(WORD_SIZE))] + self.fsm_p[1], WORD_SIZE)
         r = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        FSM_R[2], FSM_P[2] = self.S2(FSM_R[1], FSM_P[1], const_0)
-        FSM_R[1], FSM_P[1] = self.S1(FSM_R[0], FSM_P[0], const_0)
-        FSM_R[0] = r
-        FSM_P[0] = [list(range(WORD_SIZE))]
+        self.fsm_r[2], self.fsm_p[2] = self.S2(self.fsm_r[1], self.fsm_p[1], const_0)
+        self.fsm_r[1], self.fsm_p[1] = self.S1(self.fsm_r[0], self.fsm_p[0], const_0)
+        self.fsm_r[0] = r
+        self.fsm_p[0] = [list(range(WORD_SIZE))]
 
         return F
 
@@ -310,49 +309,49 @@ class Snow3GStreamCipher(Cipher):
 
     def clock_lfsr_initialization_mode(self, F, const_0):
         self.clock_lfsr(const_0)
-        self.add_xor_component(LFSR_S[15] + F, LFSR_P[15] + [list(range(WORD_SIZE))], WORD_SIZE)
-        LFSR_S[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
-        LFSR_P[15] = [list(range(WORD_SIZE))]
+        self.add_xor_component(self.lfsr_s[15] + F, self.lfsr_p[15] + [list(range(WORD_SIZE))], WORD_SIZE)
+        self.lfsr_s[15] = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
+        self.lfsr_p[15] = [list(range(WORD_SIZE))]
 
     def clock_lfsr(self, const_0):
         S0a, S11a = self.create_alpha_state(const_0)
         fsr_ids = S0a
         fsr_pos = [list(range(WORD_SIZE))]
         for i in range(1, 11):
-            fsr_ids = fsr_ids + LFSR_S[i]
-            fsr_pos = fsr_pos + LFSR_P[i]
+            fsr_ids = fsr_ids + self.lfsr_s[i]
+            fsr_pos = fsr_pos + self.lfsr_p[i]
         fsr_ids = fsr_ids + S11a
         fsr_pos = fsr_pos + [list(range(WORD_SIZE))]
         for i in range(12, WORD_NUM):
-            fsr_ids = fsr_ids + LFSR_S[i]
-            fsr_pos = fsr_pos + LFSR_P[i]
+            fsr_ids = fsr_ids + self.lfsr_s[i]
+            fsr_pos = fsr_pos + self.lfsr_p[i]
 
         self.add_fsr_component(fsr_ids, fsr_pos, WORD_SIZE * WORD_NUM, LFSR_DESCR)
         S15 = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE * WORD_NUM))]).id[0]]
         for i in range(WORD_NUM - 1):
-            LFSR_S[i] = LFSR_S[i + 1]
-            LFSR_P[i] = LFSR_P[i + 1]
-        LFSR_S[WORD_NUM - 1] = S15
-        LFSR_P[WORD_NUM - 1] = [list(range((WORD_NUM - 1) * WORD_SIZE, WORD_NUM * WORD_SIZE))]
+            self.lfsr_s[i] = self.lfsr_s[i + 1]
+            self.lfsr_p[i] = self.lfsr_p[i + 1]
+        self.lfsr_s[WORD_NUM - 1] = S15
+        self.lfsr_p[WORD_NUM - 1] = [list(range((WORD_NUM - 1) * WORD_SIZE, WORD_NUM * WORD_SIZE))]
 
     def create_alpha_state(self, const_0):
-        S0 = LFSR_S[0]
+        S0 = self.lfsr_s[0]
         S0a_id, S0a_pos = self.MULalpha(S0, const_0)
         s0_id = S0 + [const_0.id[0]] + S0a_id
-        s0_pos = [LFSR_P[0][0][8:WORD_SIZE], list(range(8))] + S0a_pos
+        s0_pos = [self.lfsr_p[0][0][8:WORD_SIZE], list(range(8))] + S0a_pos
         self.add_xor_component(s0_id, s0_pos, WORD_SIZE)
         S0a = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
-        S11a_id, S11a_pos = self.DIValpha(LFSR_S[11], const_0)
-        s11_id = [const_0.id[0]] + LFSR_S[11] + S11a_id
-        s11_pos = [list(range(8)), LFSR_P[11][0][0:24]] + S11a_pos
+        S11a_id, S11a_pos = self.DIValpha(self.lfsr_s[11], const_0)
+        s11_id = [const_0.id[0]] + self.lfsr_s[11] + S11a_id
+        s11_pos = [list(range(8)), self.lfsr_p[11][0][0:24]] + S11a_pos
         self.add_xor_component(s11_id, s11_pos, WORD_SIZE)
         S11a = [ComponentState([self.get_current_component_id()], [list(range(WORD_SIZE))]).id[0]]
 
         return S0a, S11a
 
     def MULalpha(self, S0, const_0):
-        P = LFSR_P[0][0][:8]
+        P = self.lfsr_p[0][0][:8]
         mulxpow1 = self.MULxPOW(S0, 23, const_0, P)
         mulxpow2 = self.MULxPOW(S0, 245, const_0, P)
         mulxpow3 = self.MULxPOW(S0, 48, const_0, P)
@@ -364,7 +363,7 @@ class Snow3GStreamCipher(Cipher):
         return S0a_id, S0a_pos
 
     def DIValpha(self, S11, const_0):
-        P = LFSR_P[11][0][8 * 3 : 8 * 4]
+        P = self.lfsr_p[11][0][8 * 3 : 8 * 4]
         mulxpow1 = self.MULxPOW(S11, 16, const_0, P)
         mulxpow2 = self.MULxPOW(S11, 39, const_0, P)
         mulxpow3 = self.MULxPOW(S11, 6, const_0, P)
@@ -394,7 +393,7 @@ class Snow3GStreamCipher(Cipher):
         return V
 
     def snow3g_key_stream(self, F, keystream, clock_number):
-        key_word = self.add_xor_component(F + LFSR_S[0], [list(range(WORD_SIZE))] + LFSR_P[0], WORD_SIZE).id
+        key_word = self.add_xor_component(F + self.lfsr_s[0], [list(range(WORD_SIZE))] + self.lfsr_p[0], WORD_SIZE).id
         if clock_number == 0:
             keystream = self.add_round_output_component([key_word], [list(range(WORD_SIZE))], WORD_SIZE).id
         else:

--- a/tests/unit/ciphers/stream_ciphers/snow3g_stream_cipher_test.py
+++ b/tests/unit/ciphers/stream_ciphers/snow3g_stream_cipher_test.py
@@ -6,6 +6,18 @@ def test_snow3g_stream_cipher_test_vector():
     snow = Snow3GStreamCipher(number_of_initialization_clocks=2, keystream_word_size=2)
     iv = 0xEA024714AD5C4D84DF1F9B251C0BF45F
     key = 0x2BD6459F82C5B300952C49104881FF48
-    ks_32 = 0xABEE97047AC31373 # keystream for full initialization rounds, i.e. 32
+    ks_32 = 0xABEE97047AC31373  # keystream for full initialization rounds, i.e. 32
     ks2 = 10407660024169345926
     assert snow.evaluate([key, iv]) == ks2
+
+
+def test_snow3g_stream_cipher_can_be_initialized_twice():
+    iv = 0xEA024714AD5C4D84DF1F9B251C0BF45F
+    key = 0x2BD6459F82C5B300952C49104881FF48
+    ks2 = 10407660024169345926
+
+    first_snow = Snow3GStreamCipher(number_of_initialization_clocks=2, keystream_word_size=2)
+    second_snow = Snow3GStreamCipher(number_of_initialization_clocks=2, keystream_word_size=2)
+
+    assert first_snow.evaluate([key, iv]) == ks2
+    assert second_snow.evaluate([key, iv]) == ks2


### PR DESCRIPTION
Implemented the SNOW3G fix.

Root cause: Snow3GStreamCipher used module-level mutable state for LFSR/FSM registers, so constructing one instance polluted the next one in the same pytest process. That explains why test_snow3g_stream_cipher_test_vector passed alone but failed during pytest -v tests/unit.

What changed:

- Moved SNOW3G LFSR/FSM state onto each cipher instance in
claasp/claasp/ciphers/stream_ciphers/snow3g_stream_cipher.py

- Added a regression test that initializes/evaluates two SNOW3G instances in one process in claasp/tests/unit/ciphers/stream_ciphers/snow3g_stream_cipher_test.py