### PR TITLE
FIX/Fix: rebuild Rounds indexes when unpickling legacy cipher objects

### DIFF
--- a/claasp/rounds.py
+++ b/claasp/rounds.py
@@ -26,6 +26,13 @@ class Rounds:
         self._by_id = None
         self._consumers = None
 
+    def __setstate__(self, state):
+        # Objects pickled before the _by_id/_consumers indexes were introduced
+        # won't have them in their state; rebuild lazily on first access.
+        self.__dict__.update(state)
+        self._by_id = None
+        self._consumers = None
+
     def _build_indexes(self):
         by_id = {}
         consumers = {}


### PR DESCRIPTION
Cipher objects pickled before the _by_id/_consumers lookup indexes were added to Rounds restore their __dict__ verbatim, skipping __init__ and leaving those attributes missing. component_from_id then raised AttributeError, breaking report_test.py::test_save_as_image and report_test.py::test_show, which rely on a pre-generated cache of pickled trails.