### PR TITLE
Remove stale add_concatenate_component API from Cipher

### DIFF
--- a/claasp/cipher.py
+++ b/claasp/cipher.py
@@ -170,9 +170,6 @@ class Cipher:
     def add_cipher_output_component(self, input_id_links, input_bit_positions, output_bit_size):
         return editor.add_cipher_output_component(self, input_id_links, input_bit_positions, output_bit_size)
 
-    def add_concatenate_component(self, input_id_links, input_bit_positions, output_bit_size):
-        return editor.add_concatenate_component(self, input_id_links, input_bit_positions, output_bit_size)
-
     def add_constant_component(self, output_bit_size, value):
         return editor.add_constant_component(self, output_bit_size, value)
 


### PR DESCRIPTION
## Summary
- remove Cipher.add_concatenate_component() wrapper from claasp/cipher.py
- confirm there is no add_concatenate_component implementation left in claasp/editor.py

## Why
add_concatenate_component() appears to be leftover API after concatenate component removal. Keeping the wrapper exposes a dead API that points to a non-existent editor function.

## Validation
- pytest tests/unit/cipher_test.py -q (inside claasp:latest container): 32 passed
