### PR TITLE
FEATURE/Add: one-hot MILP S-box formulation for XOR-differential and …

### DIFF
--- a/claasp/cipher_modules/models/milp/milp_model.py
+++ b/claasp/cipher_modules/models/milp/milp_model.py
@@ -140,7 +140,7 @@ def get_input_output_variables(component):
 class MilpModel:
     """Build MILP models for ciphers using Cipher."""
 
-    def __init__(self, cipher, n_window_heuristic=None, verbose=False):
+    def __init__(self, cipher, n_window_heuristic=None, verbose=False, sbox_modeling="espresso"):
         self._cipher = cipher
         self._variables_list = []
         self._model_constraints = []
@@ -151,6 +151,9 @@ class MilpModel:
         self._non_linear_component_id = []
         self._intermediate_output_names = []
         self._number_of_trails_found = 0
+        if sbox_modeling not in ("espresso", "one_hot"):
+            raise ValueError("sbox_modeling (%s) has to be one of ['espresso', 'one_hot']" % (sbox_modeling,))
+        self._sbox_modeling = sbox_modeling
         self._verbose_print = print if verbose else lambda *a, **k: None
 
     def fix_variables_value_constraints(self, fixed_variables=[]):
@@ -473,3 +476,15 @@ class MilpModel:
     @property
     def non_linear_component_id(self):
         return self._non_linear_component_id
+
+    @property
+    def sbox_modeling(self):
+        """
+        Return the S-box MILP formulation selector.
+
+        One of ``'espresso'`` (default, minimized product-of-sum inequalities with
+        big-M activation) or ``'one_hot'`` (one binary indicator per valid DDT
+        transition, big-M free). Consumed by
+        :py:meth:`~claasp.components.sbox_component.Sbox.milp_xor_differential_propagation_constraints`.
+        """
+        return self._sbox_modeling

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -55,8 +55,8 @@ from claasp.name_mappings import (
 
 
 class MilpXorDifferentialModel(MilpModel):
-    def __init__(self, cipher, n_window_heuristic=None, verbose=False):
-        super().__init__(cipher, n_window_heuristic, verbose)
+    def __init__(self, cipher, n_window_heuristic=None, verbose=False, sbox_modeling="espresso"):
+        super().__init__(cipher, n_window_heuristic, verbose, sbox_modeling=sbox_modeling)
         self._weight_precision = MILP_DEFAULT_WEIGHT_PRECISION
         self._has_non_integer_weight = False
 

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
@@ -63,8 +63,8 @@ from claasp.name_mappings import (
 
 
 class MilpXorLinearModel(MilpModel):
-    def __init__(self, cipher, n_window_heuristic=None, verbose=False):
-        super().__init__(cipher, n_window_heuristic, verbose)
+    def __init__(self, cipher, n_window_heuristic=None, verbose=False, sbox_modeling="espresso"):
+        super().__init__(cipher, n_window_heuristic, verbose, sbox_modeling=sbox_modeling)
         self.bit_bindings, self.bit_bindings_for_intermediate_output = get_bit_bindings(cipher, "_".join)
         self._weight_precision = MILP_DEFAULT_WEIGHT_PRECISION
         self._has_non_integer_weight = False

--- a/claasp/cipher_modules/models/milp/solvers.py
+++ b/claasp/cipher_modules/models/milp/solvers.py
@@ -134,7 +134,7 @@ MILP_SOLVERS_EXTERNAL = [
                 "end": "",
                 "format": ["executable", "output_file", "input_file"],
             },
-            "time": r"[\s]+Timing [\s]+([0-9]*[.]?[0-9]+) \(total\)",
+            "time": r"[\s]+Timing[\s]+([0-9]*[.]?[0-9]+)",
             "unsat_condition": r"[\s]+Status[\s]+Infeasible",
         },
     },

--- a/claasp/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search.py
+++ b/claasp/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search.py
@@ -69,6 +69,54 @@ def sbox_inequalities(sbox, analysis="differential", algorithm="milp"):
         raise ValueError("algorithm (%s) has to be one of ['greedy', 'milp']" % (algorithm,))
 
 
+def sbox_valid_transitions(sbox, analysis="differential"):
+    """
+    Return the valid (non-trivial) transitions of an S-box as ``(delta_in, delta_out, count)`` triples.
+
+    Unlike :func:`sbox_inequalities` / the espresso product-of-sum approach, this performs no
+    minimization: the valid transitions are simply the nonzero cells of the DDT (differential) or
+    LAT (linear), excluding the trivial ``delta_in == 0`` row. It is the raw material for the
+    one-hot MILP formulation, where each returned transition becomes one binary indicator variable.
+
+    INPUT:
+
+    - ``sbox`` -- **SBox object**; the S-box to model
+    - ``analysis`` -- **string** (default: `differential`); one of ``'differential'`` or ``'linear'``
+
+    OUTPUT:
+
+    - **list** of ``(delta_in, delta_out, count)`` tuples, where ``count`` is the (absolute) table
+      entry used to derive the transition weight.
+
+    EXAMPLES::
+
+        sage: from sage.crypto.sbox import SBox
+        sage: SBox_PRESENT = SBox([12,5,6,11,9,0,10,13,3,14,15,8,4,7,1,2])
+        sage: from claasp.cipher_modules.models.milp.utils.generate_sbox_inequalities_for_trail_search import sbox_valid_transitions
+        sage: transitions = sbox_valid_transitions(SBox_PRESENT)
+        sage: len(transitions)
+        96
+        sage: (1, 3, 4) in transitions
+        True
+    """
+    if analysis == "differential":
+        valid_transformations_matrix = sbox.difference_distribution_table()
+    elif analysis == "linear":
+        valid_transformations_matrix = sbox.linear_approximation_table()
+    else:
+        raise TypeError("analysis (%s) has to be one of ['differential', 'linear']" % (analysis,))
+
+    n, m = sbox.input_size(), sbox.output_size()
+    transitions = []
+    for delta_in in range(1, 1 << n):
+        for delta_out in range(0, 1 << m):
+            entry = valid_transformations_matrix[delta_in][delta_out]
+            if entry != 0:
+                transitions.append((delta_in, delta_out, abs(int(entry))))
+
+    return transitions
+
+
 def convex_hull(sbox, analysis="differential"):
     """
     Compute the convex hull of the differential or linear behaviour of the given S-box.

--- a/claasp/components/sbox_component.py
+++ b/claasp/components/sbox_component.py
@@ -31,6 +31,7 @@ from claasp.cipher_modules.models.milp.utils.generate_inequalities_for_large_sbo
 )
 from claasp.cipher_modules.models.milp.utils.generate_sbox_inequalities_for_trail_search import (
     get_dictionary_that_contains_inequalities_for_small_sboxes,
+    sbox_valid_transitions,
     update_dictionary_that_contains_inequalities_for_small_sboxes,
 )
 from claasp.cipher_modules.models.milp.utils.generate_undisturbed_bits_inequalities_for_sboxes import (
@@ -276,6 +277,85 @@ def milp_set_constraints_from_dictionnary_for_large_sbox(
         )
     constraints.append(constraint_choice_proba == x[f"{component_id}_active"])
     constraints.append(p[f"{component_id}_probability"] == constraint_compute_proba)
+
+    return constraints
+
+
+def milp_one_hot_probability_constraints(component_id, input_vars, output_vars, sbox, x, p, analysis, weight_precision):
+    """
+    Build the one-hot (indicator) MILP constraints for an S-box.
+
+    Shared by the XOR differential (DDT) and XOR linear (LAT) formulations. One binary indicator
+    ``{component_id}_onehot_{di}_{do}`` is created per valid transition ``(di, do)`` returned by
+    :func:`~claasp.cipher_modules.models.milp.utils.generate_sbox_inequalities_for_trail_search.sbox_valid_transitions`.
+    Selecting a transition pins the input/output bits (difference bits for ``'differential'``, mask
+    bits for ``'linear'``) and contributes its weight linearly. The formulation is big-M free and
+    its LP relaxation is exactly the convex hull of the valid points. The differential weight uses
+    exponent ``n`` (``-log2(count / 2^n)``); the linear (correlation) weight uses exponent ``n - 1``.
+
+    INPUT:
+
+    - ``component_id`` -- **string**; identifier of the S-box component
+    - ``input_vars`` -- **list**; names of the input (difference/mask) MILP variables, MSB first
+    - ``output_vars`` -- **list**; names of the output (difference/mask) MILP variables, MSB first
+    - ``sbox`` -- **SBox object**; the S-box to model
+    - ``x`` -- **boolean MIPVariable object**
+    - ``p`` -- **integer MIPVariable object**
+    - ``analysis`` -- **string**; one of ``'differential'`` or ``'linear'``
+    - ``weight_precision`` -- **integer**; number of decimals used when rounding the weight
+
+    OUTPUT:
+
+    - ``list`` -- the MILP constraints (one activation-sum, one per input bit, one per output bit,
+      one for the weight)
+
+    EXAMPLES::
+
+        sage: from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
+        sage: from claasp.cipher_modules.models.milp.milp_model import MilpModel
+        sage: from claasp.components.sbox_component import milp_one_hot_probability_constraints
+        sage: from sage.crypto.sbox import SBox
+        sage: cipher = SboxCipher(bit_size=3)
+        sage: milp = MilpModel(cipher)
+        sage: milp.init_model_in_sage_milp_class()
+        sage: sbox_component = cipher.component_from(0, 0)
+        sage: input_vars, output_vars = sbox_component._get_input_output_variables()
+        sage: constraints = milp_one_hot_probability_constraints(
+        ....:     'sbox_0_0', input_vars, output_vars, SBox(sbox_component.description),
+        ....:     milp.binary_variable, milp.integer_variable, 'differential', 2
+        ....: )
+        sage: len(constraints)  # 1 activation-sum + 3 input + 3 output + 1 weight
+        8
+    """
+    input_size, output_size = sbox.input_size(), sbox.output_size()
+    exponent = input_size if analysis == "differential" else input_size - 1
+    transitions = sbox_valid_transitions(sbox, analysis=analysis)
+    transition_vars = {(di, do): x[f"{component_id}_onehot_{di}_{do}"] for di, do, _ in transitions}
+
+    # mip().sum is single-pass; builtin sum() is O(n^2) on Sage linear functions
+    mip_sum = x.mip().sum
+
+    constraints = [mip_sum(transition_vars.values()) == x[f"{component_id}_active"]]
+
+    for k in range(input_size):
+        bit = input_size - 1 - k
+        constraints.append(
+            x[input_vars[k]] == mip_sum(y for (di, do), y in transition_vars.items() if (di >> bit) & 1)
+        )
+    for k in range(output_size):
+        bit = output_size - 1 - k
+        constraints.append(
+            x[output_vars[k]] == mip_sum(y for (di, do), y in transition_vars.items() if (do >> bit) & 1)
+        )
+
+    constraints.append(
+        p[f"{component_id}_probability"]
+        == (10**weight_precision)
+        * mip_sum(
+            round(-log(count / 2**exponent, 2), weight_precision) * transition_vars[(di, do)]
+            for di, do, count in transitions
+        )
+    )
 
     return constraints
 
@@ -1568,6 +1648,126 @@ class Sbox(Component):
 
         return variables, constraints
 
+    def milp_one_hot_xor_differential_probability_constraints(
+        self, binary_variable, integer_variable, non_linear_component_id, weight_precision=MILP_DEFAULT_WEIGHT_PRECISION
+    ):
+        """
+        Return variables and constraints modeling an SBOX with the one-hot (indicator) formulation.
+
+        .. NOTE::
+
+            One binary indicator variable ``{id}_onehot_{di}_{do}`` is introduced per valid DDT
+            transition ``(di, do)`` (nonzero cell with ``di != 0``). Selecting a transition pins the
+            input/output difference bits to it and contributes its weight linearly. This is the
+            big-M-free alternative to :py:meth:`milp_large_xor_differential_probability_constraints`
+            (espresso). Its LP relaxation is exactly the convex hull of the valid points. The cost is
+            one binary variable per nonzero DDT entry, which grows quickly for large S-boxes.
+            Selected via ``MilpModel(..., sbox_modeling='one_hot')``.
+
+        INPUT:
+
+        - ``binary_variable`` -- **boolean MIPVariable object**
+        - ``integer_variable`` -- **integer MIPVariable object**
+        - ``non_linear_component_id`` -- **list**
+        - ``weight_precision`` -- **integer** (default: `2`); number of decimals used when rounding the weight.
+
+        OUTPUT:
+
+        - ``tuple`` -- ``(variables, constraints)``
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
+            sage: from claasp.cipher_modules.models.milp.milp_model import MilpModel
+            sage: cipher = SboxCipher(bit_size=3)
+            sage: milp = MilpModel(cipher)
+            sage: milp.init_model_in_sage_milp_class()
+            sage: sbox_component = cipher.component_from(0, 0)
+            sage: variables, constraints = sbox_component.milp_one_hot_xor_differential_probability_constraints(milp.binary_variable, milp.integer_variable, milp._non_linear_component_id)
+            sage: variables
+            [('x[plaintext_0]', x_0),
+             ('x[plaintext_1]', x_1),
+             ('x[plaintext_2]', x_2),
+             ('x[sbox_0_0_0]', x_3),
+             ('x[sbox_0_0_1]', x_4),
+             ('x[sbox_0_0_2]', x_5)]
+            sage: constraints[0]
+            x_6 + x_7 + x_8 + x_9 + x_10 + x_11 + x_12 == x_13
+            sage: constraints[-1]
+            x_14 == 0
+        """
+
+        x = binary_variable
+        input_vars, output_vars = self._get_input_output_variables()
+        variables = [(f"x[{var}]", x[var]) for var in input_vars + output_vars]
+        non_linear_component_id.append(self.id)
+        constraints = milp_one_hot_probability_constraints(
+            self.id, input_vars, output_vars, SBox(self.description),
+            binary_variable, integer_variable, "differential", weight_precision,
+        )
+
+        return variables, constraints
+
+    def milp_one_hot_xor_linear_probability_constraints(
+        self, binary_variable, integer_variable, non_linear_component_id, weight_precision=MILP_DEFAULT_WEIGHT_PRECISION
+    ):
+        """
+        Return variables and constraints modeling an SBOX with the one-hot (indicator) formulation.
+
+        .. NOTE::
+
+            One binary indicator variable ``{id}_onehot_{mi}_{mo}`` is introduced per valid LAT
+            transition ``(mi, mo)`` (nonzero cell with input mask ``mi != 0``). Selecting a transition
+            pins the input/output mask bits to it and contributes its correlation weight linearly.
+            This is the big-M-free alternative to :py:meth:`milp_large_xor_linear_probability_constraints`
+            (espresso). Its LP relaxation is exactly the convex hull of the valid points. The cost is
+            one binary variable per nonzero LAT entry, which grows quickly for large S-boxes.
+            Selected via ``MilpModel(..., sbox_modeling='one_hot')``.
+
+        INPUT:
+
+        - ``binary_variable`` -- **boolean MIPVariable object**
+        - ``integer_variable`` -- **integer MIPVariable object**
+        - ``non_linear_component_id`` -- **list**
+        - ``weight_precision`` -- **integer** (default: `2`); number of decimals used when rounding the weight.
+
+        OUTPUT:
+
+        - ``tuple`` -- ``(variables, constraints)``
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
+            sage: from claasp.cipher_modules.models.milp.milp_model import MilpModel
+            sage: cipher = SboxCipher(bit_size=3)
+            sage: milp = MilpModel(cipher)
+            sage: milp.init_model_in_sage_milp_class()
+            sage: sbox_component = cipher.component_from(0, 0)
+            sage: variables, constraints = sbox_component.milp_one_hot_xor_linear_probability_constraints(milp.binary_variable, milp.integer_variable, milp._non_linear_component_id)
+            sage: variables
+            [('x[sbox_0_0_0_i]', x_0),
+             ('x[sbox_0_0_1_i]', x_1),
+             ('x[sbox_0_0_2_i]', x_2),
+             ('x[sbox_0_0_0_o]', x_3),
+             ('x[sbox_0_0_1_o]', x_4),
+             ('x[sbox_0_0_2_o]', x_5)]
+            sage: constraints[0]
+            x_6 + x_7 + x_8 + x_9 + x_10 + x_11 + x_12 == x_13
+            sage: constraints[-1]
+            x_14 == 0
+        """
+
+        x = binary_variable
+        input_vars, output_vars = self._get_independent_input_output_variables()
+        variables = [(f"x[{var}]", x[var]) for var in input_vars + output_vars]
+        non_linear_component_id.append(self.id)
+        constraints = milp_one_hot_probability_constraints(
+            self.id, input_vars, output_vars, SBox(self.description),
+            binary_variable, integer_variable, "linear", weight_precision,
+        )
+
+        return variables, constraints
+
     def milp_small_xor_linear_probability_constraints(
         self, binary_variable, integer_variable, non_linear_component_id, weight_precision=MILP_DEFAULT_WEIGHT_PRECISION
     ):
@@ -1705,9 +1905,14 @@ class Sbox(Component):
         integer_variable = model.integer_variable
         non_linear_component_id = model.non_linear_component_id
         weight_precision = model.weight_precision
-        variables, constraints = self.milp_large_xor_differential_probability_constraints(
-            binary_variable, integer_variable, non_linear_component_id, weight_precision
-        )
+        if getattr(model, "sbox_modeling", "espresso") == "one_hot":
+            variables, constraints = self.milp_one_hot_xor_differential_probability_constraints(
+                binary_variable, integer_variable, non_linear_component_id, weight_precision
+            )
+        else:
+            variables, constraints = self.milp_large_xor_differential_probability_constraints(
+                binary_variable, integer_variable, non_linear_component_id, weight_precision
+            )
 
         return variables, constraints
 
@@ -1748,9 +1953,14 @@ class Sbox(Component):
         integer_variable = model.integer_variable
         non_linear_component_id = model.non_linear_component_id
         weight_precision = model.weight_precision
-        variables, constraints = self.milp_large_xor_linear_probability_constraints(
-            binary_variable, integer_variable, non_linear_component_id, weight_precision
-        )
+        if getattr(model, "sbox_modeling", "espresso") == "one_hot":
+            variables, constraints = self.milp_one_hot_xor_linear_probability_constraints(
+                binary_variable, integer_variable, non_linear_component_id, weight_precision
+            )
+        else:
+            variables, constraints = self.milp_large_xor_linear_probability_constraints(
+                binary_variable, integer_variable, non_linear_component_id, weight_precision
+            )
         return variables, constraints
 
     def milp_wordwise_branch_number_number_of_active_sboxes_constraints(self, model):

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
@@ -1,9 +1,15 @@
+import pytest
+
+from claasp.cipher_modules.models.milp.milp_model import MilpModel
 from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
 from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
 from claasp.ciphers.block_ciphers.present_block_cipher import PresentBlockCipher
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
 from claasp.ciphers.block_ciphers.tea_block_cipher import TeaBlockCipher
+from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
 from claasp.name_mappings import INPUT_KEY, INPUT_PLAINTEXT
+
+PRESENT_SBOX = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
 
 
 def test_find_all_xor_differential_trails_with_fixed_weight():
@@ -101,3 +107,47 @@ def test_find_one_xor_differential_trail_with_fixed_weight():
     )
     trail = milp.find_one_xor_differential_trail_with_fixed_weight(5, fixed_values=[key, round_0_output, cipher_output])
     assert trail["total_weight"] == 5.0
+
+
+def test_sbox_modeling():
+    present = PresentBlockCipher(number_of_rounds=2)
+    assert MilpXorDifferentialModel(present).sbox_modeling == "espresso"
+    assert MilpXorDifferentialModel(present, sbox_modeling="one_hot").sbox_modeling == "one_hot"
+
+
+def test_sbox_modeling_invalid():
+    present = PresentBlockCipher(number_of_rounds=2)
+    with pytest.raises(ValueError):
+        MilpXorDifferentialModel(present, sbox_modeling="onehot")
+
+
+def test_milp_one_hot_xor_differential_probability_constraints():
+    cipher = SboxCipher(bit_size=4, lookup_table=PRESENT_SBOX)
+    milp = MilpModel(cipher, sbox_modeling="one_hot")
+    milp.init_model_in_sage_milp_class()
+    sbox_component = cipher.component_from(0, 0)
+    variables, constraints = sbox_component.milp_one_hot_xor_differential_probability_constraints(
+        milp.binary_variable, milp.integer_variable, milp.non_linear_component_id
+    )
+
+    assert len(variables) == 8
+    assert len(constraints) == 4 + 4 + 2
+
+
+def test_find_lowest_weight_xor_differential_trail_one_hot_sbox():
+    cipher = SboxCipher(bit_size=4, lookup_table=PRESENT_SBOX)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT,
+        constraint_type="not_equal",
+        bit_positions=range(4),
+        bit_values=[0] * 4,
+    )
+
+    one_hot = MilpXorDifferentialModel(cipher, sbox_modeling="one_hot")
+    trail_one_hot = one_hot.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext])
+
+    espresso = MilpXorDifferentialModel(cipher, sbox_modeling="espresso")
+    trail_espresso = espresso.find_lowest_weight_xor_differential_trail(fixed_values=[plaintext])
+
+    assert trail_one_hot["total_weight"] == 2.0
+    assert trail_one_hot["total_weight"] == trail_espresso["total_weight"]

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -1,10 +1,14 @@
 import pytest
 
+from claasp.cipher_modules.models.milp.milp_model import MilpModel
 from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
 from claasp.cipher_modules.models.utils import integer_to_bit_list, set_fixed_variables
 from claasp.ciphers.block_ciphers.simon_block_cipher import SimonBlockCipher
 from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+from claasp.ciphers.single_component_ciphers.sbox_cipher import SboxCipher
 from claasp.name_mappings import INPUT_PLAINTEXT
+
+PRESENT_SBOX = [12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2]
 
 
 def test_build_xor_linear_trail_model():
@@ -171,3 +175,41 @@ def test_fix_variables_value_xor_linear_constraints():
     assert str(constraints[1]) == "x_1 == 0"
     assert str(constraints[7]) == "x_10 == x_11"
     assert str(constraints[8]) == "1 <= x_4 + x_6 + x_8 + x_10"
+
+
+def test_sbox_modeling():
+    cipher = SboxCipher(bit_size=4, lookup_table=PRESENT_SBOX)
+    assert MilpXorLinearModel(cipher).sbox_modeling == "espresso"
+    assert MilpXorLinearModel(cipher, sbox_modeling="one_hot").sbox_modeling == "one_hot"
+
+
+def test_milp_one_hot_xor_linear_probability_constraints():
+    cipher = SboxCipher(bit_size=4, lookup_table=PRESENT_SBOX)
+    milp = MilpModel(cipher, sbox_modeling="one_hot")
+    milp.init_model_in_sage_milp_class()
+    sbox_component = cipher.component_from(0, 0)
+    variables, constraints = sbox_component.milp_one_hot_xor_linear_probability_constraints(
+        milp.binary_variable, milp.integer_variable, milp.non_linear_component_id
+    )
+
+    assert len(variables) == 8
+    assert len(constraints) == 4 + 4 + 2
+
+
+def test_find_lowest_weight_xor_linear_trail_one_hot_sbox():
+    cipher = SboxCipher(bit_size=4, lookup_table=PRESENT_SBOX)
+    plaintext = set_fixed_variables(
+        component_id=INPUT_PLAINTEXT,
+        constraint_type="not_equal",
+        bit_positions=range(4),
+        bit_values=[0] * 4,
+    )
+
+    one_hot = MilpXorLinearModel(cipher, sbox_modeling="one_hot")
+    trail_one_hot = one_hot.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+
+    espresso = MilpXorLinearModel(cipher, sbox_modeling="espresso")
+    trail_espresso = espresso.find_lowest_weight_xor_linear_trail(fixed_values=[plaintext])
+
+    assert trail_one_hot["total_weight"] == 1.0
+    assert trail_one_hot["total_weight"] == trail_espresso["total_weight"]

--- a/tests/unit/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search_test.py
+++ b/tests/unit/cipher_modules/models/milp/utils/generate_sbox_inequalities_for_trail_search_test.py
@@ -1,6 +1,10 @@
+import pytest
 from sage.crypto.sbox import SBox
 
-from claasp.cipher_modules.models.milp.utils.generate_sbox_inequalities_for_trail_search import sbox_inequalities
+from claasp.cipher_modules.models.milp.utils.generate_sbox_inequalities_for_trail_search import (
+    sbox_inequalities,
+    sbox_valid_transitions,
+)
 
 
 def test_generate_sbox_inequalities_for_trail_search():
@@ -8,3 +12,19 @@ def test_generate_sbox_inequalities_for_trail_search():
     sbox_ineqs = sbox_inequalities(SBox_PRESENT)
 
     assert str(sbox_ineqs[2][1]) == "An inequality (0, 0, 0, 1, 1, 0, 1, 0) x - 1 >= 0"
+
+
+def test_sbox_valid_transitions():
+    SBox_PRESENT = SBox([12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2])
+
+    differential = sbox_valid_transitions(SBox_PRESENT)
+    assert len(differential) == 96
+    assert (1, 3, 4) in differential
+    assert all(delta_in != 0 for delta_in, _, _ in differential)
+    assert all(isinstance(count, int) and count > 0 for _, _, count in differential)
+
+    linear = sbox_valid_transitions(SBox_PRESENT, analysis="linear")
+    assert len(linear) == 132
+
+    with pytest.raises(TypeError):
+        sbox_valid_transitions(SBox_PRESENT, analysis="invalid")


### PR DESCRIPTION
This PR adds `one_hot` as an alternative to the default `espresso` S-box formulation for MILP
XOR-differential and XOR-linear trail search, selectable via `MilpModel(..., sbox_modeling="one_hot")`:
- New `sbox_valid_transitions()` (nonzero DDT/LAT cells) and a shared
  `milp_one_hot_probability_constraints()` helper used by both the differential and linear wrappers.
- `sbox_modeling` fed through `MilpModel` / `MilpXorDifferentialModel` / `MilpXorLinearModel`,
  with validation.
  
  
While most likely too slow for 8-bit Sboxes due to the high number of transitions in the DDT (and thus, the number of binary variables that this encoding introduces), this approach can yield speedups, depending on the targeted cipher and instance (e.g. Present after 5 rounds)

**Comparison of solving time and number of variables/constraints for `find_lowest_weight_xor_differential_trail`**

| instance        | formulation | weight | exp | vars   | cons   | gurobi_s | gap | status  |
|-----------------|-------------|--------|-----|--------|--------|----------|-----|---------|
| sbox4           | espresso    | 2      | 2   | 21     | 76     | 0.007    | 0   | OPTIMAL |
| sbox4           | one_hot     | 2      | 2   | 115    | 20     | 0.003    | 0   | OPTIMAL |
| sbox3           | espresso    | 2      | 2   | 16     | 29     | 0        | 0   | OPTIMAL |
| sbox3           | one_hot     | 2      | 2   | 43     | 16     | 0.001    | 0   | OPTIMAL |
| sbox8           | espresso    | 6      | 6   | 37     | 8691   | 0.179    | 0   | OPTIMAL |
| sbox8           | one_hot     | 6      | 6   | 32420  | 36     | 0.191    | 0   | OPTIMAL |
| present_2r      | espresso    | 4      | 4   | 1339   | 3854   | 0.034    | 0   | OPTIMAL |
| present_2r      | one_hot     | 4      | 4   | 4535   | 1950   | 0.092    | 0   | OPTIMAL |
| present_3r      | espresso    | 8      | 8   | 1840   | 5548   | 0.26     | 0   | OPTIMAL |
| present_3r      | one_hot     | 8      | 8   | 6634   | 2692   | 2.091    | 0   | OPTIMAL |
| present_4r      | espresso    | 12     | 12  | 2341   | 7242   | 0.465    | 0   | OPTIMAL |
| present_4r      | one_hot     | 12     | 12  | 8733   | 3434   | 5.494    | 0   | OPTIMAL |
| present_5r      | espresso    | 20     | 20  | 2842   | 8936   | 13.138   | 0   | OPTIMAL |
| present_5r      | one_hot     | 20     | 20  | 10832  | 4176   | 3.351    | 0   | OPTIMAL |
| present_6r      | espresso    | 24     | 24  | 3343   | 10630  | 106.768  | 0   | OPTIMAL |
| present_6r      | one_hot     | 24     | 24  | 12931  | 4918   | 9.666    | 0   | OPTIMAL |
| skinny64_1r     | espresso    | 2      | ?   | 489    | 1390   | 0.004    | 0   | OPTIMAL |
| skinny64_1r     | one_hot     | 2      | ?   | 1993   | 798    | 0.008    | 0   | OPTIMAL |
| skinny64_2r     | espresso    | 4      | ?   | 845    | 2710   | 0.023    | 0   | OPTIMAL |
| skinny64_2r     | one_hot     | 4      | ?   | 3853   | 1526   | 0.079    | 0   | OPTIMAL |
| skinny64_3r     | espresso    | 10     | ?   | 1201   | 4030   | 0.116    | 0   | OPTIMAL |
| skinny64_3r     | one_hot     | 10     | ?   | 5713   | 2254   | 1.213    | 0   | OPTIMAL |
| skinny64_4r     | espresso    | 16     | ?   | 1557   | 5350   | 0.249    | 0   | OPTIMAL |
| skinny64_4r     | one_hot     | 16     | ?   | 7573   | 2982   | 3.515    | 0   | OPTIMAL |
| skinny64_5r     | espresso    | 24     | ?   | 1913   | 6670   | 3.173    | 0   | OPTIMAL |
| skinny64_5r     | one_hot     | 24     | ?   | 9433   | 3710   | 23.27    | 0   | OPTIMAL |
| toyaes8         | espresso    | 6      | 6   | 393    | 52680  | 0.735    | 0   | OPTIMAL |
| toyaes8         | one_hot     | 6      | 6   | 194691 | 750    | 0.993    | 0   | OPTIMAL |
| toyaes8_2r      | espresso    | 18     | 18  | 689    | 105710 | 8.315    | 0   | OPTIMAL |
| toyaes8_2r      | one_hot     | 18     | 18  | 389285 | 1850   | 40.596   | 0   | OPTIMAL |


Additional change: the solver time-regex in `solvers.py` for `HIGHS_EXT`was fixed. Newer HiGHS (≥1.11)
drops the `(total)` suffix, which previously caused a misleading "license might be missing" error;
the broadened regex matches both old and new output.