### PR TITLE
MILP trail search methods for one trail within a weight range 

### DIFF
--- a/claasp/cipher_modules/models/milp/milp_model.py
+++ b/claasp/cipher_modules/models/milp/milp_model.py
@@ -247,7 +247,7 @@ class MilpModel:
 
         INPUT:
 
-        - ``weight`` -- **integer**; the total weight. If negative, no constraints on the weight is added
+        - ``weight`` -- **integer**; the total weight, or ``-1`` for no constraint.
         - ``weight_precision`` -- **integer** (default: `2`); the number of decimals to use when rounding the weight of the trail.
 
         EXAMPLES::
@@ -263,16 +263,48 @@ class MilpModel:
             sage: constraints
             [x_0 == 1000]
         """
-        p = self._integer_variable
-        variables = []
-        constraints = []
+        if weight == -1:
+            return [], []
 
-        if weight >= 0:
-            constraints.append(p["probability"] == (10**weight_precision) * weight)
-            variables = [("p[probability]", p["probability"])]
-        elif weight != -1:
-            self._model.set_max(p["probability"], -(10**weight_precision) * weight)
-            variables = [("p[probability]", p["probability"])]
+        return self.weight_range_constraints(weight, weight, weight_precision)
+
+    def weight_range_constraints(self, min_weight, max_weight, weight_precision=MILP_DEFAULT_WEIGHT_PRECISION):
+        """
+        Return a list of variables and a list of constraints that bound the total weight to ``[min_weight, max_weight]``.
+
+        Unlike :py:meth:`weight_constraints`, which pins the weight to a single value, this bounds it to a
+        range. Setting ``min_weight == max_weight`` is equivalent to fixing the weight.
+
+        INPUT:
+
+        - ``min_weight`` -- **integer**; lower bound on the total weight
+        - ``max_weight`` -- **integer**; upper bound on the total weight
+        - ``weight_precision`` -- **integer** (default: `2`); the number of decimals to use when rounding the weight of the trail.
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.block_ciphers.simon_block_cipher import SimonBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_model import MilpModel
+            sage: simon = SimonBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: milp = MilpModel(simon)
+            sage: milp.init_model_in_sage_milp_class()
+            sage: variables, constraints = milp.weight_range_constraints(3, 10)
+            sage: variables
+            [('p[probability]', x_0)]
+            sage: constraints
+            [300 <= x_0, x_0 <= 1000]
+            sage: milp.weight_range_constraints(5, 5)[1]
+            [x_0 == 500]
+        """
+        p = self._integer_variable
+        prec = 10**weight_precision
+        variables = [("p[probability]", p["probability"])]
+        if min_weight == max_weight:
+            constraints = [p["probability"] == prec * min_weight]
+        else:
+            constraints = [p["probability"] <= prec * max_weight]
+            if min_weight > 0:
+                constraints.insert(0, p["probability"] >= prec * min_weight)
 
         return variables, constraints
 

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_differential_model.py
@@ -18,7 +18,6 @@ import os
 import sys
 import time
 
-import numpy as np
 from bitstring import BitArray
 
 from claasp.cipher_modules.models.milp.milp_model import MilpModel
@@ -390,8 +389,8 @@ class MilpXorDifferentialModel(MilpModel):
 
         .. NOTE::
 
-            Note that the search will start with ``min_weight`` and should end when the weight reaches a
-            value greater than the maximum cipher inputs bit-size. Fix a convenient ``max_weight`` value.
+            All trails with weight in ``[min_weight, max_weight]`` are enumerated in a single pass. Pick a
+            convenient ``max_weight``: a wide range can yield a very large number of trails.
 
         INPUT:
 
@@ -443,36 +442,31 @@ class MilpXorDifferentialModel(MilpModel):
             inputs_ids = [i for i in self._cipher.inputs if INPUT_KEY not in i]
 
         list_trails = []
-        precision = _set_weight_precision(self, "differential")
-        for weight in np.arange(min_weight, max_weight + 1, precision):
-            looking_for_other_solutions = 1
-            _, weight_constraints = self.weight_constraints(weight, weight_precision)
-            for constraint in weight_constraints:
-                mip.add_constraint(constraint)
-            number_new_constraints = len(weight_constraints)
-            while looking_for_other_solutions:
-                try:
-                    f = open(os.devnull, "w")
-                    sys.stdout = f
-                    solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
-                    sys.stdout = sys.__stdout__
-                    solution["building_time"] = building_time
-                    solution["test_name"] = "find_all_xor_differential_trails_with_weight_at_most"
-                    self._number_of_trails_found += 1
-                    self._verbose_print(f"trails found : {self._number_of_trails_found}")
-                    list_trails.append(solution)
-                    fixed_variables = self._get_fixed_variables_from_solution(fixed_values, inputs_ids, solution)
+        _set_weight_precision(self, "differential")
+        _, range_constraints = self.weight_range_constraints(min_weight, max_weight, weight_precision)
+        for constraint in range_constraints:
+            mip.add_constraint(constraint)
+        looking_for_other_solutions = 1
+        while looking_for_other_solutions:
+            try:
+                f = open(os.devnull, "w")
+                sys.stdout = f
+                solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
+                sys.stdout = sys.__stdout__
+                solution["building_time"] = building_time
+                solution["test_name"] = "find_all_xor_differential_trails_with_weight_at_most"
+                self._number_of_trails_found += 1
+                self._verbose_print(f"trails found : {self._number_of_trails_found}")
+                list_trails.append(solution)
+                fixed_variables = self._get_fixed_variables_from_solution(fixed_values, inputs_ids, solution)
 
-                    fix_var_constraints = self.exclude_variables_value_constraints(fixed_variables)
-                    for constraint in fix_var_constraints:
-                        mip.add_constraint(constraint)
-                    number_new_constraints += len(fix_var_constraints)
-                except Exception:
-                    looking_for_other_solutions = 0
-                finally:
-                    sys.stdout = sys.__stdout__
-            number_constraints = mip.number_of_constraints()
-            mip.remove_constraints(range(number_constraints - number_new_constraints, number_constraints))
+                fix_var_constraints = self.exclude_variables_value_constraints(fixed_variables)
+                for constraint in fix_var_constraints:
+                    mip.add_constraint(constraint)
+            except Exception:
+                looking_for_other_solutions = 0
+            finally:
+                sys.stdout = sys.__stdout__
         self._number_of_trails_found = 0
 
         return [trail for trail in list_trails if trail["status"] == "SATISFIABLE"]
@@ -595,6 +589,65 @@ class MilpXorDifferentialModel(MilpModel):
 
         return solution
 
+    def find_one_xor_differential_trail_with_weight_at_most(
+        self,
+        max_weight,
+        min_weight=0,
+        fixed_values=[],
+        weight_precision=MILP_DEFAULT_WEIGHT_PRECISION,
+        solver_name=SOLVER_DEFAULT,
+        external_solver_name=None,
+    ):
+        """
+        Return one XOR differential trail whose weight lies in ``[min_weight, max_weight]``, in standard format.
+        By default, the search is set in the single-key setting.
+
+        .. NOTE::
+
+            Feasibility search: returns any trail with weight in ``[min_weight, max_weight]``, not the trail of
+            lowest weight. With the default ``min_weight=0`` the returned trail may be trivial.
+
+        INPUT:
+
+        - ``max_weight`` -- **integer**; the upper bound on the weight of the trail
+        - ``min_weight`` -- **integer** (default: `0`); the lower bound on the weight of the trail
+        - ``fixed_values`` -- **list** (default: `[]`); dictionaries containing the variables to be fixed in standard
+            format
+        - ``weight_precision`` -- **integer** (default: `2`); the number of decimals to use when rounding the weight of the trail.
+        - ``solver_name`` -- **string** (default: `GLPK`); the solver to call
+        - ``external_solver_name`` -- **string** (default: None); if specified, the library will write the internal Sagemath MILP model as a .lp file and solve it outside of Sagemath, using the external solver.
+
+        .. SEEALSO::
+
+            :py:meth:`~cipher_modules.models.utils.set_fixed_variables`
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_differential_model import MilpXorDifferentialModel
+            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: milp = MilpXorDifferentialModel(speck)
+            sage: trail = milp.find_one_xor_differential_trail_with_weight_at_most(5)  # random
+            sage: trail['total_weight'] <= 5.0
+            True
+        """
+        start = time.time()
+        self.init_model_in_sage_milp_class(solver_name)
+        self._verbose_print(f"Solver used : {solver_name} (Choose Gurobi for Better performance)")
+        mip = self._model
+        mip.set_objective(None)
+        self.add_constraints_to_build_in_sage_milp_class(-1, weight_precision, fixed_values)
+        _, constraints = self.weight_range_constraints(min_weight, max_weight, weight_precision)
+        for constraint in constraints:
+            mip.add_constraint(constraint)
+        end = time.time()
+        building_time = end - start
+        solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
+        solution["building_time"] = building_time
+        solution["test_name"] = "find_one_xor_differential_trail_with_weight_at_most"
+
+        return solution
+
     def find_one_xor_differential_trail_with_fixed_weight(
         self,
         fixed_weight,
@@ -642,19 +695,14 @@ class MilpXorDifferentialModel(MilpModel):
             sage: trail['total_weight'] # doctest: +SKIP
             3.0
         """
-        start = time.time()
-        self.init_model_in_sage_milp_class(solver_name)
-        self._verbose_print(f"Solver used : {solver_name} (Choose Gurobi for Better performance)")
-        mip = self._model
-        mip.set_objective(None)
-        self.add_constraints_to_build_in_sage_milp_class(-1, weight_precision, fixed_values)
-        _, constraints = self.weight_constraints(fixed_weight, weight_precision)
-        for constraint in constraints:
-            mip.add_constraint(constraint)
-        end = time.time()
-        building_time = end - start
-        solution = self.solve(MILP_XOR_DIFFERENTIAL, solver_name, external_solver_name)
-        solution["building_time"] = building_time
+        solution = self.find_one_xor_differential_trail_with_weight_at_most(
+            fixed_weight,
+            fixed_weight,
+            fixed_values=fixed_values,
+            weight_precision=weight_precision,
+            solver_name=solver_name,
+            external_solver_name=external_solver_name,
+        )
         solution["test_name"] = "find_one_xor_differential_trail_with_fixed_weight"
 
         return solution

--- a/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
+++ b/claasp/cipher_modules/models/milp/milp_models/milp_xor_linear_model.py
@@ -20,7 +20,6 @@ import os
 import sys
 import time
 
-import numpy as np
 from bitstring import BitArray
 
 from claasp.cipher_modules.models.milp.milp_model import MilpModel
@@ -406,7 +405,7 @@ class MilpXorLinearModel(MilpModel):
         external_solver_name=None,
     ):
         """
-        Return all XOR linear trails with weight greater than ``min_weight`` and lower than or equal to ``max_weight``.
+        Return all XOR linear trails with weight greater than or equal to ``min_weight`` and lower than or equal to ``max_weight``.
         By default, the search removes the key schedule, if any.
 
         The value returned is a list of solutions in standard format.
@@ -417,8 +416,8 @@ class MilpXorLinearModel(MilpModel):
 
         .. NOTE::
 
-            Note that the search will start with ``min_weight`` and should end when the weight reaches a
-            value greater than the maximum cipher inputs bit-size. Fix a convenient ``max_weight`` value.
+            All trails with weight in ``[min_weight, max_weight]`` are enumerated in a single pass. Pick a
+            convenient ``max_weight``: a wide range can yield a very large number of trails.
 
         INPUT:
 
@@ -464,36 +463,31 @@ class MilpXorLinearModel(MilpModel):
 
         inputs_ids = self._cipher.inputs
         list_trails = []
-        precision = _set_weight_precision(self, "linear")
-        for weight in np.arange(min_weight, max_weight + 1, precision):
-            looking_for_other_solutions = 1
-            _, weight_constraints = self.weight_xor_linear_constraints(weight, weight_precision)
-            for constraint in weight_constraints:
-                mip.add_constraint(constraint)
-            number_new_constraints = len(weight_constraints)
-            while looking_for_other_solutions:
-                try:
-                    f = open(os.devnull, "w")
-                    sys.stdout = f
-                    solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
-                    sys.stdout = sys.__stdout__
-                    solution["building_time"] = building_time
-                    solution["test_name"] = "find_all_xor_linear_trails_with_weight_at_most"
-                    self._number_of_trails_found += 1
-                    self._verbose_print(f"trails found : {self._number_of_trails_found}")
-                    list_trails.append(solution)
-                    fixed_variables = self._get_fixed_variables_from_solution(fixed_values, inputs_ids, solution)
+        _set_weight_precision(self, "linear")
+        _, range_constraints = self.weight_range_constraints(min_weight, max_weight, weight_precision)
+        for constraint in range_constraints:
+            mip.add_constraint(constraint)
+        looking_for_other_solutions = 1
+        while looking_for_other_solutions:
+            try:
+                f = open(os.devnull, "w")
+                sys.stdout = f
+                solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
+                sys.stdout = sys.__stdout__
+                solution["building_time"] = building_time
+                solution["test_name"] = "find_all_xor_linear_trails_with_weight_at_most"
+                self._number_of_trails_found += 1
+                self._verbose_print(f"trails found : {self._number_of_trails_found}")
+                list_trails.append(solution)
+                fixed_variables = self._get_fixed_variables_from_solution(fixed_values, inputs_ids, solution)
 
-                    fix_var_constraints = self.exclude_variables_value_xor_linear_constraints(fixed_variables)
-                    for constraint in fix_var_constraints:
-                        mip.add_constraint(constraint)
-                    number_new_constraints += len(fix_var_constraints)
-                except Exception:
-                    looking_for_other_solutions = 0
-                finally:
-                    sys.stdout = sys.__stdout__
-            number_constraints = mip.number_of_constraints()
-            mip.remove_constraints(range(number_constraints - number_new_constraints, number_constraints))
+                fix_var_constraints = self.exclude_variables_value_xor_linear_constraints(fixed_variables)
+                for constraint in fix_var_constraints:
+                    mip.add_constraint(constraint)
+            except Exception:
+                looking_for_other_solutions = 0
+            finally:
+                sys.stdout = sys.__stdout__
         self._number_of_trails_found = 0
 
         return [trail for trail in list_trails if trail["status"] == SATISFIABLE]
@@ -632,6 +626,66 @@ class MilpXorLinearModel(MilpModel):
 
         return solution
 
+    def find_one_xor_linear_trail_with_weight_at_most(
+        self,
+        max_weight,
+        min_weight=0,
+        fixed_values=[],
+        weight_precision=MILP_DEFAULT_WEIGHT_PRECISION,
+        solver_name=SOLVER_DEFAULT,
+        external_solver_name=None,
+    ):
+        """
+        Return one XOR linear trail whose weight lies in ``[min_weight, max_weight]``, in standard format.
+        By default, the search removes the key schedule, if any, and the weight corresponds to the negative
+        base-2 logarithm of the correlation of the trail.
+
+        .. NOTE::
+
+            Feasibility search: returns any trail with weight in ``[min_weight, max_weight]``, not the trail of
+            lowest weight. With the default ``min_weight=0`` the returned trail may be trivial.
+
+        INPUT:
+
+        - ``max_weight`` -- **integer**; the upper bound on the weight of the trail
+        - ``min_weight`` -- **integer** (default: `0`); the lower bound on the weight of the trail
+        - ``fixed_values`` -- **list** (default: `[]`); dictionaries containing the variables to be fixed in standard
+            format
+        - ``weight_precision`` -- **integer** (default: `2`); the number of decimals to use when rounding the weight of the trail.
+        - ``solver_name`` -- **string** (default: `GLPK`); the name of the solver (if needed)
+        - ``external_solver_name`` -- **string** (default: None); if specified, the library will write the internal Sagemath MILP model as a .lp file and solve it outside of Sagemath, using the external solver.
+
+        .. SEEALSO::
+
+            :py:meth:`~cipher_modules.models.utils.set_fixed_variables`
+
+        EXAMPLES::
+
+            sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+            sage: from claasp.cipher_modules.models.milp.milp_models.milp_xor_linear_model import MilpXorLinearModel
+            sage: speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+            sage: milp = MilpXorLinearModel(speck)
+            sage: trail = milp.find_one_xor_linear_trail_with_weight_at_most(6)  # random
+            sage: trail['total_weight'] <= 6.0
+            True
+        """
+        start = time.time()
+        self.init_model_in_sage_milp_class(solver_name)
+        self._verbose_print(f"Solver used : {solver_name} (Choose Gurobi for Better performance)")
+        mip = self._model
+        mip.set_objective(None)
+        self.add_constraints_to_build_in_sage_milp_class(-1, weight_precision, fixed_values)
+        _, constraints = self.weight_range_constraints(min_weight, max_weight, weight_precision)
+        for constraint in constraints:
+            mip.add_constraint(constraint)
+        end = time.time()
+        building_time = end - start
+        solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
+        solution["building_time"] = building_time
+        solution["test_name"] = "find_one_xor_linear_trail_with_weight_at_most"
+
+        return solution
+
     def find_one_xor_linear_trail_with_fixed_weight(
         self,
         fixed_weight,
@@ -679,19 +733,14 @@ class MilpXorLinearModel(MilpModel):
             sage: trail["total_weight"]
             3.0
         """
-        start = time.time()
-        self.init_model_in_sage_milp_class(solver_name)
-        self._verbose_print(f"Solver used : {solver_name} (Choose Gurobi for Better performance)")
-        mip = self._model
-        mip.set_objective(None)
-        self.add_constraints_to_build_in_sage_milp_class(-1, weight_precision, fixed_values)
-        _, constraints = self.weight_xor_linear_constraints(fixed_weight, weight_precision)
-        for constraint in constraints:
-            mip.add_constraint(constraint)
-        end = time.time()
-        building_time = end - start
-        solution = self.solve(MILP_XOR_LINEAR, solver_name, external_solver_name)
-        solution["building_time"] = building_time
+        solution = self.find_one_xor_linear_trail_with_weight_at_most(
+            fixed_weight,
+            fixed_weight,
+            fixed_values=fixed_values,
+            weight_precision=weight_precision,
+            solver_name=solver_name,
+            external_solver_name=external_solver_name,
+        )
         solution["test_name"] = "find_one_xor_linear_trail_with_fixed_weight"
 
         return solution

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_differential_model_test.py
@@ -101,3 +101,12 @@ def test_find_one_xor_differential_trail_with_fixed_weight():
     )
     trail = milp.find_one_xor_differential_trail_with_fixed_weight(5, fixed_values=[key, round_0_output, cipher_output])
     assert trail["total_weight"] == 5.0
+
+
+def test_find_one_xor_differential_trail_with_weight_at_most():
+    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+    trail = MilpXorDifferentialModel(speck).find_one_xor_differential_trail_with_weight_at_most(5)
+    assert 0.0 <= trail["total_weight"] <= 5.0
+
+    trail = MilpXorDifferentialModel(speck).find_one_xor_differential_trail_with_weight_at_most(5, 3)
+    assert 3.0 <= trail["total_weight"] <= 5.0

--- a/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
+++ b/tests/unit/cipher_modules/models/milp/milp_models/milp_xor_linear_model_test.py
@@ -118,6 +118,15 @@ def test_find_one_xor_linear_trail_with_fixed_weight():
     # assert trail["total_weight"] == 10.0
 
 
+def test_find_one_xor_linear_trail_with_weight_at_most():
+    speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
+    trail = MilpXorLinearModel(speck).find_one_xor_linear_trail_with_weight_at_most(6)
+    assert 0.0 <= trail["total_weight"] <= 6.0
+
+    trail = MilpXorLinearModel(speck).find_one_xor_linear_trail_with_weight_at_most(6, 1)
+    assert 1.0 <= trail["total_weight"] <= 6.0
+
+
 def test_find_one_xor_linear_trail_with_fixed_weight_with_external_solver():
     speck = SpeckBlockCipher(block_bit_size=32, key_bit_size=64, number_of_rounds=2)
     milp = MilpXorLinearModel(speck)


### PR DESCRIPTION
Currently, the MILP xor differential/linear models only allow the user to find one optimal trail or one trail with an exact weight. This PR adds two new`find_one_xor_*_trail_with_weight_at_most` methods: 
- They take an upper bound (and optionally a lower bound), and return a trail whose weight falls within the range `[0..upper_bound]` (or `[lower_boud..upper_bound]`), mirroring the existing `find_all_*_trails_with_weight_at_most` methods.
- The old existing `fixed weight` methods now just call these with the lower and upper bound set to the same value.

Additional cleanup:
- Simplified `weight_constraints`, and removed an old unused trick where a negative weight quietly meant "at most". It only existed in the MILP model and nothing used it.
- Rewrote `find_all_..._with_weight_at_most` to add a single range constraint and collect the trails in one pass, instead of looping over every weight value. It returns the same trails, with fewer solver calls.