### PR TITLE
FEATURE/Add: experimental boomerang (BCT) distinguisher checker

### DIFF
--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -1122,6 +1122,85 @@ def linear_checker_for_block_cipher_single_key(
     return corr
 
 
+def _w_boomerang_sk(args):
+    (cipher, inverse, input_difference, output_difference, state_num_bytes, key_num_bytes,
+     fixed_key, chunk_size, seed) = args
+    rng = np.random.default_rng(seed)
+    fk = _repeat_input_difference(fixed_key, chunk_size, key_num_bytes)
+    delta_col = _repeat_input_difference(input_difference, chunk_size, state_num_bytes)      # (sb, n)
+    nabla_row = _repeat_input_difference(output_difference, chunk_size, state_num_bytes).T   # (n, sb)
+    plaintext_0 = rng.integers(0, 256, size=(state_num_bytes, chunk_size), dtype=np.uint8)
+    plaintext_1 = plaintext_0 ^ delta_col
+    ciphertext_0 = cipher.evaluate_vectorized([plaintext_0, fk])[0]                          # (n, sb)
+    ciphertext_1 = cipher.evaluate_vectorized([plaintext_1, fk])[0]
+    plaintext_2 = inverse.evaluate_vectorized([(ciphertext_0 ^ nabla_row).T, fk])[0]         # (n, sb)
+    plaintext_3 = inverse.evaluate_vectorized([(ciphertext_1 ^ nabla_row).T, fk])[0]
+    returned = plaintext_2 ^ plaintext_3
+    matches = np.all(returned == delta_col.T, axis=1)
+    return int(np.count_nonzero(matches))
+
+
+def boomerang_checker_for_block_cipher_single_key(
+    cipher, input_difference, output_difference, number_of_samples, block_size, key_size, fixed_key, seed=None,
+    num_workers=1
+):
+    """
+    Verify experimentally boomerang (BCT) distinguishers for block ciphers using the vectorized evaluator.
+
+    The sandwich/boomerang is checked directly: with a random plaintext ``P0`` and a fixed key,
+    ``P1 = P0 ^ input_difference``; the pair is encrypted, the ``output_difference`` is applied to both
+    ciphertexts, they are decrypted with the cipher's inverse, and the run is a success when the two
+    returned plaintexts differ exactly by ``input_difference``. The forward direction uses
+    ``cipher.evaluate_vectorized`` and the backward direction uses ``cipher.cipher_inverse()``.
+
+    INPUT:
+
+    - ``cipher`` -- **Cipher object**; invertible cipher providing ``evaluate_vectorized`` and ``cipher_inverse``
+    - ``input_difference`` -- **integer**; input XOR difference (delta)
+    - ``output_difference`` -- **integer**; output XOR difference (nabla)
+    - ``number_of_samples`` -- **integer**; number of random plaintext pairs
+    - ``block_size`` -- **integer**; block size in bits (must be multiple of 8)
+    - ``key_size`` -- **integer**; key size in bits (must be multiple of 8)
+    - ``fixed_key`` -- **integer**; fixed key value for the single-key scenario
+    - ``seed`` -- **integer** (default: `None`); seed for reproducible random sampling
+    - ``num_workers`` -- **integer** (default: `1`); number of parallel worker processes
+
+    OUTPUT:
+
+    - This method returns a **float**; the empirical boomerang probability in the interval ``[0, 1]``
+
+    EXAMPLES::
+
+        sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
+        sage: from claasp.cipher_modules.models.utils import boomerang_checker_for_block_cipher_single_key
+        sage: speck = SpeckBlockCipher(number_of_rounds=5)
+        sage: boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 1024, 32, 64, 0)
+        1.0
+    """
+    if block_size % 8 != 0:
+        raise ValueError("State size must be a multiple of 8.")
+    if key_size % 8 != 0:
+        raise ValueError("Key size must be a multiple of 8.")
+    state_num_bytes = int(block_size / 8)
+    key_num_bytes = int(key_size / 8)
+    # cast to Python int so `.to_bytes` / float division work when called with Sage Integers
+    input_difference = int(input_difference)
+    output_difference = int(output_difference)
+    fixed_key = int(fixed_key)
+    number_of_samples = int(number_of_samples)
+    if seed is not None:
+        seed = int(seed)
+    inverse = cipher.cipher_inverse()
+    fixed_args = (
+        cipher, inverse, input_difference, output_difference, state_num_bytes, key_num_bytes, fixed_key,
+    )
+    if num_workers > 1:
+        count, total = _parallel_dispatch(_w_boomerang_sk, fixed_args, number_of_samples, num_workers, seed)
+        return count / total
+    count = _w_boomerang_sk(fixed_args + (number_of_samples, seed))
+    return count / number_of_samples
+
+
 def differential_checker_permutation(
     cipher, input_difference, output_difference, number_of_samples, state_size, seed=None, num_workers=1
 ):

--- a/claasp/cipher_modules/models/utils.py
+++ b/claasp/cipher_modules/models/utils.py
@@ -39,6 +39,9 @@ from claasp.name_mappings import (
     WORD_OPERATION,
 )
 
+STATE_SIZE_MULTIPLE_OF_8_ERROR = "State size must be a multiple of 8."
+KEY_SIZE_MULTIPLE_OF_8_ERROR = "Key size must be a multiple of 8."
+
 
 def hex_to_bitlist(hex_str):
     if not hex_str.startswith(("0x", "0X")):
@@ -1025,9 +1028,9 @@ def differential_linear_checker_for_block_cipher_single_key(
     - This method returns a **float**; the empirical correlation in the interval ``[-1, 1]``
     """
     if block_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     if key_size % 8 != 0:
-        raise ValueError("Key size must be a multiple of 8.")
+        raise ValueError(KEY_SIZE_MULTIPLE_OF_8_ERROR)
     state_num_bytes = int(block_size / 8)
     key_num_bytes = int(key_size / 8)
     if num_workers > 1:
@@ -1077,9 +1080,9 @@ def linear_checker_for_block_cipher_single_key(
     - This method returns a **float**; the empirical correlation in the interval ``[-1, 1]``
     """
     if block_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     if key_size % 8 != 0:
-        raise ValueError("Key size must be a multiple of 8.")
+        raise ValueError(KEY_SIZE_MULTIPLE_OF_8_ERROR)
     if len(input_mask) != block_size:
         raise ValueError("Input mask length must be equal to block_size.")
     if len(output_mask) != block_size:
@@ -1174,13 +1177,23 @@ def boomerang_checker_for_block_cipher_single_key(
         sage: from claasp.ciphers.block_ciphers.speck_block_cipher import SpeckBlockCipher
         sage: from claasp.cipher_modules.models.utils import boomerang_checker_for_block_cipher_single_key
         sage: speck = SpeckBlockCipher(number_of_rounds=5)
-        sage: boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 1024, 32, 64, 0)
+        sage: input_difference = 0
+        sage: output_difference = 0
+        sage: boomerang_checker_for_block_cipher_single_key(
+        ....:     speck,
+        ....:     input_difference=input_difference,
+        ....:     output_difference=output_difference,
+        ....:     number_of_samples=1024,
+        ....:     block_size=32,
+        ....:     key_size=64,
+        ....:     fixed_key=0,
+        ....: )
         1.0
     """
     if block_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     if key_size % 8 != 0:
-        raise ValueError("Key size must be a multiple of 8.")
+        raise ValueError(KEY_SIZE_MULTIPLE_OF_8_ERROR)
     state_num_bytes = int(block_size / 8)
     key_num_bytes = int(key_size / 8)
     # cast to Python int so `.to_bytes` / float division work when called with Sage Integers
@@ -1222,7 +1235,7 @@ def differential_checker_permutation(
     - This method returns a **float**; the empirical probability weight ``log2(matches / number_of_samples)``
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     num_bytes = int(state_size / 8)
 
     if num_workers > 1:
@@ -1269,7 +1282,7 @@ def differential_truncated_checker_permutation(
     - This method returns a **float**; the empirical probability weight, or ``-inf`` if no match is found
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     num_bytes = int(state_size / 8)
 
     if num_workers > 1:
@@ -1332,7 +1345,7 @@ def differential_truncated_checker_single_key(
     - This method returns a **float**; the empirical probability weight ``log2(matches / number_of_samples)``
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     num_bytes = int(state_size / 8)
     key_num_bytes = int(key_size / 8)
 
@@ -1389,7 +1402,7 @@ def shared_difference_paired_input_differential_checker_permutation(
     - This method returns a **float**; the empirical probability weight ``log2(matches / number_of_samples)``
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     num_bytes = int(state_size / 8)
 
     if num_workers > 1:
@@ -1445,7 +1458,7 @@ def shared_difference_paired_input_differential_linear_checker_permutation(
     - This method returns a **float**; the empirical correlation in the interval ``[-1, 1]``
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     num_bytes = int(state_size / 8)
 
     if num_workers > 1:
@@ -1504,7 +1517,7 @@ def _sample_truncated_difference_from_string(pattern, num_samples, state_size, r
         raise ValueError("pattern may only contain '0', '1', '2', or '?'.")
 
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
 
     # Fixed positions & values (MSB-first indexing)
     indices = np.arange(state_size)
@@ -1550,7 +1563,7 @@ def differential_truncated_checker_permutation_input_and_output_truncated(
     - This method returns a **float**; the empirical probability weight, or ``-inf`` if no match is found
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     if len(input_trunc_diff) != state_size or len(output_trunc_diff) != state_size:
         raise ValueError("Both truncated differences must have length == state_size.")
 
@@ -1619,7 +1632,7 @@ def truncated_differential_linear_checker_permutation(
     - This method returns a **float**; the empirical correlation in the interval ``[-1, 1]``
     """
     if state_size % 8 != 0:
-        raise ValueError("State size must be a multiple of 8.")
+        raise ValueError(STATE_SIZE_MULTIPLE_OF_8_ERROR)
     if len(input_trunc_diff) != state_size or len(output_mask) != state_size:
         raise ValueError("Both truncated differences must have length == state_size.")
 

--- a/tests/unit/cipher_modules/models/models_utils_test.py
+++ b/tests/unit/cipher_modules/models/models_utils_test.py
@@ -20,6 +20,7 @@ from claasp.cipher_modules.models.utils import (
     _w_sdpi_diff_linear_perm,
     _w_sdpi_diff_perm,
     _w_trunc_diff_linear_perm,
+    boomerang_checker_for_block_cipher_single_key,
     check_if_implemented_component,
     convert_solver_solution_to_dictionary,
     differential_checker_permutation,
@@ -170,7 +171,34 @@ def test_parallel_and_validation_paths_for_checker_helpers():
 
     with pytest.raises(ValueError, match="State size must be a multiple of 8"):
         differential_checker_permutation(cipher, 0, 0, 8, 7)
-    
+
+
+def test_boomerang_checker_for_block_cipher_single_key():
+    speck = SpeckBlockCipher(number_of_rounds=5)
+
+    # deterministic edge cases: a zero difference on either side always returns
+    assert boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 4096, 32, 64, 0) == 1.0
+    assert boomerang_checker_for_block_cipher_single_key(speck, 0x81008102, 0, 4096, 32, 64, 0) == 1.0
+    assert boomerang_checker_for_block_cipher_single_key(speck, 0, 0x00008000, 4096, 32, 64, 0) == 1.0
+    # the parallel path also returns 1.0 on a deterministic case
+    assert boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 4096, 32, 64, 0, num_workers=2) == 1.0
+
+    # rounds 4 -> 7 sub-distinguisher (through the boomerang switch) of the SPECK32/64
+    # characteristic from Wang, Wang, Sun, "SAT-aided Automatic Search of Boomerang
+    # Distinguishers for ARX Ciphers", ToSC, Table 6: round-4 difference 0x81008102,
+    # round-7 difference 0x0a040804, boomerang probability ~ 2^-14. Single-key, so a
+    # 3-round reduced Speck reproduces it.
+    prob = boomerang_checker_for_block_cipher_single_key(
+        SpeckBlockCipher(number_of_rounds=3), 0x81008102, 0x0a040804, 1 << 18, 32, 64, 0, seed=1
+    )
+    assert 2 ** -17 < prob < 2 ** -11
+
+    # input validation
+    with pytest.raises(ValueError, match="State size must be a multiple of 8"):
+        boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 16, 7, 64, 0)
+    with pytest.raises(ValueError, match="Key size must be a multiple of 8"):
+        boomerang_checker_for_block_cipher_single_key(speck, 0, 0, 16, 32, 7, 0)
+
 
 def test_print_components_values():
     old_stdout = sys.stdout


### PR DESCRIPTION
## What

Adds `boomerang_checker_for_block_cipher_single_key` to `claasp/cipher_modules/models/utils.py`, completing the family of single-key experimental distinguisher checkers (which already covers differential-linear and linear).

## How

It mirrors the existing checkers and reuses their helpers (`_repeat_input_difference`, `_parallel_dispatch`). For a fixed key it draws random plaintext pairs `P1 = P0 ^ Δ`, encrypts with `evaluate_vectorized`, applies the output difference `∇` to both ciphertexts, decrypts with `cipher.cipher_inverse()`, and counts the fraction of quartets that return exactly by `Δ`:

```
P1 = P0 ^ input_difference
C0, C1 = E(P0), E(P1)
P2, P3 = E⁻¹(C0 ^ output_difference), E⁻¹(C1 ^ output_difference)
success  ⇔  (P2 ^ P3) == input_difference
```

Returns the empirical boomerang probability in `[0, 1]`. The only capability it needs beyond the differential-linear checker is `cipher.cipher_inverse()` (already available), so it is **generic for any invertible block cipher / permutation**. Parallel workers via the shared `_parallel_dispatch`.

## Tests

`tests/unit/cipher_modules/models/models_utils_test.py::test_boomerang_checker_for_block_cipher_single_key` — on **Speck-32/64**:
- deterministic edge cases (a zero difference on either side returns `1.0`), including the parallel `num_workers=2` path;
- a **rounds-4→7 sub-distinguisher** (through the switch) of the SPECK32/64 boomerang characteristic from Wang, Wang, Sun, *"SAT-aided Automatic Search of Boomerang Distinguishers for ARX Ciphers"* (ToSC), **Table 6** — round-4 diff `0x81008102`, round-7 diff `0x0a040804`, boomerang probability ≈ `2^-14`; single-key, so a 3-round reduced Speck reproduces it;
- input validation (`ValueError` on non-multiple-of-8 block/key sizes).

Doctest (`sage -t`) and the unit test pass in the CLAASP docker image.