### PR TITLE
Fix GIFT specification compliance and test vectors

### DIFF
--- a/claasp/ciphers/block_ciphers/gift_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/gift_block_cipher.py
@@ -26,11 +26,13 @@ from claasp.utils.utils import get_inputs_parameter
 KEY_NUM = 8
 KEY_SIZE = 16
 STATE_NUM = 4
-STATE_SIZE = 32
 KEY_ROT = [2, 12]
-PARAMETERS_CONFIGURATION_LIST = [{"number_of_rounds": 40}]
+PARAMETERS_CONFIGURATION_LIST = [
+    {"block_bit_size": 64, "number_of_rounds": 28},
+    {"block_bit_size": 128, "number_of_rounds": 40},
+]
 # fmt: off
-P_BOX = [
+P_BOX_128 = [
     [
         2, 6, 10, 14, 18, 22, 26, 30, 1, 5, 9, 13, 17, 21, 25, 29,
         0, 4, 8, 12, 16, 20, 24, 28, 3, 7, 11, 15, 19, 23, 27, 31
@@ -47,6 +49,12 @@ P_BOX = [
         3, 7, 11, 15, 19, 23, 27, 31, 2, 6, 10, 14, 18, 22, 26, 30,
         1, 5, 9, 13, 17, 21, 25, 29, 0, 4, 8, 12, 16, 20, 24, 28
     ],
+]
+P_BOX_64 = [
+    [2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15],
+    [1, 5, 9, 13, 0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14],
+    [0, 4, 8, 12, 3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13],
+    [3, 7, 11, 15, 2, 6, 10, 14, 1, 5, 9, 13, 0, 4, 8, 12],
 ]
 ROUND_CONSTANT = [
     0x80000001, 0x80000003, 0x80000007, 0x8000000F, 0x8000001F, 0x8000003E, 0x8000003D, 0x8000003B,
@@ -65,14 +73,20 @@ class GiftBlockCipher(Cipher):
 
     This class is used to store compact representations of a cipher, used to generate the corresponding cipher.
 
+    REFERENCES:
+
+    Specification and test vectors from [GIFT2017]_.
+
     INPUT:
 
-        - ``number_of_rounds`` -- **integer** (default: `40`); number of rounds of the block cipher
+        - ``block_bit_size`` -- **integer** (default: `128`); block size of the cipher, either 64 or 128
+        - ``number_of_rounds`` -- **integer** (default: `None`); number of rounds. If None, 28 rounds are used for a
+          64-bit block and 40 rounds for a 128-bit block
 
     EXAMPLES::
 
         sage: from claasp.ciphers.block_ciphers.gift_block_cipher import GiftBlockCipher
-        sage: gift = GiftBlockCipher(number_of_rounds=40)
+        sage: gift = GiftBlockCipher(block_bit_size=128, number_of_rounds=40)
         sage: gift.number_of_rounds
         40
 
@@ -80,9 +94,16 @@ class GiftBlockCipher(Cipher):
         'and_0_0'
     """
 
-    def __init__(self, number_of_rounds=40):
-        self.state_bit_size = STATE_NUM * STATE_SIZE
+    def __init__(self, number_of_rounds=None, block_bit_size=128):
+        if block_bit_size not in (64, 128):
+            raise ValueError('block_bit_size must be 64 or 128')
+        if number_of_rounds is None:
+            number_of_rounds = 28 if block_bit_size == 64 else 40
+
+        self.state_bit_size = block_bit_size
+        self.state_word_size = block_bit_size // STATE_NUM
         self.key_bit_size = KEY_NUM * KEY_SIZE
+        self.p_box = P_BOX_64 if block_bit_size == 64 else P_BOX_128
 
         super().__init__(
             family_name="gift",
@@ -95,7 +116,8 @@ class GiftBlockCipher(Cipher):
         # state initialization
         state = []
         for i in range(STATE_NUM):
-            p = ComponentState([INPUT_PLAINTEXT], [[k + i * STATE_SIZE for k in range(STATE_SIZE)]])
+            bit_positions = [STATE_NUM * k + STATE_NUM - 1 - i for k in range(self.state_word_size)]
+            p = ComponentState([INPUT_PLAINTEXT], [bit_positions])
             state.append(p)
 
         # key initialization
@@ -110,27 +132,28 @@ class GiftBlockCipher(Cipher):
             self.add_round()
 
             # round constant
-            ci = ROUND_CONSTANT[r]
+            ci = (1 << (self.state_word_size - 1)) | (ROUND_CONSTANT[r] & 0x3F)
 
             # update key schedule
             if r != 0:
                 key_list = self.key_schedule(key_list)
-            round_key_u = ComponentState(
-                deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
-                deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
-            )
-            round_key_v = ComponentState(
-                deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
-                deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
-            )
+            if block_bit_size == 64:
+                round_key_u = deepcopy(key_list[6])
+                round_key_v = deepcopy(key_list[7])
+            else:
+                round_key_u = ComponentState(
+                    deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
+                    deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
+                )
+                round_key_v = ComponentState(
+                    deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
+                    deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
+                )
             # round function
             state = self.round_function(state, round_key_u, round_key_v, ci)
 
             # round output
-            inputs = []
-            for i in range(STATE_NUM):
-                inputs.append(state[i])
-            inputs_id, inputs_pos = get_inputs_parameter(inputs)
+            inputs_id, inputs_pos = self.get_cipher_output_inputs(state)
             if r == number_of_rounds - 1:
                 self.add_cipher_output_component(inputs_id, inputs_pos, self.state_bit_size)
             else:
@@ -153,53 +176,63 @@ class GiftBlockCipher(Cipher):
 
         return key_new
 
+    def get_cipher_output_inputs(self, state):
+        inputs_id = []
+        inputs_pos = []
+        for bit_position in range(self.state_word_size):
+            for state_word in reversed(state):
+                inputs_id.extend(state_word.id)
+                inputs_pos.extend([[state_word.input_bit_positions[0][bit_position]]])
+
+        return inputs_id, inputs_pos
+
     def round_function(self, state, round_key_u, round_key_v, ci):
         # subcells
         # S1 = S1 xor (S0 & S2)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[2]])
-        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
-        input_bit_positions = list(range(STATE_SIZE))
+        self.add_and_component(inputs_id, inputs_pos, self.state_word_size)
+        input_bit_positions = list(range(self.state_word_size))
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[1], temp])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S0 = S0 xor (S1 & S3)
         inputs_id, inputs_pos = get_inputs_parameter([state[1], state[3]])
-        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, self.state_word_size)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[0], temp])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[0] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S2 = S2 xor (S0 or S1)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[1]])
-        self.add_or_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_or_component(inputs_id, inputs_pos, self.state_word_size)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], temp])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = S3 xor S2
         inputs_id, inputs_pos = get_inputs_parameter([state[2], state[3]])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S1 = S1 xor S3
         inputs_id, inputs_pos = get_inputs_parameter([state[1], state[3]])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = ~S3
-        self.add_not_component(state[3].id, state[3].input_bit_positions, STATE_SIZE)
+        self.add_not_component(state[3].id, state[3].input_bit_positions, self.state_word_size)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S2 = S2 xor (S0 & S1)
         inputs_id, inputs_pos = get_inputs_parameter([state[0], state[1]])
-        self.add_and_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_and_component(inputs_id, inputs_pos, self.state_word_size)
         temp = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[2], temp])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S0, S1, S2, S3 = S3, S1, S2, S0
@@ -208,25 +241,26 @@ class GiftBlockCipher(Cipher):
         # permbits
         # Si = permutation_i(Si)
         for i in range(STATE_NUM):
-            state[i] = ComponentState(state[i].id, [deepcopy(P_BOX[i])])
+            state[i] = ComponentState(state[i].id, [deepcopy(self.p_box[i])])
 
         # addroundkey
-        # S2 = S2 xor U
-        inputs_id, inputs_pos = get_inputs_parameter([state[2], round_key_u])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
-        state[2] = ComponentState([self.get_current_component_id()], [input_bit_positions])
+        key_word_u = 1 if self.state_bit_size == 64 else 2
+        key_word_v = 0 if self.state_bit_size == 64 else 1
 
-        # S1 = S1 xor V
-        inputs_id, inputs_pos = get_inputs_parameter([state[1], round_key_v])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
-        state[1] = ComponentState([self.get_current_component_id()], [input_bit_positions])
+        inputs_id, inputs_pos = get_inputs_parameter([state[key_word_u], round_key_u])
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
+        state[key_word_u] = ComponentState([self.get_current_component_id()], [input_bit_positions])
+
+        inputs_id, inputs_pos = get_inputs_parameter([state[key_word_v], round_key_v])
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
+        state[key_word_v] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         # S3 = S3 xor ci
         # add round constant
-        self.add_constant_component(STATE_SIZE, ci)
+        self.add_constant_component(self.state_word_size, ci)
         c = ComponentState([self.get_current_component_id()], [input_bit_positions])
         inputs_id, inputs_pos = get_inputs_parameter([state[3], c])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
         state[3] = ComponentState([self.get_current_component_id()], [input_bit_positions])
 
         return state

--- a/claasp/ciphers/block_ciphers/gift_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/gift_block_cipher.py
@@ -137,18 +137,7 @@ class GiftBlockCipher(Cipher):
             # update key schedule
             if r != 0:
                 key_list = self.key_schedule(key_list)
-            if block_bit_size == 64:
-                round_key_u = deepcopy(key_list[6])
-                round_key_v = deepcopy(key_list[7])
-            else:
-                round_key_u = ComponentState(
-                    deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
-                    deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
-                )
-                round_key_v = ComponentState(
-                    deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
-                    deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
-                )
+            round_key_u, round_key_v = self.get_round_keys(key_list)
             # round function
             state = self.round_function(state, round_key_u, round_key_v, ci)
 
@@ -175,6 +164,21 @@ class GiftBlockCipher(Cipher):
             key_new.append(deepcopy(key[i]))
 
         return key_new
+
+    def get_round_keys(self, key):
+        if self.state_bit_size == 64:
+            return deepcopy(key[6]), deepcopy(key[7])
+
+        round_key_u = ComponentState(
+            deepcopy(key[2].id) + deepcopy(key[3].id),
+            deepcopy(key[2].input_bit_positions) + deepcopy(key[3].input_bit_positions),
+        )
+        round_key_v = ComponentState(
+            deepcopy(key[6].id) + deepcopy(key[7].id),
+            deepcopy(key[6].input_bit_positions) + deepcopy(key[7].input_bit_positions),
+        )
+
+        return round_key_u, round_key_v
 
     def get_cipher_output_inputs(self, state):
         inputs_id = []

--- a/claasp/ciphers/block_ciphers/gift_sbox_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/gift_sbox_block_cipher.py
@@ -139,18 +139,7 @@ class GiftSboxBlockCipher(Cipher):
             # update key schedule
             if round_number != 0:
                 key_list = self.key_schedule(key_list)
-            if block_bit_size == 64:
-                round_key_u = deepcopy(key_list[6])
-                round_key_v = deepcopy(key_list[7])
-            else:
-                round_key_u = ComponentState(
-                    deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
-                    deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
-                )
-                round_key_v = ComponentState(
-                    deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
-                    deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
-                )
+            round_key_u, round_key_v = self.get_round_keys(key_list)
             # round function
             state = self.round_function(state, round_key_u, round_key_v, ci)
 
@@ -177,6 +166,21 @@ class GiftSboxBlockCipher(Cipher):
             key_new.append(deepcopy(key[i]))
 
         return key_new
+
+    def get_round_keys(self, key):
+        if self.state_bit_size == 64:
+            return deepcopy(key[6]), deepcopy(key[7])
+
+        round_key_u = ComponentState(
+            deepcopy(key[2].id) + deepcopy(key[3].id),
+            deepcopy(key[2].input_bit_positions) + deepcopy(key[3].input_bit_positions),
+        )
+        round_key_v = ComponentState(
+            deepcopy(key[6].id) + deepcopy(key[7].id),
+            deepcopy(key[6].input_bit_positions) + deepcopy(key[7].input_bit_positions),
+        )
+
+        return round_key_u, round_key_v
 
     def get_cipher_output_inputs(self, state):
         inputs_id = []

--- a/claasp/ciphers/block_ciphers/gift_sbox_block_cipher.py
+++ b/claasp/ciphers/block_ciphers/gift_sbox_block_cipher.py
@@ -27,12 +27,14 @@ KEY_NUM = 8
 KEY_SIZE = 16
 STATE_NUM = 4
 S_BOX_SIZE = 4
-STATE_SIZE = 32
 KEY_ROT = [2, 12]
-PARAMETERS_CONFIGURATION_LIST = [{"number_of_rounds": 40}]
+PARAMETERS_CONFIGURATION_LIST = [
+    {"block_bit_size": 64, "number_of_rounds": 28},
+    {"block_bit_size": 128, "number_of_rounds": 40},
+]
 S_BOX = [0x8, 0x4, 0x6, 0xA, 0x2, 0xD, 0xC, 0x1, 0x5, 0xB, 0xF, 0x0, 0x3, 0xE, 0x9, 0x7]
 # fmt: off
-P_BOX = [
+P_BOX_128 = [
     [
         16, 8, 0, 24, 17, 9, 1, 25, 18, 10, 2, 26, 19, 11, 3, 27, 20, 12,
         4, 28, 21, 13, 5, 29, 22, 14, 6, 30, 23, 15, 7, 31
@@ -49,6 +51,12 @@ P_BOX = [
         24, 16, 8, 0, 25, 17, 9, 1, 26, 18, 10, 2, 27, 19, 11,
         3, 28, 20, 12, 4, 29, 21, 13, 5, 30, 22, 14, 6, 31, 23, 15, 7
     ],
+]
+P_BOX_64 = [
+    [8, 4, 0, 12, 9, 5, 1, 13, 10, 6, 2, 14, 11, 7, 3, 15],
+    [4, 0, 12, 8, 5, 1, 13, 9, 6, 2, 14, 10, 7, 3, 15, 11],
+    [0, 12, 8, 4, 1, 13, 9, 5, 2, 14, 10, 6, 3, 15, 11, 7],
+    [12, 8, 4, 0, 13, 9, 5, 1, 14, 10, 6, 2, 15, 11, 7, 3],
 ]
 ROUND_CONSTANT = [
     0x80000001, 0x80000003, 0x80000007, 0x8000000F, 0x8000001F, 0x8000003E, 0x8000003D, 0x8000003B,
@@ -67,14 +75,20 @@ class GiftSboxBlockCipher(Cipher):
 
     This class is used to store compact representations of a cipher, used to generate the corresponding cipher.
 
+    REFERENCES:
+
+    Specification and test vectors from [GIFT2017]_.
+
     INPUT:
 
-        - ``number_of_rounds`` -- **integer** (default: `40`); number of rounds of the block cipher
+        - ``block_bit_size`` -- **integer** (default: `128`); block size of the cipher, either 64 or 128
+        - ``number_of_rounds`` -- **integer** (default: `None`); number of rounds. If None, 28 rounds are used for a
+          64-bit block and 40 rounds for a 128-bit block
 
     EXAMPLES::
 
         sage: from claasp.ciphers.block_ciphers.gift_sbox_block_cipher import GiftSboxBlockCipher
-        sage: gift = GiftSboxBlockCipher(number_of_rounds=40)
+        sage: gift = GiftSboxBlockCipher(block_bit_size=128, number_of_rounds=40)
         sage: gift.number_of_rounds
         40
 
@@ -82,9 +96,16 @@ class GiftSboxBlockCipher(Cipher):
         'sbox_0_0'
     """
 
-    def __init__(self, number_of_rounds=40):
-        self.state_bit_size = STATE_NUM * STATE_SIZE
+    def __init__(self, number_of_rounds=None, block_bit_size=128):
+        if block_bit_size not in (64, 128):
+            raise ValueError('block_bit_size must be 64 or 128')
+        if number_of_rounds is None:
+            number_of_rounds = 28 if block_bit_size == 64 else 40
+
+        self.state_bit_size = block_bit_size
+        self.state_word_size = block_bit_size // STATE_NUM
         self.key_bit_size = KEY_NUM * KEY_SIZE
+        self.p_box = P_BOX_64 if block_bit_size == 64 else P_BOX_128
 
         super().__init__(
             family_name="gift_sbox",
@@ -97,7 +118,8 @@ class GiftSboxBlockCipher(Cipher):
         # state initialization
         state = []
         for i in range(STATE_NUM):
-            p = ComponentState([INPUT_PLAINTEXT], [[k + i * STATE_SIZE for k in range(STATE_SIZE)]])
+            bit_positions = [STATE_NUM * k + STATE_NUM - 1 - i for k in range(self.state_word_size)]
+            p = ComponentState([INPUT_PLAINTEXT], [bit_positions])
             state.append(p)
 
         # key initialization
@@ -112,28 +134,28 @@ class GiftSboxBlockCipher(Cipher):
             self.add_round()
 
             # round constant
-            ci = ROUND_CONSTANT[round_number]
+            ci = (1 << (self.state_word_size - 1)) | (ROUND_CONSTANT[round_number] & 0x3F)
 
             # update key schedule
             if round_number != 0:
                 key_list = self.key_schedule(key_list)
-            round_key_u = ComponentState(
-                deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
-                deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
-            )
-
-            round_key_v = ComponentState(
-                deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
-                deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
-            )
+            if block_bit_size == 64:
+                round_key_u = deepcopy(key_list[6])
+                round_key_v = deepcopy(key_list[7])
+            else:
+                round_key_u = ComponentState(
+                    deepcopy(key_list[2].id) + deepcopy(key_list[3].id),
+                    deepcopy(key_list[2].input_bit_positions) + deepcopy(key_list[3].input_bit_positions),
+                )
+                round_key_v = ComponentState(
+                    deepcopy(key_list[6].id) + deepcopy(key_list[7].id),
+                    deepcopy(key_list[6].input_bit_positions) + deepcopy(key_list[7].input_bit_positions),
+                )
             # round function
             state = self.round_function(state, round_key_u, round_key_v, ci)
 
             # round output
-            inputs = []
-            for i in range(STATE_NUM):
-                inputs.append(state[i])
-            inputs_id, inputs_pos = get_inputs_parameter(inputs)
+            inputs_id, inputs_pos = self.get_cipher_output_inputs(state)
             if round_number == number_of_rounds - 1:
                 self.add_cipher_output_component(inputs_id, inputs_pos, self.state_bit_size)
             else:
@@ -156,12 +178,24 @@ class GiftSboxBlockCipher(Cipher):
 
         return key_new
 
+    def get_cipher_output_inputs(self, state):
+        inputs_id = []
+        inputs_pos = []
+        for bit_position in range(self.state_word_size):
+            for state_word in reversed(state):
+                inputs_id.extend(state_word.id)
+                inputs_pos.extend([[state_word.input_bit_positions[0][bit_position]]])
+
+        return inputs_id, inputs_pos
+
     def round_function(self, state, round_key_u, round_key_v, ci):
         # subcells
         # using sbox
-        p = ComponentState(["" for _ in range(STATE_SIZE)], [[] for _ in range(STATE_SIZE)])
+        p = ComponentState(
+            ["" for _ in range(self.state_word_size)], [[] for _ in range(self.state_word_size)]
+        )
         state_new = [deepcopy(p) for _ in range(STATE_NUM)]
-        for k in range(STATE_SIZE):
+        for k in range(self.state_word_size):
             inputs_id = []
             inputs_pos = []
             for i in range(STATE_NUM):
@@ -178,26 +212,27 @@ class GiftSboxBlockCipher(Cipher):
         # Si = permutation_i(Si)
         for i in range(STATE_NUM):
             inputs_id, inputs_pos = get_inputs_parameter([state[i]])
-            self.add_permutation_component(inputs_id, inputs_pos, STATE_SIZE, deepcopy(P_BOX[i]))
-            state[i] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
+            self.add_permutation_component(inputs_id, inputs_pos, self.state_word_size, deepcopy(self.p_box[i]))
+            state[i] = ComponentState([self.get_current_component_id()], [list(range(self.state_word_size))])
 
         # addroundkey
-        # S2 = S2 xor U
-        inputs_id, inputs_pos = get_inputs_parameter([state[2], round_key_u])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
-        state[2] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
+        key_word_u = 1 if self.state_bit_size == 64 else 2
+        key_word_v = 0 if self.state_bit_size == 64 else 1
 
-        # S1 = S1 xor V
-        inputs_id, inputs_pos = get_inputs_parameter([state[1], round_key_v])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
-        state[1] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
+        inputs_id, inputs_pos = get_inputs_parameter([state[key_word_u], round_key_u])
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
+        state[key_word_u] = ComponentState([self.get_current_component_id()], [list(range(self.state_word_size))])
+
+        inputs_id, inputs_pos = get_inputs_parameter([state[key_word_v], round_key_v])
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
+        state[key_word_v] = ComponentState([self.get_current_component_id()], [list(range(self.state_word_size))])
 
         # S3 = S3 xor ci
         # add round constant
-        self.add_constant_component(STATE_SIZE, ci)
-        c = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
+        self.add_constant_component(self.state_word_size, ci)
+        c = ComponentState([self.get_current_component_id()], [list(range(self.state_word_size))])
         inputs_id, inputs_pos = get_inputs_parameter([state[3], c])
-        self.add_xor_component(inputs_id, inputs_pos, STATE_SIZE)
-        state[3] = ComponentState([self.get_current_component_id()], [list(range(STATE_SIZE))])
+        self.add_xor_component(inputs_id, inputs_pos, self.state_word_size)
+        state[3] = ComponentState([self.get_current_component_id()], [list(range(self.state_word_size))])
 
         return state

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -374,6 +374,14 @@
         *Gimli: a cross-platform permutation* : CHES 2017 :
         https://gimli.cr.yp.to/gimli-20170627.pdf
 
+.. [GIFT2017]
+        Banik S., Pandey S. K., Peyrin T., Sasaki Y., Sim S. M., Todo Y. :
+        *GIFT: A Small Present -- Towards Reaching the Limit of Lightweight Encryption* :
+        In Cryptographic Hardware and Embedded Systems -- CHES 2017, Lecture Notes in Computer Science,
+        vol. 10529, pp. 321--345. Springer (2017) : https://doi.org/10.1007/978-3-319-66787-4_16.
+        Full version: https://eprint.iacr.org/2017/622.pdf.
+        Reference implementation and test vectors: https://github.com/giftcipher/gift.
+
 .. [Go2019]
         Gohr A. : *Improving Attacks on Round-Reduced Speck32/64 using Deep Learning
 * : In Advances in Cryptology – CRYPTO 2019

--- a/tests/unit/ciphers/block_ciphers/gift_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/gift_block_cipher_test.py
@@ -1,11 +1,15 @@
 from claasp.ciphers.block_ciphers.gift_block_cipher import GiftBlockCipher
 
 
+# Test vectors from https://github.com/giftcipher/gift/tree/master/implementations/test%20vectors
+# (GIFT64_test_vector_1.txt through GIFT64_test_vector_3.txt).
 GIFT_64_TEST_VECTORS = [
     (0x0000000000000000, 0x00000000000000000000000000000000, 0xF62BC3EF34F775AC),
     (0xFEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210, 0xC1B71F66160FF587),
     (0xC450C7727A9B8A7D, 0xBD91731EB6BC2713A1F9F6FFC75044E7, 0xE3272885FA94BA8B),
 ]
+# Test vectors from https://github.com/giftcipher/gift/tree/master/implementations/test%20vectors
+# (GIFT128_test_vector_1.txt through GIFT128_test_vector_3.txt).
 GIFT_128_TEST_VECTORS = [
     (0x00000000000000000000000000000000, 0x00000000000000000000000000000000,
      0xCD0BD738388AD3F668B15A36CEB6FF92),

--- a/tests/unit/ciphers/block_ciphers/gift_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/gift_block_cipher_test.py
@@ -1,6 +1,21 @@
 from claasp.ciphers.block_ciphers.gift_block_cipher import GiftBlockCipher
 
 
+GIFT_64_TEST_VECTORS = [
+    (0x0000000000000000, 0x00000000000000000000000000000000, 0xF62BC3EF34F775AC),
+    (0xFEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210, 0xC1B71F66160FF587),
+    (0xC450C7727A9B8A7D, 0xBD91731EB6BC2713A1F9F6FFC75044E7, 0xE3272885FA94BA8B),
+]
+GIFT_128_TEST_VECTORS = [
+    (0x00000000000000000000000000000000, 0x00000000000000000000000000000000,
+     0xCD0BD738388AD3F668B15A36CEB6FF92),
+    (0xFEDCBA9876543210FEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210,
+     0x8422241A6DBF5A9346AF468409EE0152),
+    (0xE39C141FA57DBA43F08A85B6A91F86C1, 0xD0F5C59A7700D3E799028FA9F90AD837,
+     0x13EDE67CBDCC3DBF400A62D6977265EA),
+]
+
+
 def test_gift_block_cipher():
     gift = GiftBlockCipher()
     assert gift.family_name == 'gift'
@@ -14,19 +29,20 @@ def test_gift_block_cipher():
     assert gift.id == 'gift_p128_k128_o128_r4'
     assert gift.component_from(3, 0).id == 'rot_3_0'
 
-    gift = GiftBlockCipher(number_of_rounds=40)
-    key = 0x000102030405060708090A0B0C0D0E0F
-    plaintext = 0x000102030405060708090A0B0C0D0E0F
-    ciphertext = 0xA94AF7F9BA181DF9B2B00EB7DBFA93DF
+    gift = GiftBlockCipher()
+    plaintext, key, ciphertext = GIFT_128_TEST_VECTORS[0]
     assert gift.evaluate([plaintext, key]) == ciphertext
     assert gift.evaluate_vectorized([plaintext, key], evaluate_api=True) == ciphertext
 
-    key1 = 0x000102030405060708090A0B0C0D0E0F
-    plaintext1 = 0x000102030405060708090A0B0C0D0E0F
-    ciphertext1 = 0xA94AF7F9BA181DF9B2B00EB7DBFA93DF
-    key2 = 0xE0841F8FB90783136AA8B7F192F5C474
-    plaintext2 = 0xE491C665522031CF033BF71B9989ECB3
-    ciphertext2 = 0x3331EFC3A6604F9599ED42B7DBC02A38
-    input_list = [[plaintext1, key1], [plaintext2, key2]]
-    output_list = [ciphertext1, ciphertext2]
-    assert gift.test_vector_check(input_list, output_list) is True
+    input_list = [[plaintext, key] for plaintext, key, _ in GIFT_128_TEST_VECTORS]
+    output_list = [ciphertext for _, _, ciphertext in GIFT_128_TEST_VECTORS]
+    assert gift.test_vector_check(input_list, output_list)
+
+    gift_64 = GiftBlockCipher(block_bit_size=64)
+    assert gift_64.number_of_rounds == 28
+    assert gift_64.id == 'gift_p64_k128_o64_r28'
+    plaintext, key, ciphertext = GIFT_64_TEST_VECTORS[0]
+    assert gift_64.evaluate_vectorized([plaintext, key], evaluate_api=True) == ciphertext
+    input_list = [[plaintext, key] for plaintext, key, _ in GIFT_64_TEST_VECTORS]
+    output_list = [ciphertext for _, _, ciphertext in GIFT_64_TEST_VECTORS]
+    assert gift_64.test_vector_check(input_list, output_list)

--- a/tests/unit/ciphers/block_ciphers/gift_sbox_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/gift_sbox_block_cipher_test.py
@@ -1,6 +1,21 @@
 from claasp.ciphers.block_ciphers.gift_sbox_block_cipher import GiftSboxBlockCipher
 
 
+GIFT_64_TEST_VECTORS = [
+    (0x0000000000000000, 0x00000000000000000000000000000000, 0xF62BC3EF34F775AC),
+    (0xFEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210, 0xC1B71F66160FF587),
+    (0xC450C7727A9B8A7D, 0xBD91731EB6BC2713A1F9F6FFC75044E7, 0xE3272885FA94BA8B),
+]
+GIFT_128_TEST_VECTORS = [
+    (0x00000000000000000000000000000000, 0x00000000000000000000000000000000,
+     0xCD0BD738388AD3F668B15A36CEB6FF92),
+    (0xFEDCBA9876543210FEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210,
+     0x8422241A6DBF5A9346AF468409EE0152),
+    (0xE39C141FA57DBA43F08A85B6A91F86C1, 0xD0F5C59A7700D3E799028FA9F90AD837,
+     0x13EDE67CBDCC3DBF400A62D6977265EA),
+]
+
+
 def test_gift_sbox_block_cipher():
     gift = GiftSboxBlockCipher()
     assert gift.family_name == 'gift_sbox'
@@ -14,19 +29,20 @@ def test_gift_sbox_block_cipher():
     assert gift.id == 'gift_sbox_p128_k128_o128_r4'
     assert gift.component_from(3, 0).id == 'rot_3_0'
 
-    gift = GiftSboxBlockCipher(number_of_rounds=40)
-    key = 0x000102030405060708090A0B0C0D0E0F
-    plaintext = 0x000102030405060708090A0B0C0D0E0F
-    ciphertext = 0xA94AF7F9BA181DF9B2B00EB7DBFA93DF
+    gift = GiftSboxBlockCipher()
+    plaintext, key, ciphertext = GIFT_128_TEST_VECTORS[0]
     assert gift.evaluate([plaintext, key]) == ciphertext
     assert gift.evaluate_vectorized([plaintext, key], evaluate_api=True) == ciphertext
 
-    key1 = 0x000102030405060708090A0B0C0D0E0F
-    plaintext1 = 0x000102030405060708090A0B0C0D0E0F
-    ciphertext1 = 0xA94AF7F9BA181DF9B2B00EB7DBFA93DF
-    key2 = 0xE0841F8FB90783136AA8B7F192F5C474
-    plaintext2 = 0xE491C665522031CF033BF71B9989ECB3
-    ciphertext2 = 0x3331EFC3A6604F9599ED42B7DBC02A38
-    input_list = [[plaintext1, key1], [plaintext2, key2]]
-    output_list = [ciphertext1, ciphertext2]
-    assert gift.test_vector_check(input_list, output_list) is True
+    input_list = [[plaintext, key] for plaintext, key, _ in GIFT_128_TEST_VECTORS]
+    output_list = [ciphertext for _, _, ciphertext in GIFT_128_TEST_VECTORS]
+    assert gift.test_vector_check(input_list, output_list)
+
+    gift_64 = GiftSboxBlockCipher(block_bit_size=64)
+    assert gift_64.number_of_rounds == 28
+    assert gift_64.id == 'gift_sbox_p64_k128_o64_r28'
+    plaintext, key, ciphertext = GIFT_64_TEST_VECTORS[0]
+    assert gift_64.evaluate_vectorized([plaintext, key], evaluate_api=True) == ciphertext
+    input_list = [[plaintext, key] for plaintext, key, _ in GIFT_64_TEST_VECTORS]
+    output_list = [ciphertext for _, _, ciphertext in GIFT_64_TEST_VECTORS]
+    assert gift_64.test_vector_check(input_list, output_list)

--- a/tests/unit/ciphers/block_ciphers/gift_sbox_block_cipher_test.py
+++ b/tests/unit/ciphers/block_ciphers/gift_sbox_block_cipher_test.py
@@ -1,11 +1,15 @@
 from claasp.ciphers.block_ciphers.gift_sbox_block_cipher import GiftSboxBlockCipher
 
 
+# Test vectors from https://github.com/giftcipher/gift/tree/master/implementations/test%20vectors
+# (GIFT64_test_vector_1.txt through GIFT64_test_vector_3.txt).
 GIFT_64_TEST_VECTORS = [
     (0x0000000000000000, 0x00000000000000000000000000000000, 0xF62BC3EF34F775AC),
     (0xFEDCBA9876543210, 0xFEDCBA9876543210FEDCBA9876543210, 0xC1B71F66160FF587),
     (0xC450C7727A9B8A7D, 0xBD91731EB6BC2713A1F9F6FFC75044E7, 0xE3272885FA94BA8B),
 ]
+# Test vectors from https://github.com/giftcipher/gift/tree/master/implementations/test%20vectors
+# (GIFT128_test_vector_1.txt through GIFT128_test_vector_3.txt).
 GIFT_128_TEST_VECTORS = [
     (0x00000000000000000000000000000000, 0x00000000000000000000000000000000,
      0xCD0BD738388AD3F668B15A36CEB6FF92),


### PR DESCRIPTION
## Summary

- add the CHES 2017, ePrint, and official implementation references to both GIFT implementations
- expose canonical GIFT plaintext/ciphertext ordering instead of the internal bitsliced layout
- add the specified GIFT-64-128 configuration alongside GIFT-128-128
- replace non-authoritative tests with all six upstream GIFT-64 and GIFT-128 vectors

## Testing

- `pytest -q tests/unit/ciphers/block_ciphers/gift_block_cipher_test.py tests/unit/ciphers/block_ciphers/gift_sbox_block_cipher_test.py` (2 passed)
- `pycodestyle` on the modified Python files
- `pydocstyle` on both modified cipher implementations
- GIFT-64 and GIFT-128 two-round inverse checks
- block-cipher suite: 205 passed; 15 unrelated environment failures from NumPy uint8 casting and Sage finite-field API compatibility